### PR TITLE
Base pair arc loading and rendering.

### DIFF
--- a/src/org/broad/igv/feature/basepair/BasePairData.java
+++ b/src/org/broad/igv/feature/basepair/BasePairData.java
@@ -1,0 +1,52 @@
+
+// should perhaps be in igv.data or some other location
+package org.broad.igv.feature.basepair;
+
+import java.awt.*; // does this have Color definition?
+import java.util.List;
+import java.util.HashMap;
+
+public class BasePairData{
+    // should have enumerated colors here
+    public Color[] colors;
+
+    // should hold list of helices with same color, and enum ID for arc color
+    public int[][] startLeftNucs;
+    public int[][] startRightNucs;
+    public int[][] endLeftNucs;
+    public int[][] endRightNucs;
+
+    // convert lists to simple arrays
+    public BasePairData(List<Color> inputColors, HashMap<Color,List<Object>> rowsByColor){
+        colors = new Color[inputColors.size()];
+        inputColors.toArray(colors);
+        startLeftNucs = new int[colors.length][0];
+        startRightNucs = new int[colors.length][0];
+        endLeftNucs = new int[colors.length][0];
+        endRightNucs = new int[colors.length][0];
+        for (int i=0 ; i< colors.length ; i++){
+            Color color = colors[i];
+            System.out.println(color);
+            List<Object> rows = rowsByColor.get(color);
+
+            startLeftNucs[i] = new int[rows.size()];
+            startRightNucs[i] = new int[rows.size()];
+            endLeftNucs[i] = new int[rows.size()];
+            endRightNucs[i] = new int[rows.size()];
+
+            for (int j=0 ; j<rows.size() ; j++){
+                // this is ugly
+                List<Object> row = (List<Object>) rows.get(j);
+                startLeftNucs[i][j] = (Integer) (row.get(0));
+                startRightNucs[i][j] = (Integer) (row.get(1));
+                endLeftNucs[i][j] = (Integer) (row.get(2));
+                endRightNucs[i][j] = (Integer) (row.get(3));
+                //System.out.format("%d\t%d\t%d\t%d\n",startLeftNucs[i][j],startRightNucs[i][j],endLeftNucs[i][j],endRightNucs[i][j]);
+            }
+        }
+        //System.out.println("Colors: ");
+        //for (int i=0; i<colors.length; i++){
+        //    System.out.println(colors[i]);
+        //}
+    }
+}

