### PR TITLE
Fix to import genome from directory

### DIFF
--- a/src/org/broad/igv/feature/genome/GenomeImporter.java
+++ b/src/org/broad/igv/feature/genome/GenomeImporter.java
@@ -107,9 +107,9 @@ public class GenomeImporter {
                             throw new GenomeException(msg);
                         }
 
-                        File indexFile = new File(fastaIndexPath);
+                        File indexFile = new File(sequenceInputFile, file.getName() + ".fai");
                         if (!indexFile.exists()) {
-                            FastaUtils.createIndexFile(fastaFile, fastaIndexPath);
+                            FastaUtils.createIndexFile(file.getAbsolutePath(), indexFile.getAbsolutePath());
                         }
                         fastaIndexPathList.add(fastaIndexPath);
                         fastaFileNames.add(file.getName());


### PR DESCRIPTION
When loading from a directory, it was trying to index from the directory. It seemed the correct behaviour was index on each file. Tested and loads properly.
