### PR TITLE
Fix possible IndexArrayOutOfBounds exception.

### DIFF
--- a/src/org/broad/igv/goby/GobyAlignment.java
+++ b/src/org/broad/igv/goby/GobyAlignment.java
@@ -178,11 +178,15 @@ public class GobyAlignment implements Alignment {
         int endAlignmentRefPosition = matchLength + start;
         bases.clear();
         scores.clear();
-
+        int maxIndex = Math.min(readBases.length, readQual.length);
         while (pos < endAlignmentRefPosition) {
             final int index = pos - start + leftPadding;
-            bases.add(readBases[index]);
-            scores.add(readQual[index]);
+            if (index < maxIndex) {
+                bases.add(readBases[index]);
+                scores.add(readQual[index]);
+            } else {
+                break;
+            }
             ++pos;
         }
 


### PR DESCRIPTION
A bug fix to prevent a possible exception when reading Goby alignments (reported by two independent users).