--- a/src/org/broad/igv/feature/basepair/BasePairFileParser.java
+++ b/src/org/broad/igv/feature/basepair/BasePairFileParser.java
@@ -1,0 +1,114 @@
+package org.broad.igv.feature.basepair;
+
+import org.apache.batik.dom.svg12.Global;
+import org.apache.log4j.Logger;
+import org.broad.igv.Globals;
+import org.broad.igv.exceptions.ParserException;
+import org.broad.igv.feature.genome.Genome;
+import org.broad.igv.feature.Strand;
+import org.broad.igv.feature.basepair.BasePairData;
+import org.broad.igv.track.BasePairTrack;
+import org.broad.igv.renderer.BasePairRenderer;
+import org.broad.igv.util.ParsingUtils;
+import org.broad.igv.util.ResourceLocator;
+import htsjdk.tribble.readers.AsciiLineReader;
+
+import java.awt.*;
+import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class BasePairFileParser {
+
+    static Logger log = Logger.getLogger(BasePairFileParser.class);
+
+    BasePairData basePairData;
+    BasePairTrack track;
+
+    public BasePairTrack loadTrack(ResourceLocator locator, Genome genome) {
+        AsciiLineReader reader = null;
+
+        List<Object> rows = new ArrayList();
+        List<Color> colors = new ArrayList();
+        HashMap<Color, List<Object>> rowsByColor = new HashMap<Color, List<Object>>();
+
+        int parseColumn = -1;
+        String nextLine = null;
+        int rowCounter = 0;
+
+        try {
+            reader = ParsingUtils.openAsciiReader(locator);
+            // read lines specifying arc colors
+            nextLine = reader.readLine();
+            rowCounter++;
+            while (nextLine.substring(0,6).equals("color:")){
+                String[] tokens = Globals.tabPattern.split(nextLine, -1);
+                int r = Integer.parseInt(tokens[1]);
+                int g = Integer.parseInt(tokens[2]);
+                int b = Integer.parseInt(tokens[3]);
+                Color color = new Color(r,g,b,255);
+                colors.add(color);
+                nextLine = reader.readLine();
+                rowCounter++;
+            }
+
+            for (Color color : colors){
+                rowsByColor.put(color, new ArrayList());
+            }
+
+            while (nextLine != null) {
+
+                String[] tokens = Globals.tabPattern.split(nextLine, -1);
+
+                int nTokens = tokens.length;
+
+                int startLeftNuc = Integer.parseInt(tokens[0])-1; // stick to IGV's 0-based coordinate convention
+                int startRightNuc = Integer.parseInt(tokens[1])-1;
+                int endLeftNuc = Integer.parseInt(tokens[2])-1;
+                int endRightNuc = Integer.parseInt(tokens[3])-1;
+                Color color = colors.get(Integer.parseInt(tokens[4]));
+
+                List<Object> columns = new ArrayList();
+                if (startLeftNuc <= endRightNuc){
+                    columns.add(Math.min(startLeftNuc, startRightNuc));
+                    columns.add(Math.max(startLeftNuc, startRightNuc));
+                    columns.add(Math.min(endLeftNuc, endRightNuc));
+                    columns.add(Math.max(endLeftNuc, endRightNuc));
+                } else {
+                    // maintain left-to-right basepair order even if swapped in file
+                    columns.add(Math.min(endLeftNuc, endRightNuc));
+                    columns.add(Math.max(endLeftNuc, endRightNuc));
+                    columns.add(Math.min(startLeftNuc, startRightNuc));
+                    columns.add(Math.max(startLeftNuc, startRightNuc));
+                }
+                rowsByColor.get(color).add(columns);
+                nextLine = reader.readLine();
+                rowCounter++;
+            }
+
+            basePairData = new BasePairData(colors, rowsByColor);
+
+        } catch (Exception e) {
+            log.error("Error parsing base pair file", e);
+            if (nextLine != null && rowCounter != 0) {
+                throw new ParserException(e.getMessage(), e, rowCounter, nextLine);
+            } else {
+                throw new RuntimeException(e);
+            }
+        } finally {
+            if (reader != null) {
+                reader.close();
+            }
+        }
+
+        //for (Object row : rows){
+        //    System.out.println(row);
+        //}
+
+        track = new BasePairTrack(basePairData, locator.getTrackName());
+        return track;
+    }
+
+}

