### PR TITLE
Division by zero in renderAlignments

### DIFF
--- a/src/org/broad/igv/sam/AlignmentTrack.java
+++ b/src/org/broad/igv/sam/AlignmentTrack.java
@@ -382,7 +382,11 @@ public class AlignmentTrack extends AbstractTrack implements AlignmentTrackEvent
             if (getDisplayMode() != DisplayMode.EXPANDED) {
                 int visHeight = visibleRect.height;
                 int depth = dataManager.getNLevels();
-                squishedHeight = Math.min(maxSquishedHeight, Math.max(1, Math.min(expandedHeight, visHeight / depth)));
+                if (depth == 0) {
+                    squishedHeight = Math.min(maxSquishedHeight, Math.max(1, expandedHeight));
+                } else {
+                    squishedHeight = Math.min(maxSquishedHeight, Math.max(1, Math.min(expandedHeight, visHeight / depth)));
+                }
                 h = squishedHeight;
             }
 


### PR DESCRIPTION
renderAlignments of AlignmentTrack can throw an exception for division by zero if the depth in a region is 0. This commit checks for depth == 0 before dividing and gives a sensible alternative.
