### PR TITLE
Improve alignment details tooltip

### DIFF
--- a/src/org/broad/igv/PreferenceManager.java
+++ b/src/org/broad/igv/PreferenceManager.java
@@ -107,6 +107,7 @@ public class PreferenceManager implements PropertyManager {
     public static final String SAM_FILTER_SECONDARY_ALIGNMENTS = "SAM.FILTER_SECONDARY_ALIGNMENTS";
     public static final String SAM_FILTER_SUPPLEMENTARY_ALIGNMENTS = "SAM.FILTER_SUPPLEMENTARY_ALIGNMENTS";
     public static final String SAM_FILTER_URL = "SAM.FILTER_URL";
+    public static final String SAM_HIDDEN_TAGS = "SAM.HIDDEN_TAGS";
     public static final String SAM_MAX_VISIBLE_RANGE = "SAM.MAX_VISIBLE_RANGE";
     public static final String SAM_SHOW_DUPLICATES = "SAM.SHOW_DUPLICATES";
     public static final String SAM_SHOW_SOFT_CLIPPED = "SAM.SHOW_SOFT_CLIPPED";
@@ -1093,6 +1094,7 @@ public class PreferenceManager implements PropertyManager {
         defaultValues.put(SAM_BASE_QUALITY_MIN, "5");
         defaultValues.put(SAM_BASE_QUALITY_MAX, "20");
         defaultValues.put(SAM_FILTER_URL, null);
+        defaultValues.put(SAM_HIDDEN_TAGS, "MD,SA");
         defaultValues.put(SAM_QUALITY_THRESHOLD, "0");
         defaultValues.put(SAM_ALLELE_THRESHOLD, "0.2f");
         defaultValues.put(SAM_ALLELE_USE_QUALITY, "true");

--- a/src/org/broad/igv/sam/PicardAlignment.java
+++ b/src/org/broad/igv/sam/PicardAlignment.java
@@ -234,6 +234,8 @@ public class PicardAlignment extends SAMAlignment implements Alignment {
         if (attributes != null && !attributes.isEmpty()) {
 
             for (SAMRecord.SAMTagAndValue tag : attributes) {
+                // skip the read group (RG) tag, as it is handled as a special case
+                if (tag.tag.equals("RG")) { continue; }
                 buf.append("<br>" + tag.tag + " = ");
 
                 if (tag.value.getClass().isArray()) { // ignore array types

--- a/src/org/broad/igv/sam/SAMAlignment.java
+++ b/src/org/broad/igv/sam/SAMAlignment.java
@@ -553,11 +553,49 @@ public abstract class SAMAlignment implements Alignment {
             cigarString = (lMatcher.find() ? lMatcher.group(1) : "") + "..." + (rMatcher.find() ? rMatcher.group(1) : "");
         }
 
+        // Identify the number of hard and soft clipped bases.
+        Matcher lclipMatcher = Pattern.compile("^(([0-9]+)H)?(([0-9]+)S)?").matcher(cigarString);
+        Matcher rclipMatcher = Pattern.compile("(([0-9]+)S)?(([0-9]+)H)?$").matcher(cigarString);
+        int lclipHard = 0, lclipSoft = 0, rclipHard = 0, rclipSoft = 0;
+        if (lclipMatcher.find()) {
+            lclipHard = lclipMatcher.group(2) == null ? 0 : Integer.parseInt(lclipMatcher.group(2),10);
+            lclipSoft = lclipMatcher.group(4) == null ? 0 : Integer.parseInt(lclipMatcher.group(4),10);
+        }
+        if (rclipMatcher.find()) {
+            rclipHard = rclipMatcher.group(4) == null ? 0 : Integer.parseInt(rclipMatcher.group(4),10);
+            rclipSoft = rclipMatcher.group(2) == null ? 0 : Integer.parseInt(rclipMatcher.group(2),10);
+        }
+
         buf.append("----------------------" + "<br>");
         int basePosition = (int) position;
         buf.append("Location = " + getChr() + ":" + Globals.DECIMAL_FORMAT.format(1 + (long) position) + "<br>");
         buf.append("Alignment start = " + Globals.DECIMAL_FORMAT.format(getAlignmentStart() + 1) + " (" + (isNegativeStrand() ? "-" : "+") + ")<br>");
         buf.append("Cigar = " + cigarString + "<br>");
+        buf.append("Clipping = ");
+        if (lclipHard + lclipSoft + rclipHard + rclipSoft == 0) {
+            buf.append("None");
+        }
+        else {
+            if (lclipHard + lclipSoft > 0) {
+                buf.append("Left");
+                if (lclipHard > 0) {
+                    buf.append(" " + Globals.DECIMAL_FORMAT.format(lclipHard) + " hard");
+                }
+                if (lclipSoft > 0) {
+                    buf.append(" " + Globals.DECIMAL_FORMAT.format(lclipSoft) + " soft");
+                }
+            }
+            if (rclipHard + rclipSoft > 0) {
+                buf.append((lclipHard + lclipSoft > 0 ? "; " : "") + "Right");
+                if (rclipHard > 0) {
+                    buf.append(" " + Globals.DECIMAL_FORMAT.format(rclipHard) + " hard");
+                }
+                if (rclipSoft > 0) {
+                    buf.append(" " + Globals.DECIMAL_FORMAT.format(rclipSoft) + " soft");
+                }
+            }
+        }
+        buf.append("<br>");
         buf.append("Mapped = " + (isMapped() ? "yes" : "no") + "<br>");
         buf.append("Mapping quality = " + getMappingQuality() + "<br>");
         buf.append("Secondary = " + (isPrimary() ? "no" : "yes") + "<br>");

--- a/src/org/broad/igv/sam/SAMAlignment.java
+++ b/src/org/broad/igv/sam/SAMAlignment.java
@@ -569,7 +569,6 @@ public abstract class SAMAlignment implements Alignment {
         }
 
         buf.append("----------------------" + "<br>");
-        buf.append("Location = " + getChr() + ":" + Globals.DECIMAL_FORMAT.format(1 + (long) position) + "<br>");
         buf.append("Alignment start = " + Globals.DECIMAL_FORMAT.format(getAlignmentStart() + 1) + " (" + (isNegativeStrand() ? "-" : "+") + ")<br>");
         buf.append("Cigar = " + cigarString + "<br>");
         buf.append("Clipping = ");
@@ -657,6 +656,7 @@ public abstract class SAMAlignment implements Alignment {
                 }
 
                 byte quality = block.getQuality(offset);
+                buf.append("Location = " + getChr() + ":" + Globals.DECIMAL_FORMAT.format(1 + (long) position) + "<br>");
                 buf.append("Base = " + (char) base + "<br>");
                 buf.append("Base phred quality = " + quality + "<br>");
 

--- a/src/org/broad/igv/sam/SAMAlignment.java
+++ b/src/org/broad/igv/sam/SAMAlignment.java
@@ -40,6 +40,8 @@ import org.broad.igv.track.WindowFunction;
 import java.awt.*;
 import java.util.*;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * @author jrobinso
@@ -539,9 +541,16 @@ public abstract class SAMAlignment implements Alignment {
             buf.append("Read group = " + readGroup + "<br>");
         }
 
+
         String cigarString = getCigarString();
-        if (cigarString.length() > 80) {
-            cigarString = cigarString.substring(0, 80) + "...";
+        // Abbreviate long CIGAR strings.  Retain the start and end of the CIGAR, which show
+        // clipping; trim the middle.
+        int maxCigarStringLength = 60;
+        if (cigarString.length() > maxCigarStringLength) {
+            // Match only full <length><operator> pairs at the beginning and end of the string.
+            Matcher lMatcher = Pattern.compile("^(.{1," + Integer.toString(maxCigarStringLength/2 - 1) + "}[A-Z])").matcher(cigarString);
+            Matcher rMatcher = Pattern.compile("[A-Z](.{1," + Integer.toString(maxCigarStringLength/2) + "})$").matcher(cigarString);
+            cigarString = (lMatcher.find() ? lMatcher.group(1) : "") + "..." + (rMatcher.find() ? rMatcher.group(1) : "");
         }
 
         buf.append("----------------------" + "<br>");

--- a/src/org/broad/igv/sam/SAMAlignment.java
+++ b/src/org/broad/igv/sam/SAMAlignment.java
@@ -569,10 +569,12 @@ public abstract class SAMAlignment implements Alignment {
         }
 
         buf.append("----------------------" + "<br>");
-        buf.append("Alignment start = " + Globals.DECIMAL_FORMAT.format(getAlignmentStart() + 1) + " (" + (isNegativeStrand() ? "-" : "+") + ")<br>");
         buf.append("Mapping = " + (isPrimary() ? (isSupplementary() ?  "Supplementary" : "Primary") : "Secondary") +
             (isDuplicate() ? " Duplicate" : "") + (isVendorFailedRead() ? " Failed QC" : "") +
             " @ MAPQ " + Globals.DECIMAL_FORMAT.format(getMappingQuality()) + "<br>");
+        buf.append("Reference span = " + getChr() + ":" + Globals.DECIMAL_FORMAT.format(getAlignmentStart() + 1) + "-" +
+            Globals.DECIMAL_FORMAT.format(getAlignmentEnd()) + " (" + (isNegativeStrand() ? "-" : "+") + ")" +
+            " = " + Globals.DECIMAL_FORMAT.format(getAlignmentEnd()-getAlignmentStart()) + "bp<br>");
         buf.append("Cigar = " + cigarString + "<br>");
         buf.append("Clipping = ");
         if (lclipHard + lclipSoft + rclipHard + rclipSoft == 0) {

--- a/src/org/broad/igv/sam/SAMAlignment.java
+++ b/src/org/broad/igv/sam/SAMAlignment.java
@@ -570,6 +570,9 @@ public abstract class SAMAlignment implements Alignment {
 
         buf.append("----------------------" + "<br>");
         buf.append("Alignment start = " + Globals.DECIMAL_FORMAT.format(getAlignmentStart() + 1) + " (" + (isNegativeStrand() ? "-" : "+") + ")<br>");
+        buf.append("Mapping = " + (isPrimary() ? (isSupplementary() ?  "Supplementary" : "Primary") : "Secondary") +
+            (isDuplicate() ? " Duplicate" : "") + (isVendorFailedRead() ? " Failed QC" : "") +
+            " @ MAPQ " + Globals.DECIMAL_FORMAT.format(getMappingQuality()) + "<br>");
         buf.append("Cigar = " + cigarString + "<br>");
         buf.append("Clipping = ");
         if (lclipHard + lclipSoft + rclipHard + rclipSoft == 0) {
@@ -596,12 +599,6 @@ public abstract class SAMAlignment implements Alignment {
             }
         }
         buf.append("<br>");
-        buf.append("Mapped = " + (isMapped() ? "yes" : "no") + "<br>");
-        buf.append("Mapping quality = " + getMappingQuality() + "<br>");
-        buf.append("Secondary = " + (isPrimary() ? "no" : "yes") + "<br>");
-        buf.append("Supplementary = " + (isSupplementary() ? "yes" : "no") + "<br>");
-        buf.append("Duplicate = " + (isDuplicate() ? "yes" : "no") + "<br>");
-        buf.append("Failed QC = " + (isVendorFailedRead() ? "yes" : "no") + "<br>");
         buf.append("----------------------<br>");
 
         // First check insertions.  Position is zero based, block coords 1 based
@@ -657,8 +654,7 @@ public abstract class SAMAlignment implements Alignment {
 
                 byte quality = block.getQuality(offset);
                 buf.append("Location = " + getChr() + ":" + Globals.DECIMAL_FORMAT.format(1 + (long) position) + "<br>");
-                buf.append("Base = " + (char) base + "<br>");
-                buf.append("Base phred quality = " + quality + "<br>");
+                buf.append("Base = " + (char) base +  " @ QV " + Globals.DECIMAL_FORMAT.format(quality) + "<br>");
 
                 // flow signals
                 if (block.hasFlowSignals()) {

--- a/src/org/broad/igv/sam/SAMAlignment.java
+++ b/src/org/broad/igv/sam/SAMAlignment.java
@@ -528,6 +528,7 @@ public abstract class SAMAlignment implements Alignment {
 
     private String getValueStringImpl(double position, boolean truncate) {
 
+        int basePosition = (int) position;
         StringBuffer buf = new StringBuffer();
 
         buf.append("Read name = " + getReadName() + "<br>");
@@ -540,6 +541,7 @@ public abstract class SAMAlignment implements Alignment {
         if (readGroup != null) {
             buf.append("Read group = " + readGroup + "<br>");
         }
+        buf.append("Read length = " + Globals.DECIMAL_FORMAT.format(getReadLength()) + "bp<br>");
 
 
         String cigarString = getCigarString();
@@ -567,7 +569,6 @@ public abstract class SAMAlignment implements Alignment {
         }
 
         buf.append("----------------------" + "<br>");
-        int basePosition = (int) position;
         buf.append("Location = " + getChr() + ":" + Globals.DECIMAL_FORMAT.format(1 + (long) position) + "<br>");
         buf.append("Alignment start = " + Globals.DECIMAL_FORMAT.format(getAlignmentStart() + 1) + " (" + (isNegativeStrand() ? "-" : "+") + ")<br>");
         buf.append("Cigar = " + cigarString + "<br>");

--- a/src/org/broad/igv/ui/PreferencesEditor.java
+++ b/src/org/broad/igv/ui/PreferencesEditor.java
@@ -262,6 +262,9 @@ public class PreferencesEditor extends javax.swing.JDialog {
         panel9 = new JPanel();
         filterCB = new JCheckBox();
         filterURL = new JTextField();
+        panel31b = new JPanel();
+        jLabel11b = new JLabel();
+        samHiddenTagsField = new JTextField();
         panel10 = new JPanel();
         samFlagInsertionsCB = new JCheckBox();
         samFlagInsertionsThresholdField = new JTextField();
@@ -1366,7 +1369,7 @@ public class PreferencesEditor extends javax.swing.JDialog {
 
                         //======== panel13 ========
                         {
-                            panel13.setLayout(new GridLayout(6, 0));
+                            panel13.setLayout(new GridLayout(7, 0));
 
                             //======== panel31 ========
                             {
@@ -1576,6 +1579,33 @@ public class PreferencesEditor extends javax.swing.JDialog {
                                 panel9.add(filterURL);
                             }
                             panel13.add(panel9);
+
+                            //======== panel31b ========
+                            {
+                                panel31b.setLayout(new FlowLayout(FlowLayout.LEFT));
+
+                                //---- jLabel11b ----
+                                jLabel11b.setText("Hidden SAM tags:");
+                                jLabel11b.setPreferredSize(new Dimension(120, 16));
+                                panel31b.add(jLabel11b);
+
+                                //---- samHiddenTagsField ----
+                                samHiddenTagsField.setPreferredSize(new Dimension(250, 28));
+                                samHiddenTagsField.addFocusListener(new FocusAdapter() {
+                                    @Override
+                                    public void focusLost(FocusEvent e) {
+                                        samHiddenTagsFieldFocusLost(e);
+                                    }
+                                });
+                                samHiddenTagsField.addActionListener(new ActionListener() {
+                                    @Override
+                                    public void actionPerformed(ActionEvent e) {
+                                        samHiddenTagsFieldActionPerformed(e);
+                                    }
+                                });
+                                panel31b.add(samHiddenTagsField);
+                            }
+                            panel13.add(panel31b);
 
                             //======== panel10 ========
                             {
@@ -3150,7 +3180,6 @@ public class PreferencesEditor extends javax.swing.JDialog {
     }
 
     private void okButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_okButtonActionPerformed
-
         if (inputValidated) {
 
             checkForVCFColors();
@@ -3635,6 +3664,22 @@ public class PreferencesEditor extends javax.swing.JDialog {
             inputValidated = false;
             MessageUtils.showMessage("Visibility range must be a number.");
         }
+    }
+
+
+    private void samHiddenTagsFieldFocusLost(java.awt.event.FocusEvent evt) {
+        samHiddenTagsFieldActionPerformed(null);
+    }
+
+    private void samHiddenTagsFieldActionPerformed(java.awt.event.ActionEvent evt) {
+        String samHiddenTags = String.valueOf(samHiddenTagsField.getText()), samHiddenTagsClean = "";
+        for (String s: (samHiddenTags == null ? "" : samHiddenTags).split("[, ]")) {
+            if (!s.equals("")) {
+                samHiddenTagsClean += (samHiddenTagsClean.equals("") ? "" : ",") + s;
+            }
+        }
+        samHiddenTagsClean += ","; // ensure non-empty string, which results in the option being unset
+        updatedPreferenceMap.put(PreferenceManager.SAM_HIDDEN_TAGS, samHiddenTagsClean);
     }
 
 
@@ -4440,6 +4485,13 @@ public class PreferencesEditor extends javax.swing.JDialog {
         if (prefMgr.get(PreferenceManager.SAM_FILTER_URL) != null) {
             filterURL.setText(prefMgr.get(PreferenceManager.SAM_FILTER_URL));
         }
+        String samHiddenTags = prefMgr.get(PreferenceManager.SAM_HIDDEN_TAGS), samHiddenTagsClean = "";
+        for (String s: (samHiddenTags == null ? "" : samHiddenTags).split("[, ]")) {
+            if (!s.equals("")) {
+                samHiddenTagsClean += (samHiddenTagsClean.equals("") ? "" : ",") + s;
+            }
+        }
+        samHiddenTagsField.setText(samHiddenTagsClean);
 
         final boolean junctionTrackEnabled = prefMgr.getAsBoolean(PreferenceManager.SAM_SHOW_JUNCTION_TRACK);
         showJunctionTrackCB.setSelected(junctionTrackEnabled);
@@ -4700,6 +4752,9 @@ public class PreferencesEditor extends javax.swing.JDialog {
     private JPanel panel9;
     private JCheckBox filterCB;
     private JTextField filterURL;
+    private JPanel panel31b;
+    private JLabel jLabel11b;
+    private JTextField samHiddenTagsField;
     private JPanel panel10;
     private JCheckBox samFlagInsertionsCB;
     private JTextField samFlagInsertionsThresholdField;

--- a/src/org/broad/igv/ui/PreferencesEditor.jfd
+++ b/src/org/broad/igv/ui/PreferencesEditor.jfd
@@ -3698,6 +3698,75 @@
                   </void> 
                  </object> 
                 </void> 
+                <void method="add">
+                 <object class="com.jformdesigner.model.FormContainer">
+                  <string>javax.swing.JPanel</string>
+                  <object class="com.jformdesigner.model.FormLayoutManager">
+                   <class>java.awt.FlowLayout</class>
+                   <void method="setProperty">
+                    <string>alignment</string>
+                    <int>0</int>
+                   </void>
+                  </object>
+                  <void property="name">
+                   <string>panel31b</string>
+                  </void>
+                  <void method="add">
+                   <object class="com.jformdesigner.model.FormComponent">
+                    <string>javax.swing.JLabel</string>
+                    <void method="setProperty">
+                     <string>text</string>
+                     <string>Hidden SAM tags:</string>
+                    </void>
+                    <void method="setProperty">
+                     <string>preferredSize</string>
+                     <object class="java.awt.Dimension">
+                      <int>120</int>
+                      <int>16</int>
+                     </object>
+                    </void>
+                    <void property="name">
+                     <string>jLabel11b</string>
+                    </void>
+                   </object>
+                  </void>
+                  <void method="add">
+                   <object class="com.jformdesigner.model.FormComponent">
+                    <string>javax.swing.JTextField</string>
+                    <void method="setProperty">
+                     <string>text</string>
+                     <string>jTextField1b</string>
+                    </void>
+                    <void method="setProperty">
+                     <string>preferredSize</string>
+                     <object class="java.awt.Dimension">
+                      <int>250</int>
+                      <int>28</int>
+                     </object>
+                    </void>
+                    <void property="name">
+                     <string>samHiddenTags</string>
+                    </void>
+                    <void method="addEvent">
+                     <object class="com.jformdesigner.model.FormEvent">
+                      <string>java.awt.event.FocusListener</string>
+                      <string>focusLost</string>
+                      <string>samHiddenTagsFieldFocusLost</string>
+                      <boolean>true</boolean>
+                     </object>
+                    </void>
+                    <void method="addEvent">
+                     <object class="com.jformdesigner.model.FormEvent">
+                      <string>java.awt.event.ActionListener</string>
+                      <string>actionPerformed</string>
+                      <string>samHiddenTagsFieldActionPerformed</string>
+                      <boolean>true</boolean>
+                     </object>
+                    </void>
+                   </object>
+                  </void>
+                 </object>
+                </void>
                 <void method="add"> 
                  <object class="com.jformdesigner.model.FormContainer"> 
                   <string>javax.swing.JPanel</string> 


### PR DESCRIPTION
Improve the alignment details tooltip information:

1. Abbreviate long CIGAR strings in the middle instead of at the end.  This is useful with third generation long read sequence data, which can have very long CIGAR strings.  The beginning and the end of the CIGAR, which show clipping information, are particularly informative.
2. Add an explicit line to show soft/hard clipping information.
3. Add the `SAM_HIDDEN_TAGS` option to suppress certain tags from the tooltip (default to "MD,SA").  Some tags, like `MD` and `SA` are verbose and not readily understandable by a human reader.  The tags can consume a huge amount of screen space with long read data.
4. Add the read length.
5. List the full alignment reference span, not just the alignment start.
6. Consolidate mapping information into a single line.
7. Consolidate basepair information into a single line.

An example before & after is:

![alignment details modifications](https://cloud.githubusercontent.com/assets/7155109/16630239/6ab7c632-436e-11e6-9875-7461b2c2620a.png)