--- a/src/org/broad/igv/renderer/BasePairRenderer.java
+++ b/src/org/broad/igv/renderer/BasePairRenderer.java
@@ -1,0 +1,240 @@
+// previously ArcRenderer
+
+package org.broad.igv.renderer;
+
+//~--- non-JDK imports --------------------------------------------------------
+
+import org.apache.commons.math.stat.Frequency;
+import org.apache.log4j.Logger;
+import org.broad.igv.feature.basepair.BasePairData;
+import org.broad.igv.PreferenceManager;
+import org.broad.igv.track.RenderContext;
+import org.broad.igv.track.Track;
+import org.broad.igv.ui.FontManager;
+
+import java.awt.*;
+import java.awt.geom.GeneralPath;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+// TODO: add vertical scaling option so arcs fit on track, or clip arcs outside of track rect?
+
+public class BasePairRenderer {
+
+    private static Logger log = Logger.getLogger(BasePairRenderer.class);
+
+    Color ARC_COLOR_A = new Color(50, 50, 150, 140); //transparent dull blue
+    Color ARC_COLOR_B = new Color(150, 50, 50, 140); //transparent dull red
+    Color ARC_COLOR_C = new Color(50, 0, 50, 250);
+
+    int dir = -1; // 1 for up, -1 for down
+
+    // central horizontal line color
+    Color COLOR_CENTERLINE = new Color(0, 0, 0, 100);
+
+    public int getDirection(){
+        return dir;
+    }
+
+    public void setDirection(int d){
+        dir = d;
+    }
+
+    public void draw(BasePairData data, RenderContext context, Rectangle trackRectangle){
+
+        double nucsPerPixel = context.getScale();
+        double origin = context.getOrigin();
+        //The location of the first base that is loaded
+        int start = Math.max(0, (int) origin - 1);
+        //The location of the last base that is loaded
+        int end = (int) (origin + trackRectangle.width * nucsPerPixel) + 1;
+        if (end <= start) return;
+
+        // TODO: should make this a function (ugh no multiple value return from java functions)
+        for (int i=0 ; i< data.colors.length ; i++){
+            //System.out.println("Color: "+data.colors[i]);
+            int arcCount = 0;
+            for (int j=0; j<data.startLeftNucs[i].length; j++){
+                // TODO: only render arcs whose interior overlaps the viewing area - i.e. if an arc starts left of the window and ends right of the window, should still render
+
+
+                //System.out.println("In arcRenderer.draw(): ");
+                //System.out.println("    track.width = " + trackRectangle.width);
+                //System.out.println("    nucsPerPixel = " + nucsPerPixel);
+                //System.out.println("    origin = " + origin);
+                //System.out.println("    start = " + start);
+                //System.out.println("    end = " + end);
+
+                double startLeftPix = (double) ((data.startLeftNucs[i][j]-origin)/nucsPerPixel);
+                double startRightPix = (double) ((data.startRightNucs[i][j]+1.0-origin)/nucsPerPixel);
+                double endLeftPix = (double) ((data.endLeftNucs[i][j]-origin)/nucsPerPixel);
+                double endRightPix = (double) ((data.endRightNucs[i][j]+1.0-origin)/nucsPerPixel);
+
+                drawArc(startLeftPix, startRightPix, endLeftPix, endRightPix, trackRectangle, context, data.colors[i]);
+                arcCount++;
+
+                //System.out.println("    leftStart = " + leftStartNucPix);
+                //System.out.println("    leftEnd = " + leftEndNucPix);
+                //System.out.println("    rightStart = " + rightStartNucPix);
+                //System.out.println("    rightEnd = " + rightEndNucPix);
+                //System.out.println("    arcWidth = " + arcWidthPix);
+
+                //drawArc(10, 210, 50, trackRectangle, context, ARC_COLOR_B);
+                //drawArc(300, 500, 50, trackRectangle, context, ARC_COLOR_A);
+
+            }
+            //System.out.println("Drew "+arcCount+" arcs");
+        }
+        //System.out.println("");
+
+        //draw a central horizontal line
+        Graphics2D g2D = context.getGraphic2DForColor(COLOR_CENTERLINE);
+
+        //g2D.drawLine((int) trackRectangle.getX(), y,
+        //        (int) trackRectangle.getMaxX(), y);
+    }
+
+
+
+
+    /**
+     * Draw a filled arc between two regions of equal length
+     *
+     * @param pixelStart  the starting position of the feature, whether on-screen or not
+     * @param pixelEnd    the ending position of the feature, whether on-screen or not
+     * @param pixelWidth  the width of the arc in pixels
+     * @param trackRectangle
+     * @param context
+     * @param featureColor       the color specified for this feature.  May be null.
+     */
+    protected void drawArc(double startLeft, double startRight, double endLeft, double endRight,
+                           Rectangle trackRectangle, RenderContext context, Color featureColor) {
+
+        Color color;
+        if (featureColor != null) {
+            color = featureColor;
+        } else {
+            color = ARC_COLOR_A;
+        }
+
+        Graphics2D g2D = context.getGraphic2DForColor(color);
+        if (PreferenceManager.getInstance().getAsBoolean(PreferenceManager.ENABLE_ANTIALISING)) {
+            g2D.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+            g2D.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
+        }
+        //Height of top of an arc of maximum depth
+        int maxPossibleArcHeight = (trackRectangle.height - 1) / 2;
+
+        // Equation by G. Adam Stanislav from http://www.whizkidtech.redprince.net/bezier/circle/
+        double handleLengthFactor = 4f*((double)Math.sqrt(2f)-1f)/3f;
+
+        double outerRadius = (double) (endRight-startLeft)/2.0;
+        double innerRadius = (double) (endLeft-startRight)/2.0;
+
+        double arcWidth = Math.max(1.0, startRight-startLeft);
+
+        int y = 0;
+        if (dir>0){
+            y = (int) trackRectangle.getMaxY();
+        } else {
+            y = (int) trackRectangle.getMinY();
+        }
+
+        // Define all control points
+        // Use a minimum arc width of 1 pixel
+        int outerLX = (int) (trackRectangle.getX() + startLeft);
+        int outerLY = y;
+
+        int outerLC1X = (int) (trackRectangle.getX() + outerLX);
+        int outerLC1Y = (int) (outerLY - dir * handleLengthFactor*outerRadius);
+
+        int outerLC2X = (int) (trackRectangle.getX() + outerLX+outerRadius - handleLengthFactor*outerRadius);
+        int outerLC2Y = (int) (outerLY - dir * outerRadius);
+
+        int outerCenterX = (int) (trackRectangle.getX() + outerLX+outerRadius);
+        int outerCenterY = (int) (outerLY - dir * outerRadius);
+
+        int outerRC1X = (int) (trackRectangle.getX() + outerLX+outerRadius + handleLengthFactor*outerRadius);
+        int outerRC1Y = (int) (outerLY - dir * outerRadius);
+
+        int outerRC2X = (int) (trackRectangle.getX() + endRight);
+        int outerRC2Y = (int) (outerLY - dir * handleLengthFactor*outerRadius);
+
+        int outerRX = (int) (trackRectangle.getX() + endRight);
+        int outerRY = outerLY;
+
+        int innerRX = (int) (trackRectangle.getX() + endRight - arcWidth);
+        int innerRY = outerLY;
+
+        int innerRC1X = (int) (trackRectangle.getX() + innerRX);
+        int innerRC1Y = (int) (outerLY - dir * handleLengthFactor*innerRadius);
+
+        int innerRC2X = (int) (trackRectangle.getX() + outerLX + outerRadius + handleLengthFactor*innerRadius);
+        int innerRC2Y = (int) (outerCenterY + dir * arcWidth);
+
+        int innerCenterX = (int) (trackRectangle.getX() + outerLX + outerRadius);
+        int innerCenterY = (int) (outerCenterY + dir * arcWidth);
+
+        int innerLC1X = (int) (trackRectangle.getX() + outerLX + outerRadius - handleLengthFactor*innerRadius);
+        int innerLC1Y = (int) (outerCenterY + dir * arcWidth);
+
+        int innerLC2X = (int) (trackRectangle.getX() + startLeft + arcWidth);
+        int innerLC2Y = (int) (outerLY - dir * handleLengthFactor*innerRadius);
+
+        int innerLX = (int) (trackRectangle.getX() + startLeft + arcWidth);
+        int innerLY = outerLY;
+
+        if (false){
+            GeneralPath arcCage = new GeneralPath();
+            arcCage.moveTo(outerLX, outerLY); // outer left
+            arcCage.lineTo(outerLC1X, outerLC1Y);
+            arcCage.lineTo(outerLC2X, outerLC2Y);
+            arcCage.lineTo(outerCenterX, outerCenterY); // outer left control 1, outer left control 2, outer center
+            arcCage.lineTo(outerRC1X, outerRC1Y);
+            arcCage.lineTo(outerRC2X, outerRC2Y);
+            arcCage.lineTo(outerRX, outerRY);// outer right control 1, outer right control 2, outer right
+            arcCage.lineTo(innerRX, innerRY); // inner right
+            arcCage.lineTo(innerRC1X, innerRC1Y);
+            arcCage.lineTo(innerRC2X, innerRC2Y);
+            arcCage.lineTo(innerCenterX, innerCenterY); // inner right control 1, inner right control 2, inner center
+            arcCage.lineTo(innerLC1X, innerLC1Y);
+            arcCage.lineTo(innerLC2X, innerLC2Y);
+            arcCage.lineTo(innerLX, innerLY); // inner left control 1, inner left control 2, inner left
+            arcCage.lineTo(outerLX, outerLY); // outer left
+            arcCage.moveTo(outerLX, outerLY);
+            arcCage.closePath();
+            // Draw the shape
+            //g2D.draw(arcCage);
+            g2D.fill(arcCage);
+        }
+
+        // Create path
+        if (true){
+            GeneralPath arcPath = new GeneralPath();
+            arcPath.moveTo(outerLX, outerLY); // outer left
+            arcPath.curveTo(outerLC1X, outerLC1Y,
+                    outerLC2X, outerLC2Y,
+                    outerCenterX, outerCenterY); // outer left control 1, outer left control 2, outer center
+            arcPath.curveTo(outerRC1X, outerRC1Y,
+                    outerRC2X, outerRC2Y,
+                    outerRX, outerRY);// outer right control 1, outer right control 2, outer right
+            arcPath.lineTo(innerRX, innerRY); // inner right
+            arcPath.curveTo(innerRC1X, innerRC1Y,
+                    innerRC2X, innerRC2Y,
+                    innerCenterX, innerCenterY); // inner right control 1, inner right control 2, inner center
+            arcPath.curveTo(innerLC1X, innerLC1Y,
+                    innerLC2X, innerLC2Y,
+                    innerLX, innerLY); // inner left control 1, inner left control 2, inner left
+            arcPath.lineTo(outerLX, outerLY); // outer left
+            arcPath.moveTo(outerLX, outerLY);
+            arcPath.closePath();
+
+            // Draw the arc face
+            g2D.fill(arcPath);
+        }
+
+        g2D.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_DEFAULT);
+        g2D.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_DEFAULT);
+    }
+}

