### PR TITLE
Add "quick consensus" mode to show only consistent mismatches

### DIFF
--- a/src/org/broad/igv/PreferenceManager.java
+++ b/src/org/broad/igv/PreferenceManager.java
@@ -110,6 +110,7 @@ public class PreferenceManager implements PropertyManager {
     public static final String SAM_HIDDEN_TAGS = "SAM.HIDDEN_TAGS";
     public static final String SAM_MAX_VISIBLE_RANGE = "SAM.MAX_VISIBLE_RANGE";
     public static final String SAM_SHOW_DUPLICATES = "SAM.SHOW_DUPLICATES";
+    public static final String SAM_QUICK_CONSENSUS_MODE = "SAM.QUICK_CONSENSUS_MODE";
     public static final String SAM_SHOW_SOFT_CLIPPED = "SAM.SHOW_SOFT_CLIPPED";
     public static final String SAM_FLAG_UNMAPPED_PAIR = "SAM.FLAG_UNMAPPED_PAIR";
     public static final String SAM_SAMPLING_COUNT = "SAM.MAX_LEVELS"; // Sampling count
@@ -1077,6 +1078,7 @@ public class PreferenceManager implements PropertyManager {
         defaultValues.put(UNLOAD_ON_GENOME_CHANGE, "false");
 
         defaultValues.put(SAM_SHOW_DUPLICATES, "false");
+        defaultValues.put(SAM_QUICK_CONSENSUS_MODE, "false");
         defaultValues.put(SAM_SHOW_SOFT_CLIPPED, "false");
         defaultValues.put(SAM_FLAG_UNMAPPED_PAIR, "false");
         defaultValues.put(SAM_AUTO_SORT, "false");
@@ -1403,6 +1405,7 @@ public class PreferenceManager implements PropertyManager {
             PreferenceManager.SAM_FILTER_URL,
             PreferenceManager.SAM_MAX_VISIBLE_RANGE,
             PreferenceManager.SAM_SHOW_DUPLICATES,
+            PreferenceManager.SAM_QUICK_CONSENSUS_MODE,
             PreferenceManager.SAM_SHOW_SOFT_CLIPPED,
             PreferenceManager.SAM_SAMPLING_COUNT,
             PreferenceManager.SAM_SAMPLING_WINDOW,

--- a/src/org/broad/igv/PreferenceManager.java
+++ b/src/org/broad/igv/PreferenceManager.java
@@ -1406,6 +1406,7 @@ public class PreferenceManager implements PropertyManager {
             PreferenceManager.SAM_MAX_VISIBLE_RANGE,
             PreferenceManager.SAM_SHOW_DUPLICATES,
             PreferenceManager.SAM_QUICK_CONSENSUS_MODE,
+            PreferenceManager.SAM_ALLELE_THRESHOLD,
             PreferenceManager.SAM_SHOW_SOFT_CLIPPED,
             PreferenceManager.SAM_SAMPLING_COUNT,
             PreferenceManager.SAM_SAMPLING_WINDOW,

--- a/src/org/broad/igv/sam/AlignmentRenderer.java
+++ b/src/org/broad/igv/sam/AlignmentRenderer.java
@@ -913,7 +913,8 @@ public class AlignmentRenderer implements FeatureRenderer {
         int dY = (int) rect.getHeight();
         int dX = (int) Math.max(1, (1.0 / locScale));
         Graphics2D g = (Graphics2D) context.getGraphics().create();
-        if (PreferenceManager.getInstance().getAsBoolean(PreferenceManager.ENABLE_ANTIALISING)) {
+        PreferenceManager prefs = PreferenceManager.getInstance();
+        if (prefs.getAsBoolean(PreferenceManager.ENABLE_ANTIALISING)) {
             g.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
         }
         if (dX >= 8) {
@@ -971,7 +972,8 @@ public class AlignmentRenderer implements FeatureRenderer {
                 BisulfiteBaseInfo.DisplayStatus bisstatus = (bisinfo == null) ? null : bisinfo.getDisplayStatus(idx);
                 if (isSoftClipped || bisulfiteMode ||
                     // In "quick consensus" mode, only show mismatches at positions with a consistent alternative basepair.
-                    (!quickConsensus || alignmentCounts.isMismatch(loc, reference[idx], chr, renderOptions.samAlleleThreshold))) {
+                    (!quickConsensus || alignmentCounts.isMismatch(loc, reference[idx], chr, prefs.getAsFloat(PreferenceManager.SAM_ALLELE_THRESHOLD)))
+                   ) {
                     drawBase(g, color, c, pX, pY, dX, dY, bisulfiteMode, bisstatus);
                 }
             }

--- a/src/org/broad/igv/sam/AlignmentRenderer.java
+++ b/src/org/broad/igv/sam/AlignmentRenderer.java
@@ -289,7 +289,8 @@ public class AlignmentRenderer implements FeatureRenderer {
                                  Rectangle trackRect,
                                  RenderOptions renderOptions,
                                  boolean leaveMargin,
-                                 Map<String, Color> selectedReadNames) {
+                                 Map<String, Color> selectedReadNames,
+                                 AlignmentCounts alignmentCounts) {
 
         double origin = context.getOrigin();
         double locScale = context.getScale();
@@ -341,14 +342,14 @@ public class AlignmentRenderer implements FeatureRenderer {
                     g.fillRect((int) pixelStart, y, w, h);
                     lastPixelDrawn = (int) pixelStart + w;
                 } else if (alignment instanceof PairedAlignment) {
-                    drawPairedAlignment((PairedAlignment) alignment, rowRect, trackRect, context, renderOptions, leaveMargin, selectedReadNames, font);
+                    drawPairedAlignment((PairedAlignment) alignment, rowRect, trackRect, context, renderOptions, leaveMargin, selectedReadNames, font, alignmentCounts);
                 } else if (alignment instanceof LinkedAlignment) {
-                    drawExtendedAlignment((LinkedAlignment) alignment, rowRect, trackRect, context, renderOptions, leaveMargin, selectedReadNames, font);
+                    drawExtendedAlignment((LinkedAlignment) alignment, rowRect, trackRect, context, renderOptions, leaveMargin, selectedReadNames, font, alignmentCounts);
                 } else {
                     Color alignmentColor = getAlignmentColor(alignment, renderOptions);
                     Graphics2D g = context.getGraphic2DForColor(alignmentColor);
                     g.setFont(font);
-                    drawAlignment(alignment, rowRect, trackRect, g, context, alignmentColor, renderOptions, leaveMargin, selectedReadNames);
+                    drawAlignment(alignment, rowRect, trackRect, g, context, alignmentColor, renderOptions, leaveMargin, selectedReadNames, alignmentCounts);
                 }
             }
 
@@ -370,7 +371,7 @@ public class AlignmentRenderer implements FeatureRenderer {
         }
     }
 
-    private void drawExtendedAlignment(LinkedAlignment alignment, Rectangle rowRect, Rectangle trackRect, RenderContext context, RenderOptions renderOptions, boolean leaveMargin, Map<String, Color> selectedReadNames, Font font) {
+    private void drawExtendedAlignment(LinkedAlignment alignment, Rectangle rowRect, Rectangle trackRect, RenderContext context, RenderOptions renderOptions, boolean leaveMargin, Map<String, Color> selectedReadNames, Font font, AlignmentCounts alignmentCounts) {
 
         double origin = context.getOrigin();
         double locScale = context.getScale();
@@ -394,7 +395,7 @@ public class AlignmentRenderer implements FeatureRenderer {
                 gline.drawLine(startX, y + h / 2, endX, y + h / 2);
             }
             for (Alignment al : barcodedAlignments) {
-                drawAlignment(al, rowRect, trackRect, g, context, alignmentColor, renderOptions, leaveMargin, selectedReadNames);
+                drawAlignment(al, rowRect, trackRect, g, context, alignmentColor, renderOptions, leaveMargin, selectedReadNames, alignmentCounts);
             }
         }
     }
@@ -468,6 +469,7 @@ public class AlignmentRenderer implements FeatureRenderer {
      * @param leaveMargin
      * @param selectedReadNames
      * @param font
+     * @param alignmentCounts
      */
     private void drawPairedAlignment(
             PairedAlignment pair,
@@ -477,7 +479,8 @@ public class AlignmentRenderer implements FeatureRenderer {
             RenderOptions renderOptions,
             boolean leaveMargin,
             Map<String, Color> selectedReadNames,
-            Font font) {
+            Font font,
+            AlignmentCounts alignmentCounts) {
 
         //Only plot outliers
         if (renderOptions.isPairedArcView() && getOutlierStatus(pair, renderOptions) == 0) {
@@ -498,7 +501,7 @@ public class AlignmentRenderer implements FeatureRenderer {
 
         Graphics2D g = context.getGraphic2DForColor(alignmentColor1);
         g.setFont(font);
-        drawAlignment(pair.firstAlignment, rowRect, trackRect, g, context, alignmentColor1, renderOptions, leaveMargin, selectedReadNames);
+        drawAlignment(pair.firstAlignment, rowRect, trackRect, g, context, alignmentColor1, renderOptions, leaveMargin, selectedReadNames, alignmentCounts);
 
         //If the paired alignment is in memory, we draw it.
         //However, we get the coordinates from the first alignment
@@ -509,7 +512,7 @@ public class AlignmentRenderer implements FeatureRenderer {
             }
             g = context.getGraphic2DForColor(alignmentColor2);
 
-            drawAlignment(pair.secondAlignment, rowRect, trackRect, g, context, alignmentColor2, renderOptions, leaveMargin, selectedReadNames);
+            drawAlignment(pair.secondAlignment, rowRect, trackRect, g, context, alignmentColor2, renderOptions, leaveMargin, selectedReadNames, alignmentCounts);
         } else {
             return;
         }
@@ -571,6 +574,7 @@ public class AlignmentRenderer implements FeatureRenderer {
      * @param renderOptions
      * @param leaveMargin
      * @param selectedReadNames
+     * @param alignmentCounts
      */
     private void drawAlignment(
             Alignment alignment,
@@ -581,7 +585,8 @@ public class AlignmentRenderer implements FeatureRenderer {
             Color alignmentColor,
             AlignmentTrack.RenderOptions renderOptions,
             boolean leaveMargin,
-            Map<String, Color> selectedReadNames) {
+            Map<String, Color> selectedReadNames,
+            AlignmentCounts alignmentCounts) {
 
         double origin = context.getOrigin();
         double locScale = context.getScale();
@@ -707,9 +712,11 @@ public class AlignmentRenderer implements FeatureRenderer {
             if ((locScale < 5) || (AlignmentTrack.isBisulfiteColorType(renderOptions.getColorOption()) && (locScale < 100))) // Is 100 here going to kill some machines? bpb
             {
                 if (renderOptions.showMismatches || renderOptions.showAllBases) {
-                    drawBases(context, rowRect, alignment, aBlock, alignmentColor, renderOptions);
+                    boolean quickConsensus = prefs.getAsBoolean(PreferenceManager.SAM_QUICK_CONSENSUS_MODE);
+                    drawBases(context, rowRect, alignment, aBlock, alignmentCounts, quickConsensus, alignmentColor, renderOptions);
                 }
             }
+
 
             // Draw connecting lines between blocks, if in view
 //            if (lastBlockEnd > Integer.MIN_VALUE && blockPixelStart > rowRect.x) {
@@ -852,6 +859,8 @@ public class AlignmentRenderer implements FeatureRenderer {
      * @param rect
      * @param baseAlignment
      * @param block
+     * @param alignmentCounts
+     * @param quickConsensus
      * @param alignmentColor
      * @param renderOptions
      */
@@ -859,6 +868,8 @@ public class AlignmentRenderer implements FeatureRenderer {
                            Rectangle rect,
                            Alignment baseAlignment,
                            AlignmentBlock block,
+                           AlignmentCounts alignmentCounts,
+                           boolean quickConsensus,
                            Color alignmentColor,
                            RenderOptions renderOptions) {
 
@@ -958,7 +969,11 @@ public class AlignmentRenderer implements FeatureRenderer {
                 }
 
                 BisulfiteBaseInfo.DisplayStatus bisstatus = (bisinfo == null) ? null : bisinfo.getDisplayStatus(idx);
-                drawBase(g, color, c, pX, pY, dX, dY, bisulfiteMode, bisstatus);
+                if (isSoftClipped || bisulfiteMode ||
+                    // In "quick consensus" mode, only show mismatches at positions with a consistent alternative basepair.
+                    (!quickConsensus || alignmentCounts.isMismatch(loc, reference[idx], chr, renderOptions.samAlleleThreshold))) {
+                    drawBase(g, color, c, pX, pY, dX, dY, bisulfiteMode, bisstatus);
+                }
             }
         }
 

--- a/src/org/broad/igv/sam/AlignmentTrack.java
+++ b/src/org/broad/igv/sam/AlignmentTrack.java
@@ -1118,7 +1118,6 @@ public class AlignmentTrack extends AbstractTrack implements AlignmentTrackEvent
         @XmlAttribute
         GroupOption groupByOption = null;
         BisulfiteContext bisulfiteContext;
-        public float samAlleleThreshold = 0;
         //ContinuousColorScale insertSizeColorScale;
         private boolean viewPairs = false;
         private boolean pairedArcView = false;
@@ -1159,7 +1158,6 @@ public class AlignmentTrack extends AbstractTrack implements AlignmentTrackEvent
             groupByOption = null;
             flagZeroQualityAlignments = prefs.getAsBoolean(PreferenceManager.SAM_FLAG_ZERO_QUALITY);
             bisulfiteContext = DEFAULT_BISULFITE_CONTEXT;
-            samAlleleThreshold = prefs.getAsFloat(PreferenceManager.SAM_ALLELE_THRESHOLD);
 
 
             colorByTag = prefs.get(PreferenceManager.SAM_COLOR_BY_TAG);

--- a/src/org/broad/igv/sam/AlignmentTrack.java
+++ b/src/org/broad/igv/sam/AlignmentTrack.java
@@ -446,8 +446,9 @@ public class AlignmentTrack extends AbstractTrack implements AlignmentTrackEvent
 
                 if (y + h > visibleRect.getY()) {
                     Rectangle rowRectangle = new Rectangle(inputRect.x, (int) y, inputRect.width, (int) h);
+                    AlignmentCounts alignmentCounts = dataManager.getLoadedInterval(context.getReferenceFrame().getCurrentRange()).getCounts();
                     renderer.renderAlignments(row.alignments, context, rowRectangle,
-                            inputRect, renderOptions, leaveMargin, selectedReadNames);
+                            inputRect, renderOptions, leaveMargin, selectedReadNames, alignmentCounts);
                     row.y = y;
                     row.h = h;
                 }
@@ -1117,6 +1118,7 @@ public class AlignmentTrack extends AbstractTrack implements AlignmentTrackEvent
         @XmlAttribute
         GroupOption groupByOption = null;
         BisulfiteContext bisulfiteContext;
+        public float samAlleleThreshold = 0;
         //ContinuousColorScale insertSizeColorScale;
         private boolean viewPairs = false;
         private boolean pairedArcView = false;
@@ -1157,6 +1159,7 @@ public class AlignmentTrack extends AbstractTrack implements AlignmentTrackEvent
             groupByOption = null;
             flagZeroQualityAlignments = prefs.getAsBoolean(PreferenceManager.SAM_FLAG_ZERO_QUALITY);
             bisulfiteContext = DEFAULT_BISULFITE_CONTEXT;
+            samAlleleThreshold = prefs.getAsFloat(PreferenceManager.SAM_ALLELE_THRESHOLD);
 
 
             colorByTag = prefs.get(PreferenceManager.SAM_COLOR_BY_TAG);

--- a/src/org/broad/igv/sam/BedRenderer.java
+++ b/src/org/broad/igv/sam/BedRenderer.java
@@ -29,6 +29,7 @@
  */
 package org.broad.igv.sam;
 
+import org.broad.igv.sam.AlignmentCounts;
 import org.broad.igv.track.RenderContext;
 
 import java.awt.*;
@@ -42,7 +43,7 @@ public class BedRenderer implements FeatureRenderer {
 
     public void renderAlignments(List<Alignment> alignments, RenderContext context,
                                  Rectangle rowRect, Rectangle inputRect, AlignmentTrack.RenderOptions renderOptions, boolean leaveMargin,
-                                 Map<String, Color> selectedReadNames) {
+                                 Map<String, Color> selectedReadNames, AlignmentCounts alignmentCounts) {
 
         double origin = context.getOrigin();
         double locScale = context.getScale();

--- a/src/org/broad/igv/sam/FeatureRenderer.java
+++ b/src/org/broad/igv/sam/FeatureRenderer.java
@@ -29,6 +29,7 @@
  */
 package org.broad.igv.sam;
 
+import org.broad.igv.sam.AlignmentCounts;
 import org.broad.igv.track.RenderContext;
 
 import java.awt.*;
@@ -48,8 +49,9 @@ public interface FeatureRenderer {
      * @param renderOptions
      * @param leaveMargin
      * @param selectedReadNames
+     * @param alignmentCounts
      */
     public void renderAlignments(List<Alignment> alignments, RenderContext context,
                                  Rectangle rowRect, Rectangle trackRect, AlignmentTrack.RenderOptions renderOptions,
-                                 boolean leaveMargin, Map<String, Color> selectedReadNames);
+                                 boolean leaveMargin, Map<String, Color> selectedReadNames, AlignmentCounts alignmentCounts);
 }

--- a/src/org/broad/igv/ui/PreferencesEditor.java
+++ b/src/org/broad/igv/ui/PreferencesEditor.java
@@ -274,6 +274,7 @@ public class PreferencesEditor extends javax.swing.JDialog {
         samFlagUnmappedPairCB = new JCheckBox();
         filterFailedReadsCB = new JCheckBox();
         showSoftClippedCB = new JCheckBox();
+        quickConsensusModeCB = new JCheckBox();
         filterSecondaryAlignmentsCB = new JCheckBox();
         showCenterLineCB = new JCheckBox();
         filterSupplementaryAlignmentsCB = new JCheckBox();
@@ -1700,15 +1701,15 @@ public class PreferencesEditor extends javax.swing.JDialog {
                             });
                             panel8.add(filterSecondaryAlignmentsCB);
 
-                            //---- showCenterLineCB ----
-                            showCenterLineCB.setText("Show center line");
-                            showCenterLineCB.addActionListener(new ActionListener() {
+                            //---- quickConsensusModeCB ----
+                            quickConsensusModeCB.setText("Quick consensus mode");
+                            quickConsensusModeCB.addActionListener(new ActionListener() {
                                 @Override
                                 public void actionPerformed(ActionEvent e) {
-                                    showCenterLineCBActionPerformed(e);
+                                    quickConsensusModeCBActionPerformed(e);
                                 }
                             });
-                            panel8.add(showCenterLineCB);
+                            panel8.add(quickConsensusModeCB);
 
                             //---- filterSupplementaryAlignmentsCB ----
                             filterSupplementaryAlignmentsCB.setText("Filter supplementary alignments");
@@ -1719,6 +1720,16 @@ public class PreferencesEditor extends javax.swing.JDialog {
                                 }
                             });
                             panel8.add(filterSupplementaryAlignmentsCB);
+
+                            //---- showCenterLineCB ----
+                            showCenterLineCB.setText("Show center line");
+                            showCenterLineCB.addActionListener(new ActionListener() {
+                                @Override
+                                public void actionPerformed(ActionEvent e) {
+                                    showCenterLineCBActionPerformed(e);
+                                }
+                            });
+                            panel8.add(showCenterLineCB);
                         }
                         jPanel12.add(panel8);
                     }
@@ -3599,6 +3610,12 @@ public class PreferencesEditor extends javax.swing.JDialog {
                 String.valueOf(showSoftClippedCB.isSelected()));
     }
 
+    private void quickConsensusModeCBActionPerformed(ActionEvent e) {
+        updatedPreferenceMap.put(
+                PreferenceManager.SAM_QUICK_CONSENSUS_MODE,
+                String.valueOf(quickConsensusModeCB.isSelected()));
+    }
+
 
     private void isizeComputeCBActionPerformed(ActionEvent e) {
         final boolean selected = isizeComputeCB.isSelected();
@@ -4472,6 +4489,7 @@ public class PreferencesEditor extends javax.swing.JDialog {
         filterSecondaryAlignmentsCB.setSelected(prefMgr.getAsBoolean(PreferenceManager.SAM_FILTER_SECONDARY_ALIGNMENTS));
         filterSupplementaryAlignmentsCB.setSelected(prefMgr.getAsBoolean(PreferenceManager.SAM_FILTER_SUPPLEMENTARY_ALIGNMENTS));
         showSoftClippedCB.setSelected(prefMgr.getAsBoolean(PreferenceManager.SAM_SHOW_SOFT_CLIPPED));
+        quickConsensusModeCB.setSelected(prefMgr.getAsBoolean(PreferenceManager.SAM_QUICK_CONSENSUS_MODE));
         samFlagUnmappedPairCB.setSelected(prefMgr.getAsBoolean(PreferenceManager.SAM_FLAG_UNMAPPED_PAIR));
         showCenterLineCB.setSelected(prefMgr.getAsBoolean(PreferenceManager.SAM_SHOW_CENTER_LINE));
         samShadeMismatchedBaseCB.setSelected(ShadeBasesOption.QUALITY ==
@@ -4764,6 +4782,7 @@ public class PreferencesEditor extends javax.swing.JDialog {
     private JCheckBox samFlagUnmappedPairCB;
     private JCheckBox filterFailedReadsCB;
     private JCheckBox showSoftClippedCB;
+    private JCheckBox quickConsensusModeCB;
     private JCheckBox filterSecondaryAlignmentsCB;
     private JCheckBox showCenterLineCB;
     private JCheckBox filterSupplementaryAlignmentsCB;

--- a/src/org/broad/igv/ui/PreferencesEditor.jfd
+++ b/src/org/broad/igv/ui/PreferencesEditor.jfd
@@ -3977,6 +3977,26 @@
                   <string>javax.swing.JCheckBox</string> 
                   <void method="setProperty"> 
                    <string>text</string> 
+                   <string>Quick consensus mode</string> 
+                  </void> 
+                  <void property="name"> 
+                   <string>quickConsensusModeCB</string> 
+                  </void> 
+                  <void method="addEvent"> 
+                   <object class="com.jformdesigner.model.FormEvent"> 
+                    <string>java.awt.event.ActionListener</string> 
+                    <string>actionPerformed</string> 
+                    <string>quickConsensusModeCBActionPerformed</string> 
+                    <boolean>false</boolean> 
+                   </object> 
+                  </void> 
+                 </object> 
+                </void> 
+                <void method="add"> 
+                 <object class="com.jformdesigner.model.FormComponent"> 
+                  <string>javax.swing.JCheckBox</string> 
+                  <void method="setProperty"> 
+                   <string>text</string> 
                    <string>Show center line</string> 
                   </void> 
                   <void property="name"> 


### PR DESCRIPTION
Add a "quick consensus" mode feature controlled by a setting that limits
the display of basepair mismatches to positions with a consistent
alternative base.  This is especially useful with third generation
sequencers that have a high single-read mismatch error rate.  The
consensus mode uses the same logic as the coverage track to determine
which mismatches to show.

Addresses point 1 in #277 