### PR TITLE
Fix argument passing to igvtools shell script

### DIFF
--- a/scripts/igvtools
+++ b/scripts/igvtools
@@ -1,2 +1,2 @@
 #!/bin/sh
-java -Djava.awt.headless=true  -Xmx1500m  -jar `dirname $0`/igvtools.jar $*
+java -Djava.awt.headless=true  -Xmx1500m  -jar `dirname $0`/igvtools.jar "$@"


### PR DESCRIPTION
Passing arguments using ``$*`` can [cause issues](http://stackoverflow.com/questions/448407/#3990540). I was having problems calling the igvtools scripts from within Python's like this

    import subprocess
    subprocess.call(["/opt/bin/IGVTools/igvtools", "index", "/tmp/test folder/test.bed"])

because of the space in the file name - even when I escaped the spaces, the shell script would treat this as separate arguments! Changing from ``$*`` to ``"$@"`` fixes this issue.

<!---
@huboard:{"order":60.5,"milestone_order":115,"custom_state":""}
-->