--- a/src/org/broad/igv/track/BasePairTrack.java
+++ b/src/org/broad/igv/track/BasePairTrack.java
@@ -1,0 +1,56 @@
+package org.broad.igv.track;
+
+import org.apache.log4j.Logger;
+import org.broad.igv.Globals;
+import org.broad.igv.PreferenceManager;
+import org.broad.igv.feature.basepair.BasePairData;
+import org.broad.igv.renderer.*;
+import org.broad.igv.session.IGVSessionReader;
+import org.broad.igv.session.SessionXmlAdapters;
+import org.broad.igv.session.SubtlyImportant;
+import org.broad.igv.ui.IGV;
+import org.broad.igv.ui.panel.FrameManager;
+import org.broad.igv.ui.panel.ReferenceFrame;
+import org.broad.igv.util.ResourceLocator;
+
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import java.awt.*;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+
+/**
+ * Show base-pairing arcs
+ *
+ * @author sbusan
+ */
+public class BasePairTrack extends AbstractTrack {
+
+    private static Logger log = Logger.getLogger(BasePairTrack.class);
+
+    private BasePairRenderer basePairRenderer = new BasePairRenderer();
+    private BasePairData basePairData;
+
+    public BasePairTrack(BasePairData data, String name) {
+        super(name);
+        basePairData = data;
+    }
+
+    public void render(RenderContext context, Rectangle rect) {
+        basePairRenderer.draw(basePairData, context, rect);
+    }
+
+    public Renderer getRenderer() {
+        return null;
+    }
+
+    public int getDirection(){
+        return basePairRenderer.getDirection();
+    }
+
+    public void setDirection(int d){
+        basePairRenderer.setDirection(d);
+    }
+}

