### PR TITLE
Adding ability to directly supply index paths

### DIFF
--- a/src/org/broad/igv/PreferenceManager.java
+++ b/src/org/broad/igv/PreferenceManager.java
@@ -209,6 +209,7 @@ public class PreferenceManager implements PropertyManager {
     public static final String USE_PROBE_MAPPING_FILE = "USE_PROBE_MAPPING_FILE";
 
     public static final String SEARCH_ZOOM = "SEARCH_ZOOM";
+    public static final String BYPASS_FILE_AUTO_DISCOVERY = "BYPASS_FILE_AUTO_DISCOVERY";
     public static final String NORMALIZE_COVERAGE = "NORMALIZE_COVERAGE";
     public static final String SHOW_EXPAND_ICON = "SHOW_EXPAND_ICON";
     public static final String SHOW_DEFAULT_TRACK_ATTRIBUTES = "SHOW_DEFAULT_TRACK_ATTRIBUTES";
@@ -1060,6 +1061,7 @@ public class PreferenceManager implements PropertyManager {
         defaultValues.put(SAM_COMPLETE_READS_ONLY, "false");
         defaultValues.put(SAM_SHOW_ALL_BASES, "false");
 
+        defaultValues.put(BYPASS_FILE_AUTO_DISCOVERY, "false");
         defaultValues.put(NORMALIZE_COVERAGE, "false");
 
         defaultValues.put(SHOW_GENOME_SERVER_WARNING, "true");

--- a/src/org/broad/igv/session/IndexAwareSessionReader.java
+++ b/src/org/broad/igv/session/IndexAwareSessionReader.java
@@ -1,0 +1,254 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2007-2015 Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.broad.igv.session;
+
+import org.apache.log4j.Logger;
+import org.broad.igv.feature.genome.Genome;
+import org.broad.igv.feature.genome.GenomeManager;
+import org.broad.igv.track.Track;
+import org.broad.igv.track.TrackProperties;
+import org.broad.igv.ui.IGV;
+import org.broad.igv.ui.panel.TrackPanel;
+import org.broad.igv.ui.util.MessageUtils;
+import org.broad.igv.util.ParsingUtils;
+import org.broad.igv.util.ResourceLocator;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Class to parse an index aware session file
+ *
+ * @author Brett T. Hannigan
+ * @date 09/16/2015
+ */
+public class IndexAwareSessionReader implements SessionReader {
+
+    private static Logger log = Logger.getLogger(IndexAwareSessionReader.class);
+
+    IGV igv;
+
+    public IndexAwareSessionReader(IGV igv) {
+        this.igv = igv;
+    }
+
+    /**
+     * Load an inex aware session from the given stream.
+     *
+     * @param inputStream
+     * @param session
+     * @param sessionName
+     * @throws IOException
+     */
+    public void loadSession(InputStream inputStream, Session session, String sessionName) throws IOException {
+
+        BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream));
+
+        String trackLine = null;
+        String nextLine;
+
+        final List<String> errors = new ArrayList<String>();
+        final HashMap<String, List<Track>> loadedTracks = new HashMap();
+        List<ResourceLocator> aSync = new ArrayList();
+
+        // Index aware sessions do not have means to set genome, or if they do we don't use it
+        Genome genome = GenomeManager.getInstance().getCurrentGenome();
+        if (genome != null) {
+            IGV.getInstance().setGenomeTracks(genome.getGeneTrack());
+        }
+
+        while ((nextLine = reader.readLine()) != null) {
+            ResourceLocator locator = null;
+            try {
+
+                if (nextLine.startsWith("#")) {
+                    continue;
+                } else if (nextLine.startsWith("browser")) {
+                    parseBrowserLine(nextLine, session);
+                } else if (nextLine.startsWith("track")) {
+                    trackLine = nextLine;
+                    String dataURL = getDataURL(trackLine);
+                    if (dataURL != null) {
+                        locator = new ResourceLocator(dataURL);
+                        String indexURL = getIndexURL(trackLine);
+                        if (indexURL != null) {
+                            locator.setIndexPath(indexURL);
+                        }
+
+                        String coverageURL = getCoverageURL(trackLine);
+                        if (coverageURL != null) {
+                            locator.setCoverage(coverageURL);
+                        }
+                        loadedTracks.put(dataURL, igv.load(locator));
+                    }
+                } else {
+                    locator = parseResourceLine(nextLine);
+                }
+
+                if (locator != null) {
+                    locator.setTrackLine(trackLine);
+                    // Alignment tracks must be loaded synchronously
+                    if (isAlignmentFile(locator.getPath())) {
+                        TrackPanel panel = igv.getPanelFor(locator);
+                        panel.addTracks(igv.load(locator));
+                    } else {
+                        aSync.add(locator);
+                    }
+                    trackLine = null; // Reset for next time
+                    locator = null;
+                }
+            } catch (Exception e) {
+                log.error("Error loading resource " + locator.getPath(), e);
+                String ms = "<b>" + locator.getPath() + "</b><br>&nbs;p&nbsp;" + e.toString() + "<br>";
+                errors.add(ms);
+            }
+        }
+
+        loadAsynchronous(aSync, loadedTracks, errors);
+
+        if (errors.size() > 0) {
+            displayErrors(errors);
+        }
+
+    }
+
+    private void loadAsynchronous(List<ResourceLocator> aSync, final HashMap<String, List<Track>> loadedTracks,
+                                  final List<String> errors) {
+        List<Thread> threads = new ArrayList(aSync.size());
+        for (final ResourceLocator locator : aSync) {
+            Runnable runnable = new Runnable() {
+                public void run() {
+                    // TODO handle errors
+                    try {
+                        loadedTracks.put(locator.getPath(), igv.load(locator));
+                    } catch (Exception e) {
+                        log.error("Error loading resource " + locator.getPath(), e);
+                        String ms = "<b>" + locator.getPath() + "</b><br>&nbs;p&nbsp;" + e.toString() + "<br>";
+                        errors.add(ms);
+                    }
+                }
+            };
+            Thread t = new Thread(runnable);
+            threads.add(t);
+            t.start();
+        }
+        // Wait for all threads to complete
+        for (Thread t : threads) {
+            try {
+                t.join();
+            } catch (InterruptedException ignore) {
+            }
+        }
+        placeTracksInPanels(aSync, loadedTracks);
+
+    }
+
+    private String getDataURL(String nextLine) {
+        TrackProperties props = new TrackProperties();
+        ParsingUtils.parseTrackLine(nextLine, props);
+        return props.getDataURL();
+    }
+
+    private String getIndexURL(String nextLine) {
+        TrackProperties props = new TrackProperties();
+        ParsingUtils.parseTrackLine(nextLine, props);
+        return props.getIndexURL();
+    }
+
+    private String getCoverageURL(String nextLine) {
+        TrackProperties props = new TrackProperties();
+        ParsingUtils.parseTrackLine(nextLine, props);
+        return props.getCoverageURL();
+    }
+
+    private void placeTracksInPanels(List<ResourceLocator> locatorPaths, Map<String, List<Track>> loadedTracks) {
+        for (ResourceLocator loc : locatorPaths) {
+            //TrackPanel panel = IGV.getInstance().getPanelFor(new ResourceLocator(path));
+            // If loading from an index aware session use a single panel
+            TrackPanel panel = igv.getTrackPanel(IGV.DATA_PANEL_NAME);
+            String path = loc.getPath();
+            if (loadedTracks.containsKey(path)) {
+                panel.addTracks(loadedTracks.get(path));
+            }
+        }
+    }
+
+    private boolean isAlignmentFile(String path) {
+        return path.endsWith(".bam") || path.endsWith(".entries") || path.endsWith(".sam");
+    }
+
+
+    /**
+     * Browser lines have 2 or 3 tokens,  e.g.
+     * browser position chr19:11500000-12000000
+     *
+     * @param line
+     */
+    private void parseBrowserLine(String line, Session session) {
+
+        String[] tokens = line.split("\\s+");
+        if (tokens.length >= 3 && tokens[1].equals("position")) {
+            session.setLocus(tokens[2]);
+        }
+    }
+
+    private ResourceLocator parseResourceLine(String line) {
+        ResourceLocator locator = null;
+        String[] tokens = line.split("\\s+");
+        if (tokens.length == 1) {
+            locator = new ResourceLocator(tokens[0]);
+        }
+        else if (tokens.length >= 2) {
+            // Might want to do some error checking here on
+            // making sure file prefixes match and file extensions
+            // indicate the index comes second.
+            locator = new ResourceLocator(tokens[0]);
+            locator.setIndexPath(tokens[1]);
+
+            if (tokens.length >= 3) {
+                locator.setCoverage(tokens[2]);
+            }
+        }
+
+        return locator;
+    }
+
+    private void displayErrors(List<String> errors) {
+        StringBuffer buffer = new StringBuffer();
+        buffer.append("<html>Errors were encountered while loading session:<br>");
+        for (String e : errors) {
+            buffer.append(e);
+        }
+        MessageUtils.showMessage(buffer.toString());
+    }
+
+}

