### PR TITLE
Refactor splice junction counting

### DIFF
--- a/src/org/broad/igv/sam/AlignmentDataManager.java
+++ b/src/org/broad/igv/sam/AlignmentDataManager.java
@@ -15,7 +15,6 @@ import com.google.common.eventbus.EventBus;
 import org.apache.log4j.Logger;
 import org.broad.igv.Globals;
 import org.broad.igv.PreferenceManager;
-import org.broad.igv.feature.SpliceJunctionFeature;
 import org.broad.igv.feature.genome.Genome;
 import org.broad.igv.sam.AlignmentTrack.SortOption;
 import org.broad.igv.sam.reader.AlignmentReaderFactory;
@@ -51,7 +50,7 @@ public class AlignmentDataManager {
 
     private AlignmentTrack.ExperimentType experimentType;
 
-    private SpliceJunctionHelper.LoadOptions loadOptions = new SpliceJunctionHelper.LoadOptions(false, false);
+    private SpliceJunctionHelper spliceJunctionHelper;
 
     /**
      * This {@code EventBus} is typically used to notify listeners when new data
@@ -63,7 +62,7 @@ public class AlignmentDataManager {
     public AlignmentDataManager(ResourceLocator locator, Genome genome) throws IOException {
         reader = new AlignmentTileLoader(AlignmentReaderFactory.getReader(locator));
         peStats = new HashMap();
-        initLoadOptions();
+        this.spliceJunctionHelper = new SpliceJunctionHelper(new SpliceJunctionHelper.LoadOptions());
         initChrMap(genome);
     }
 
@@ -72,12 +71,6 @@ public class AlignmentDataManager {
         initChrMap(genome);
     }
 
-
-    void initLoadOptions(){
-        PreferenceManager prefs = PreferenceManager.getInstance();
-        boolean showSpliceJunctions = prefs.getAsBoolean(PreferenceManager.SAM_SHOW_JUNCTION_TRACK);
-        this.loadOptions = new SpliceJunctionHelper.LoadOptions(showSpliceJunctions, false);
-    }
     /**
      * Create an alias -> chromosome lookup map.  Enable loading BAM files that use alternative names for chromosomes,
      * provided the alias has been defined  (e.g. 1 -> chr1,  etc).
@@ -96,13 +89,6 @@ public class AlignmentDataManager {
 
     public void setExperimentType(AlignmentTrack.ExperimentType experimentType) {
         this.experimentType = experimentType;
-        boolean showSpliceJunctions = false;
-        if (experimentType == AlignmentTrack.ExperimentType.BISULFITE) {
-            showSpliceJunctions = false;
-        } else {
-            showSpliceJunctions = PreferenceManager.getInstance().getAsBoolean(PreferenceManager.SAM_SHOW_JUNCTION_TRACK);
-        }
-        this.loadOptions = new SpliceJunctionHelper.LoadOptions(showSpliceJunctions, loadOptions.minJunctionCoverage, loadOptions.minReadFlankingWidth, loadOptions.ignoreStrandedness);
     }
 
     public AlignmentTrack.ExperimentType getExperimentType() {
@@ -314,12 +300,6 @@ public class AlignmentDataManager {
         }
     }
 
-
-    public void clear() {
-        // reader.clearCache();
-        loadedIntervalMap.clear();
-    }
-
     public synchronized void loadAlignments(final String chr, final int start, final int end,
                                             final AlignmentTrack.RenderOptions renderOptions,
                                             final RenderContext context) {
@@ -371,13 +351,11 @@ public class AlignmentDataManager {
                 renderOptions != null ? renderOptions.bisulfiteContext : null;
 
 
-        AlignmentTileLoader.AlignmentTile t = reader.loadTile(sequence, start, end, loadOptions,
+        AlignmentTileLoader.AlignmentTile t = reader.loadTile(sequence, start, end, this.spliceJunctionHelper,
                 downsampleOptions, peStats, bisulfiteContext);
         //System.out.println(chr + "\t" + start + "\t" + end + "\t" + (n++) + "   (" + format.format(delta) + ")");
 
         List<Alignment> alignments = t.getAlignments();
-
-        List<SpliceJunctionFeature> spliceJunctions = t.getSpliceJunctionFeatures();
 
         List<DownsampledInterval> downsampledIntervals = t.getDownsampledIntervals();
 
@@ -395,7 +373,7 @@ public class AlignmentDataManager {
 
         LinkedHashMap<String, List<AlignmentInterval.Row>> alignmentRows = alignmentPacker.packAlignments(iter, end, renderOptions);
 
-        return new AlignmentInterval(chr, start, end, alignmentRows, t.getCounts(), spliceJunctions, downsampledIntervals, renderOptions);
+        return new AlignmentInterval(chr, start, end, alignmentRows, t.getCounts(), spliceJunctionHelper, downsampledIntervals, renderOptions);
     }
 
     private void addLoadedInterval(ReferenceFrame frame, AlignmentInterval interval) {
@@ -471,24 +449,12 @@ public class AlignmentDataManager {
         }
     }
 
-    public boolean isShowSpliceJunctions() {
-        return loadOptions.showSpliceJunctions;
-    }
-
     public EventBus getEventBus() {
         return eventBus;
     }
 
-    public SpliceJunctionHelper.LoadOptions getSpliceJunctionLoadOptions() {
-        return loadOptions;
-    }
-
-    public void setSpliceJunctionLoadOptions(SpliceJunctionHelper.LoadOptions spliceJunctionLoadOptions) {
-        this.loadOptions = spliceJunctionLoadOptions;
-    }
-
-    public void setShowSpliceJunctions(boolean showSpliceJunctions) {
-        this.loadOptions = new SpliceJunctionHelper.LoadOptions(showSpliceJunctions, loadOptions.minJunctionCoverage, loadOptions.minReadFlankingWidth, loadOptions.ignoreStrandedness);
+    public SpliceJunctionHelper getSpliceJunctionHelper() {
+        return spliceJunctionHelper;
     }
 
     public static class DownsampleOptions {

--- a/src/org/broad/igv/sam/AlignmentInterval.java
+++ b/src/org/broad/igv/sam/AlignmentInterval.java
@@ -17,7 +17,6 @@ package org.broad.igv.sam;
 
 import org.apache.log4j.Logger;
 import org.broad.igv.feature.Locus;
-import org.broad.igv.feature.SpliceJunctionFeature;
 import org.broad.igv.feature.Strand;
 import org.broad.igv.feature.genome.Genome;
 import org.broad.igv.feature.genome.GenomeManager;
@@ -36,14 +35,14 @@ public class AlignmentInterval extends Locus{
     private int maxCount = 0;
     private AlignmentCounts counts;
     private LinkedHashMap<String, List<Row>> groupedAlignmentRows;  // The alignments
-    private List<SpliceJunctionFeature> spliceJunctions;
+    private SpliceJunctionHelper spliceJunctionHelper;
     private List<DownsampledInterval> downsampledIntervals;
     private AlignmentTrack.RenderOptions renderOptions;
 
     public AlignmentInterval(String chr, int start, int end,
                              LinkedHashMap<String, List<Row>> groupedAlignmentRows,
                              AlignmentCounts counts,
-                             List<SpliceJunctionFeature> spliceJunctions,
+                             SpliceJunctionHelper spliceJunctionHelper,
                              List<DownsampledInterval> downsampledIntervals,
                              AlignmentTrack.RenderOptions renderOptions) {
 
@@ -55,7 +54,7 @@ public class AlignmentInterval extends Locus{
         this.counts = counts;
         this.maxCount = counts.getMaxCount();
 
-        this.spliceJunctions = spliceJunctions;
+        this.spliceJunctionHelper = spliceJunctionHelper;
         this.downsampledIntervals = downsampledIntervals;
         this.renderOptions = renderOptions;
     }
@@ -225,10 +224,6 @@ public class AlignmentInterval extends Locus{
 
     public Iterator<Alignment> getAlignmentIterator() {
         return new AlignmentIterator();
-    }
-
-    public List<SpliceJunctionFeature> getSpliceJunctions() {
-        return spliceJunctions;
     }
 
     public List<DownsampledInterval> getDownsampledIntervals() {

--- a/src/org/broad/igv/sam/AlignmentTileLoader.java
+++ b/src/org/broad/igv/sam/AlignmentTileLoader.java
@@ -89,12 +89,12 @@ public class AlignmentTileLoader {
 
 
     AlignmentTile loadTile(String chr, int start, int end,
-                           SpliceJunctionHelper.LoadOptions loadOptions,
+                           SpliceJunctionHelper spliceJunctionHelper,
                            AlignmentDataManager.DownsampleOptions downsampleOptions,
                            Map<String, PEStats> peStats,
                            AlignmentTrack.BisulfiteContext bisulfiteContext) {
 
-        AlignmentTile t = new AlignmentTile(start, end, loadOptions, downsampleOptions, bisulfiteContext);
+        AlignmentTile t = new AlignmentTile(start, end, spliceJunctionHelper, downsampleOptions, bisulfiteContext);
 
 
         //assert (tiles.size() > 0);
@@ -284,7 +284,6 @@ public class AlignmentTileLoader {
         private AlignmentCounts counts;
         private List<Alignment> alignments;
         private List<DownsampledInterval> downsampledIntervals;
-        private List<SpliceJunctionFeature> spliceJunctionFeatures;
         private SpliceJunctionHelper spliceJunctionHelper;
 
         private boolean downsample;
@@ -296,7 +295,7 @@ public class AlignmentTileLoader {
 
 
         AlignmentTile(int start, int end,
-                      SpliceJunctionHelper.LoadOptions loadOptions,
+                      SpliceJunctionHelper spliceJunctionHelper,
                       AlignmentDataManager.DownsampleOptions downsampleOptions,
                       AlignmentTrack.BisulfiteContext bisulfiteContext) {
             this.start = start;
@@ -320,11 +319,7 @@ public class AlignmentTileLoader {
             this.samplingWindowSize = downsampleOptions.getSampleWindowSize();
             this.samplingDepth = Math.max(1, downsampleOptions.getMaxReadCount());
 
-            if (loadOptions != null && loadOptions.showSpliceJunctions) {
-                spliceJunctionFeatures = new ArrayList<SpliceJunctionFeature>(100);
-                spliceJunctionHelper = new SpliceJunctionHelper(loadOptions);
-            }
-
+            this.spliceJunctionHelper = spliceJunctionHelper;
         }
 
         public int getStart() {
@@ -418,14 +413,16 @@ public class AlignmentTileLoader {
         private void finalizeSpliceJunctions() {
             if (spliceJunctionHelper != null) {
                 spliceJunctionHelper.finish();
-                spliceJunctionFeatures.addAll(spliceJunctionHelper.getFeatures());
             }
-            spliceJunctionHelper = null;
         }
 
-
         public List<SpliceJunctionFeature> getSpliceJunctionFeatures() {
-            return spliceJunctionFeatures;
+            if(spliceJunctionHelper == null) return null;
+            return spliceJunctionHelper.getFilteredJunctions();
+        }
+
+        public SpliceJunctionHelper getSpliceJunctionHelper() {
+            return spliceJunctionHelper;
         }
 
 

--- a/src/org/broad/igv/sam/AlignmentTrack.java
+++ b/src/org/broad/igv/sam/AlignmentTrack.java
@@ -82,6 +82,8 @@ public class AlignmentTrack extends AbstractTrack implements AlignmentTrackEvent
     static final int DOWNAMPLED_ROW_HEIGHT = 3;
     static final int DS_MARGIN_2 = 5;
 
+    private boolean showSpliceJunctions;
+
     public enum ShadeBasesOption {
         NONE, QUALITY, FLOW_SIGNAL_DEVIATION_READ, FLOW_SIGNAL_DEVIATION_REFERENCE
     }
@@ -179,7 +181,7 @@ public class AlignmentTrack extends AbstractTrack implements AlignmentTrackEvent
 
         PreferenceManager prefs = PreferenceManager.getInstance();
 
-        dataManager.setShowSpliceJunctions(prefs.getAsBoolean(PreferenceManager.SAM_SHOW_JUNCTION_TRACK));
+        setShowSpliceJunctions(prefs.getAsBoolean(PreferenceManager.SAM_SHOW_JUNCTION_TRACK));
 
         float maxRange = prefs.getAsFloat(PreferenceManager.SAM_MAX_VISIBLE_RANGE);
         minVisibleScale = (maxRange * 1000) / 700;
@@ -425,10 +427,6 @@ public class AlignmentTrack extends AbstractTrack implements AlignmentTrackEvent
 
         final int bottom = inputRect.y + inputRect.height;
         groupBorderGraphics.drawLine(inputRect.x, bottom, inputRect.width, bottom);
-    }
-
-    public void clearCaches() {
-        dataManager.clear();
     }
 
     /**
@@ -711,12 +709,12 @@ public class AlignmentTrack extends AbstractTrack implements AlignmentTrackEvent
     //Public only for testing
     @XmlAttribute
     public boolean isShowSpliceJunctions() {
-        return dataManager.isShowSpliceJunctions();
+        return showSpliceJunctions;
     }
 
     @SubtlyImportant
     private void setShowSpliceJunctions(boolean showSpliceJunctions) {
-        dataManager.setShowSpliceJunctions(showSpliceJunctions);
+        this.showSpliceJunctions = showSpliceJunctions;
     }
 
     public String getValueStringAt(String chr, double position, int y, ReferenceFrame frame) {
@@ -806,9 +804,6 @@ public class AlignmentTrack extends AbstractTrack implements AlignmentTrackEvent
                 break;
             case RELOAD:
             case SPLICE_JUNCTION:
-                dataManager.initLoadOptions();
-                clearCaches();
-                break;
         }
 
     }

--- a/src/org/broad/igv/sam/SpliceJunctionFinderTrack.java
+++ b/src/org/broad/igv/sam/SpliceJunctionFinderTrack.java
@@ -57,13 +57,16 @@ public class SpliceJunctionFinderTrack extends FeatureTrack implements Alignment
     // directory,  so this field might be null at any given time.  It is updated each repaint.
     JComponent parent;
 
-    public SpliceJunctionFinderTrack(ResourceLocator locator, String name, AlignmentDataManager dataManager) {
+    boolean ignoreStrand;
+
+    public SpliceJunctionFinderTrack(ResourceLocator locator, String name, AlignmentDataManager dataManager, boolean ignoreStrand) {
         super(locator, locator.getPath() + "_junctions", name);
 
         super.setDataRange(new DataRange(0, 0, 60));
         setRendererClass(SpliceJunctionRenderer.class);
         this.dataManager = dataManager;
         prefs = PreferenceManager.getInstance();
+        this.ignoreStrand = ignoreStrand;
         // Register track
         IGV.getInstance().addAlignmentTrackEventListener(this);
     }
@@ -124,7 +127,8 @@ public class SpliceJunctionFinderTrack extends FeatureTrack implements Alignment
         AlignmentInterval loadedInterval = dataManager.getLoadedInterval(context.getReferenceFrame().getName());
         if (loadedInterval == null) return;
 
-        List<SpliceJunctionFeature> features = loadedInterval.getSpliceJunctions();
+        SpliceJunctionHelper helper = dataManager.getSpliceJunctionHelper();
+        List<SpliceJunctionFeature> features =  ignoreStrand ? helper.getFilteredJunctionsIgnoreStrand() : helper.getFilteredJunctions();
         if (features == null) {
             features = Collections.emptyList();
         }

--- a/src/org/broad/igv/track/TrackLoader.java
+++ b/src/org/broad/igv/track/TrackLoader.java
@@ -975,7 +975,7 @@ public class TrackLoader {
             boolean showSpliceJunctionTrack = PreferenceManager.getInstance().getAsBoolean(PreferenceManager.SAM_SHOW_JUNCTION_TRACK);
             if (showSpliceJunctionTrack) {
                 SpliceJunctionFinderTrack spliceJunctionTrack = new SpliceJunctionFinderTrack(locator,
-                        alignmentTrack.getName() + " Junctions", dataManager);
+                        alignmentTrack.getName() + " Junctions", dataManager, false);
                 spliceJunctionTrack.setHeight(60);
 
                 spliceJunctionTrack.setVisible(showSpliceJunctionTrack);


### PR DESCRIPTION
This shouldn't be pulled without some review. 

We count and store splice junctions always, and filter on demand. This is actually only true for minJunctionCoverage and ignoreStrandedness; we still filter based on minFlankingWidth upon loading (needs revisiting). 