--- a/src/org/broad/igv/track/TrackLoader.java
+++ b/src/org/broad/igv/track/TrackLoader.java
@@ -47,6 +47,8 @@ import org.broad.igv.dev.db.SQLCodecSource;
 import org.broad.igv.dev.db.SampleInfoSQLReader;
 import org.broad.igv.dev.db.SegmentedSQLReader;
 import org.broad.igv.exceptions.DataLoadException;
+import org.broad.igv.feature.basepair.BasePairFileParser;
+import org.broad.igv.feature.basepair.BasePairData;
 import org.broad.igv.feature.CachingFeatureSource;
 import org.broad.igv.feature.GisticFileParser;
 import org.broad.igv.feature.MutationTrackLoader;
@@ -76,6 +78,7 @@ import org.broad.igv.synteny.BlastMapping;
 import org.broad.igv.synteny.BlastParser;
 import org.broad.igv.tdf.TDFDataSource;
 import org.broad.igv.tdf.TDFReader;
+import org.broad.igv.track.BasePairTrack;
 import org.broad.igv.ui.IGV;
 import org.broad.igv.ui.util.ConfirmDialog;
 import org.broad.igv.ui.util.MessageUtils;
@@ -202,6 +205,8 @@ public class TrackLoader {
             } else if (typeString.endsWith("mage-tab") || ExpressionFileParser.parsableMAGE_TAB(locator)) {
                 locator.setDescription("MAGE_TAB");
                 loadGctFile(locator, newTracks, genome);
+            }  else if (typeString.endsWith(".bp")){
+                loadBasePairFile(locator, newTracks, genome);
             } else if (GWASParser.isGWASFile(typeString)) {
                 loadGWASFile(locator, newTracks, genome);
             } else if (GobyAlignmentQueryReader.supportsFileType(path)) {
@@ -1175,6 +1180,11 @@ public class TrackLoader {
         PedigreeUtils.parseTrioFile(locator.getPath());
     }
 
+
+    private void loadBasePairFile(ResourceLocator locator, List<Track> newTracks, Genome genome) throws IOException {
+        BasePairFileParser parser = new BasePairFileParser();
+        newTracks.add(parser.loadTrack(locator, genome)); // should create one track from the given file
+    }
 
     public static boolean isIndexed(ResourceLocator locator, Genome genome) {
 

--- a/src/org/broad/igv/track/TrackMenuUtils.java
+++ b/src/org/broad/igv/track/TrackMenuUtils.java
@@ -176,6 +176,17 @@ public class TrackMenuUtils {
             }
         }
 
+        boolean hasBasePairTracks = false;
+        for (Track track : tracks) {
+            if (track instanceof BasePairTrack) {
+                hasBasePairTracks = true;
+                break;
+            }
+        }
+        if (hasBasePairTracks) {
+            addBasePairItems(menu, tracks);
+        }
+
         boolean featureTracksOnly = hasFeatureTracks && !hasDataTracks && !hasOtherTracks;
         boolean dataTracksOnly = !hasFeatureTracks && hasDataTracks && !hasOtherTracks;
 
@@ -488,6 +499,47 @@ public class TrackMenuUtils {
         featurePopupMenu.addSeparator();
         featurePopupMenu.add(getChangeFeatureWindow(tracks));
 
+    }
+
+    /**
+     * Return popup menu with items applicable to arc tracks
+     *
+     * @return
+     */
+    // stevenbusan
+    public static void addBasePairItems(JPopupMenu menu, final Collection<Track> tracks) {
+
+        JLabel arcDirectionHeading = new JLabel(LEADING_HEADING_SPACER + "Arc direction", JLabel.LEFT);
+        arcDirectionHeading.setFont(UIConstants.boldFont);
+
+        menu.add(arcDirectionHeading);
+
+        final String[] arcDirectionLabels = {"Up", "Down"};
+
+        for (int i = 0; i < arcDirectionLabels.length; i++) {
+            JCheckBoxMenuItem item = new JCheckBoxMenuItem(arcDirectionLabels[i]);
+            final int n = (i==0) ? 1 : -1 ;
+            for (Track track : tracks) {
+                if (track instanceof BasePairTrack) {
+                    if (((BasePairTrack) track).getDirection() == n){
+                        item.setSelected(true);
+                    }
+                }
+            }
+            item.addActionListener(new ActionListener() {
+                public void actionPerformed(ActionEvent evt) {
+                    for (Track track : tracks) {
+                        if (track instanceof BasePairTrack) {
+                            ((BasePairTrack) track).setDirection(n);
+                        }
+                    }
+                    IGV.getInstance().repaint();
+                }
+            });
+            menu.add(item);
+        }
+
+        menu.addSeparator();
     }
 
     private static JMenuItem getFeatureToGeneListItem(final Track t) {


### PR DESCRIPTION
Added BasePairTrack, a filled arc track for base pairing data relevant to RNA structure modeling.  Added a new class BasePairData and a loader for a new file format, *.bp.  Attached are an example viral genome (HIV.fna) and a file describing base pairing arcs colored by modeled base-pairing probability (HIV.bp).

[example_arc_data.zip](https://github.com/igvteam/igv/files/133197/example_arc_data.zip)

Weaknesses with my implementation:
- Arcs can vertically extend beyond the height of the containing track depending on the zoom level.
- No support for multiple "chromosomes"
- All arcs are rendered, with no bounding box to limit the number of arcs. This can cause some lag on older laptops or with large numbers of arcs when zoomed out.
- No direct support for loading base pairing probability files from RNAStructure (*.dp).  I instead run an intermediate conversion script.

--------------------------------------------------
Steve Busan