--- a/src/org/broad/igv/session/SessionWriter.java
+++ b/src/org/broad/igv/session/SessionWriter.java
@@ -339,6 +339,9 @@ public class SessionWriter {
                     if (resourceLocator.getType() != null) {
                         dataFileElement.setAttribute(SessionAttribute.TYPE.getText(), resourceLocator.getType());
                     }
+                    if (resourceLocator.getIndexPath() != null) {
+                        dataFileElement.setAttribute(SessionAttribute.INDEX.getText(), resourceLocator.getIndexPath());
+                    }
                     if (resourceLocator.getCoverage() != null) {
                         dataFileElement.setAttribute(SessionAttribute.COVERAGE.getText(), resourceLocator.getCoverage());
                     }

--- a/src/org/broad/igv/track/TrackLoader.java
+++ b/src/org/broad/igv/track/TrackLoader.java
@@ -908,13 +908,14 @@ public class TrackLoader {
             // Search for precalculated coverage data
             // Skip for GA4GH & SU2C resources
             if (!(Ga4ghAPIHelper.RESOURCE_TYPE.equals(locator.getType()) ||
-                   locator.getPath().contains("dataformat=.bam") ||
-                    OAuthUtils.isGoogleCloud(locator.getPath()))) {
+                  locator.getPath().contains("dataformat=.bam") ||
+                  OAuthUtils.isGoogleCloud(locator.getPath()))) {
 
                 String covPath = locator.getCoverage();
                 if (covPath == null) {
+                    boolean bypassFileAutoDiscovery = PreferenceManager.getInstance().getAsBoolean(PreferenceManager.BYPASS_FILE_AUTO_DISCOVERY);
                     String path = locator.getPath();
-                    if (!path.contains("/query.cgi?")) {
+                    if (!bypassFileAutoDiscovery && !path.contains("/query.cgi?")) {
                         covPath = path + ".tdf";
                     }
 

--- a/src/org/broad/igv/track/TrackProperties.java
+++ b/src/org/broad/igv/track/TrackProperties.java
@@ -138,6 +138,10 @@ public class TrackProperties {
 
     private String dataURL;
 
+    private String indexURL;
+
+    private String coverageURL;
+
     /**
      * Track attributes (meta data)
      */
@@ -422,8 +426,24 @@ public class TrackProperties {
         return dataURL;
     }
 
+    public String getIndexURL() {
+        return indexURL;
+    }
+
+    public String getCoverageURL() {
+        return coverageURL;
+    }
+
     public void setDataURL(String dataURL) {
         this.dataURL = dataURL;
+    }
+
+    public void setIndexURL(String indexURL) {
+        this.indexURL = indexURL;
+    }
+
+    public void setCoverageURL(String coverageURL) {
+        this.coverageURL = coverageURL;
     }
 
 

--- a/src/org/broad/igv/track/TribbleFeatureSource.java
+++ b/src/org/broad/igv/track/TribbleFeatureSource.java
@@ -26,6 +26,7 @@
 package org.broad.igv.track;
 
 import org.broad.igv.Globals;
+import org.broad.igv.PreferenceManager;
 import org.broad.igv.data.AbstractDataSource;
 import org.broad.igv.data.DataSource;
 import org.broad.igv.data.DataTile;
@@ -134,9 +135,10 @@ abstract public class TribbleFeatureSource implements org.broad.igv.track.Featur
                 new CachingFeatureReader(reader, 5, featureWindowSize) :
                 new TribbleReaderWrapper(reader);
 
-        initCoverageSource(locator.getPath() + ".tdf");
-
-
+        boolean bypassFileAutoDiscovery = PreferenceManager.getInstance().getAsBoolean(PreferenceManager.BYPASS_FILE_AUTO_DISCOVERY);
+        if (!bypassFileAutoDiscovery) {
+            initCoverageSource(locator.getPath() + ".tdf");
+        }
     }
 
     protected abstract int estimateFeatureWindowSize(FeatureReader reader);

--- a/src/org/broad/igv/ui/IGV.java
+++ b/src/org/broad/igv/ui/IGV.java
@@ -61,6 +61,7 @@ import org.broad.igv.session.IGVSessionReader;
 import org.broad.igv.session.Session;
 import org.broad.igv.session.SessionReader;
 import org.broad.igv.session.UCSCSessionReader;
+import org.broad.igv.session.IndexAwareSessionReader;
 import org.broad.igv.track.*;
 import org.broad.igv.ui.dnd.GhostGlassPane;
 import org.broad.igv.ui.event.*;
@@ -1419,9 +1420,10 @@ public class IGV {
             inputStream = new BufferedInputStream(ParsingUtils.openInputStreamGZ(new ResourceLocator(sessionPath)));
 
             boolean isUCSC = sessionPath.endsWith(".session") || sessionPath.endsWith(".session.txt");
+            boolean isIndexAware = sessionPath.endsWith(".idxsession") || sessionPath.endsWith(".idxsession.txt");
             final SessionReader sessionReader = isUCSC ?
                     new UCSCSessionReader(this) :
-                    new IGVSessionReader(this);
+                    (isIndexAware ? new IndexAwareSessionReader(this) : new IGVSessionReader(this));
 
             sessionReader.loadSession(inputStream, session, sessionPath);
 

--- a/src/org/broad/igv/ui/IGVMenuBar.java
+++ b/src/org/broad/igv/ui/IGVMenuBar.java
@@ -401,6 +401,10 @@ public class IGVMenuBar extends JMenuBar {
         menuAction.setToolTipText(UIConstants.LOAD_TRACKS_TOOLTIP);
         menuItems.add(MenuAndToolbarUtils.createMenuItem(menuAction));
 
+        menuAction = new LoadFromURLMenuAction(LoadFromURLMenuAction.LOAD_FILE_AND_INDEX_FROM_URLS, KeyEvent.VK_B, igv);
+        menuAction.setToolTipText(UIConstants.LOAD_TRACKS_TOOLTIP);
+        menuItems.add(MenuAndToolbarUtils.createMenuItem(menuAction));
+
         menuAction = new LoadFromServerAction("Load from Server...", KeyEvent.VK_S, igv);
         menuAction.setToolTipText(UIConstants.LOAD_SERVER_DATA_TOOLTIP);
         menuItems.add(MenuAndToolbarUtils.createMenuItem(menuAction));

--- a/src/org/broad/igv/ui/PreferencesEditor.java
+++ b/src/org/broad/igv/ui/PreferencesEditor.java
@@ -170,7 +170,9 @@ public class PreferencesEditor extends javax.swing.JDialog {
         defaultTrackHeightField = new JTextField();
         hSpacer1 = new JPanel(null);
         expandCB = new JCheckBox();
+        bypassFileAutoDiscoveryCB = new JCheckBox();
         normalizeCoverageCB = new JCheckBox();
+        bypassFileAutoDiscoveryExplanation = new JLabel();
         missingDataExplanation8 = new JLabel();
         expandIconCB = new JCheckBox();
         panel24 = new JScrollPane();
@@ -808,6 +810,27 @@ public class PreferencesEditor extends javax.swing.JDialog {
                         GridBagConstraints.CENTER, GridBagConstraints.BOTH,
                         new Insets(0, 0, 15, 10), 0, 0));
 
+                    //---- Bypass looking for tdf, bam, or other helper files ----
+                    bypassFileAutoDiscoveryCB.setText("Bypass automatic discovery of helper files");
+                    bypassFileAutoDiscoveryCB.addActionListener(new ActionListener() {
+                        @Override
+                        public void actionPerformed(ActionEvent e) {
+                            bypassFileAutoDiscoveryCBActionPerformed(e);
+                        }
+                    });
+                    tracksPanel.add(bypassFileAutoDiscoveryCB, new GridBagConstraints(2, 6, 2, 1, 0.0, 0.0,
+                        GridBagConstraints.CENTER, GridBagConstraints.BOTH,
+                        new Insets(0, 0, 15, 10), 0, 0));
+
+                    //---- Bypass file auto discovery explanation ----
+                    bypassFileAutoDiscoveryExplanation.setFont(new Font("Lucida Grande", Font.ITALIC, 12));
+                    bypassFileAutoDiscoveryExplanation.setText("<html><i> By default, igv will attempt to automatically discover helper files to some tracks by checking to see if a filename with a given extension exists (for instance a tdf file for a given bam file).  Some environments may not be compatible with this behavior.");
+                    //bypassFileAutoDiscoveryExplanation.setMaximumSize(new Dimension(500, 2147483647));
+                    bypassFileAutoDiscoveryExplanation.setPreferredSize(new Dimension(500, 60));
+                    tracksPanel.add(bypassFileAutoDiscoveryExplanation, new GridBagConstraints(2, 7, 2, 1, 0.0, 0.0,
+                        GridBagConstraints.CENTER, GridBagConstraints.BOTH,
+                        new Insets(0, 0, 15, 10), 0, 0));
+
                     //---- normalizeCoverageCB ----
                     normalizeCoverageCB.setText("Normalize Coverage Data");
                     normalizeCoverageCB.addActionListener(new ActionListener() {
@@ -822,18 +845,18 @@ public class PreferencesEditor extends javax.swing.JDialog {
                             normalizeCoverageCBFocusLost(e);
                         }
                     });
-                    tracksPanel.add(normalizeCoverageCB, new GridBagConstraints(2, 7, 2, 1, 0.0, 0.0,
+                    tracksPanel.add(normalizeCoverageCB, new GridBagConstraints(2, 8, 2, 1, 0.0, 0.0,
                         GridBagConstraints.CENTER, GridBagConstraints.BOTH,
                         new Insets(0, 0, 15, 10), 0, 0));
 
                     //---- missingDataExplanation8 ----
                     missingDataExplanation8.setFont(new Font("Lucida Grande", Font.ITALIC, 12));
                     missingDataExplanation8.setText("<html><i> Applies to coverage tracks computed with igvtools (.tdf files).  If selected coverage values are scaled by (1,000,000 / totalCount),  where totalCount is the total number of features or alignments.");
-                    missingDataExplanation8.setMaximumSize(new Dimension(500, 2147483647));
+                    //missingDataExplanation8.setMaximumSize(new Dimension(500, 2147483647));
                     missingDataExplanation8.setPreferredSize(new Dimension(500, 50));
-                    tracksPanel.add(missingDataExplanation8, new GridBagConstraints(2, 8, 6, 2, 0.0, 0.0,
+                    tracksPanel.add(missingDataExplanation8, new GridBagConstraints(2, 9, 2, 1, 0.0, 0.0,
                         GridBagConstraints.CENTER, GridBagConstraints.BOTH,
-                        new Insets(0, 0, 0, 0), 0, 0));
+                        new Insets(0, 0, 15, 10), 0, 0));
 
                     //---- expandIconCB ----
                     expandIconCB.setText("Show Expand Icon");
@@ -844,8 +867,8 @@ public class PreferencesEditor extends javax.swing.JDialog {
                             expandIconCBActionPerformed(e);
                         }
                     });
-                    tracksPanel.add(expandIconCB, new GridBagConstraints(2, 6, 2, 1, 0.0, 0.0,
-                        GridBagConstraints.CENTER, GridBagConstraints.BOTH,
+                    tracksPanel.add(expandIconCB, new GridBagConstraints(2, 10, 2, 1, 0.0, 0.0,
+                        GridBagConstraints.PAGE_START, GridBagConstraints.HORIZONTAL,
                         new Insets(0, 0, 15, 10), 0, 0));
                 }
                 panel23.setViewportView(tracksPanel);
@@ -3802,6 +3825,10 @@ public class PreferencesEditor extends javax.swing.JDialog {
         snpThresholdFieldActionPerformed(null);
     }
 
+    private void bypassFileAutoDiscoveryCBActionPerformed(java.awt.event.ActionEvent evt) {
+        updatedPreferenceMap.put(PreferenceManager.BYPASS_FILE_AUTO_DISCOVERY, String.valueOf(bypassFileAutoDiscoveryCB.isSelected()));
+    }
+
     private void normalizeCoverageCBActionPerformed(java.awt.event.ActionEvent evt) {
         updatedPreferenceMap.put(PreferenceManager.NORMALIZE_COVERAGE, String.valueOf(normalizeCoverageCB.isSelected()));
         portField.setEnabled(enablePortCB.isSelected());
@@ -4206,6 +4233,7 @@ public class PreferencesEditor extends javax.swing.JDialog {
         useProbeMappingCB.setSelected(useProbeMapping);
         updateProbeMappingOptions(useProbeMapping);
 
+        bypassFileAutoDiscoveryCB.setSelected(prefMgr.getAsBoolean(PreferenceManager.BYPASS_FILE_AUTO_DISCOVERY));
         normalizeCoverageCB.setSelected(prefMgr.getAsBoolean(PreferenceManager.NORMALIZE_COVERAGE));
 
 
@@ -4405,7 +4433,9 @@ public class PreferencesEditor extends javax.swing.JDialog {
     private JTextField defaultTrackHeightField;
     private JPanel hSpacer1;
     private JCheckBox expandCB;
+    private JCheckBox bypassFileAutoDiscoveryCB;
     private JCheckBox normalizeCoverageCB;
+    private JLabel bypassFileAutoDiscoveryExplanation;
     private JLabel missingDataExplanation8;
     private JCheckBox expandIconCB;
     private JScrollPane panel24;

--- a/src/org/broad/igv/ui/action/LoadFromURLMenuAction.java
+++ b/src/org/broad/igv/ui/action/LoadFromURLMenuAction.java
@@ -59,6 +59,7 @@ public class LoadFromURLMenuAction extends MenuAction {
     static Logger log = Logger.getLogger(LoadFilesMenuAction.class);
     public static final String LOAD_FROM_DAS = "Load from DAS...";
     public static final String LOAD_FROM_URL = "Load from URL...";
+    public static final String LOAD_FILE_AND_INDEX_FROM_URLS = "Load file and index from URLs...";
     public static final String LOAD_GENOME_FROM_URL = "Load Genome from URL...";
     private IGV igv;
 
@@ -107,6 +108,17 @@ public class LoadFromURLMenuAction extends MenuAction {
                     igv.loadTracks(Arrays.asList(rl));
 
                 }
+            }
+        } else if ((e.getActionCommand().equalsIgnoreCase(LOAD_FILE_AND_INDEX_FROM_URLS))) {
+            String fileUrl = JOptionPane.showInputDialog(IGV.getMainFrame(), ta, "Enter file URL (http or ftp)", JOptionPane.QUESTION_MESSAGE);
+            String indexUrl = JOptionPane.showInputDialog(IGV.getMainFrame(), ta, "Enter index URL (http or ftp)", JOptionPane.QUESTION_MESSAGE);
+
+            if (fileUrl != null && fileUrl.trim().length() > 0 && indexUrl != null && indexUrl.trim().length() > 0) {
+                fileUrl = fileUrl.trim();
+                indexUrl = indexUrl.trim();
+                ResourceLocator rl = new ResourceLocator(fileUrl.trim());
+                rl.setIndexPath(indexUrl.trim());
+                igv.loadTracks(Arrays.asList(rl));
             }
         } else if ((e.getActionCommand().equalsIgnoreCase(LOAD_FROM_DAS))) {
             String url = JOptionPane.showInputDialog(IGV.getMainFrame(), ta, "Enter DAS feature source URL",

--- a/src/org/broad/igv/util/ParsingUtils.java
+++ b/src/org/broad/igv/util/ParsingUtils.java
@@ -496,6 +496,10 @@ public class ParsingUtils {
                             trackProperties.setGenome(value);
                         } else if (key.equals("bigdataurl") || key.equals("dataurl")) {
                             trackProperties.setDataURL(value);
+                        } else if (key.equals("indexurl")) {
+                            trackProperties.setIndexURL(value);
+                        } else if (key.equals("coverageurl")) {
+                            trackProperties.setCoverageURL(value);
                         } else if (key.equals("meta")) {
                             trackProperties.setMetaData(value);
                         }

--- a/src/org/broad/igv/variant/VariantTrack.java
+++ b/src/org/broad/igv/variant/VariantTrack.java
@@ -211,8 +211,9 @@ public class VariantTrack extends FeatureTrack implements TrackGroupEventListene
         }
 
         // If sample->bam list file is supplied enable vcfToBamMode.
+        boolean bypassFileAutoDiscovery = PreferenceManager.getInstance().getAsBoolean(PreferenceManager.BYPASS_FILE_AUTO_DISCOVERY);
         String vcfToBamMapping = path != null ? path + ".mapping" : null;
-        if (ParsingUtils.pathExists(vcfToBamMapping)) {
+        if (!bypassFileAutoDiscovery && ParsingUtils.pathExists(vcfToBamMapping)) {
             loadAlignmentMappings(vcfToBamMapping);
         }
 


### PR DESCRIPTION
This pull request addresses the following main points, with a common theme of allowing more flexibility in the paths of supporting files (for instance .bai companions to .bam files).

1. It updates the IGV session writer to save the index file path into the session file if there is an index file known.  The native IGV session writer already saves the coverage file path if known, and has a field to save the index file, but at present the writer did not actually write the index path.
2. This pull request makes it easier to provide the paths of index files which may differ from the paths of the files they support.  For instance, some users may keep their .bam files in one directory, and supporting files like .bai or .tdf in separate directories.  To make it easier to explicitly set these paths this pull request includes:
  * A new menu item allowing for users to give the path to a bam file and a separate path to the .bai file that belongs to that bam.
  * Introduces a new session file based heavily on the UCSC session file.  The main difference is this session file has fields to supply index and coverage file paths, and just as the UCSC session file allows for users to simply give a list of paths for files, one path per line, this session file allows users to provide paths along with their index file paths and coverage file paths.  For instance, let's say a user wants to load in a couple of bam files and a vcf.gz file into IGV.  With this "index aware" session file, they can simply write:
  ```
  /path/to/foo.bam /different/path/to/foo.bam.bai
  /path/to/bar.bam /different/path/to/bar.bam.bai /yet/another/path/to/bar.bam.tdf
  /another/path/to/bob.vcf.gz /last/path/to/bob.vcf.gz.tbi
  ```
This makes it very easy to import a set of reads/variants with their corresponding index files and coverage files.  Then with the update in the IGV session writer mentioned previously, saving this as an IGV session will now contain all information to reload this data easily.
3. In the IGV source, there is existing special case logic for files from GoogleCloud or Ga4ghAPIHelper so that it will not attempt to find helper files (like coverarage files) by adding .tdf onto the path and checking for a file to exist.  This pull request makes this more generalizable by providing a check box item in preferences allowing users to selectively disable this "helper function auto-discovery".  This enables additional environments where such auto-discovery is not appropriate.

