### PR TITLE
Increase scroll amount when left/right key pressed

### DIFF
--- a/src/org/broad/igv/ui/panel/DataPanel.java
+++ b/src/org/broad/igv/ui/panel/DataPanel.java
@@ -466,9 +466,9 @@ public class DataPanel extends JComponent implements Paintable {
                     zoomIncr = -1;
                     showWaitCursor = true;
                 } else if (e.getKeyCode() == KeyEvent.VK_RIGHT) {
-                    shiftOriginPixels = 5;
+                    shiftOriginPixels = 50;
                 } else if (e.getKeyCode() == KeyEvent.VK_LEFT) {
-                    shiftOriginPixels = -5;
+                    shiftOriginPixels = -50;
                 } else if (e.getKeyCode() == KeyEvent.VK_HOME) {
                     shiftOriginPixels = -getWidth();
                     showWaitCursor = true;


### PR DESCRIPTION
The 'left' and 'right' keys are not really helpful right now since they scroll too little. I'd like to have a way to 'scan' through a reference just by keeping a button pressed. With this change, the left and right keys scroll by 50 pixels instead of 5, which improves usability, in my opinion.
