### PR TITLE
Add a "group by base" feature to phase reads

### DIFF
--- a/src/org/broad/igv/sam/AlignmentPacker.java
+++ b/src/org/broad/igv/sam/AlignmentPacker.java
@@ -353,6 +353,7 @@ public class AlignmentPacker {
 
         AlignmentTrack.GroupOption groupBy = renderOptions.groupByOption;
         String tag = renderOptions.getGroupByTag();
+        Range pos = renderOptions.getGroupByBaseAtPos();
 
         switch (groupBy) {
             case STRAND:
@@ -387,6 +388,27 @@ public class AlignmentPacker {
                 }
             case SUPPLEMENTARY:
                 return String.valueOf(!al.isSupplementary());
+            case BASE_AT_POS:
+                // Use a string prefix to enforce grouping rules:
+                //    1: alignments with a base at the position
+                //    2: alignments with a gap at the position
+                //    3: alignment that do not overlap the position (or are on a different chromosome)
+
+                if (al.getChr().equals(pos.getChr()) &&
+                    al.getAlignmentStart() <= pos.getStart() &&
+                    al.getAlignmentEnd() > pos.getStart()) {
+
+                    byte[] baseAtPos = new byte[] {al.getBase(pos.getStart())};
+                    if (baseAtPos[0] == 0) { // gap at position
+                        return "2:";
+                    }
+                    else { // base at position
+                        return "1:" + new String(baseAtPos);
+                    }
+                }
+                else { // does not overlap position
+                    return "3:";
+                }
         }
         return null;
     }

--- a/src/org/broad/igv/sam/AlignmentPacker.java
+++ b/src/org/broad/igv/sam/AlignmentPacker.java
@@ -341,7 +341,7 @@ public class AlignmentPacker {
                             if (NULL_GROUP_VALUE.equals(o2)) {
                                 return -1;
                             } else {
-                                return o2.compareToIgnoreCase(o1);
+                                return o1.compareToIgnoreCase(o2);
                             }
                         }
                     }

--- a/src/org/broad/igv/ui/IGV.java
+++ b/src/org/broad/igv/ui/IGV.java
@@ -48,6 +48,7 @@ import org.broad.igv.batch.CommandListener;
 import org.broad.igv.dev.api.IGVPlugin;
 import org.broad.igv.exceptions.DataLoadException;
 import org.broad.igv.feature.Locus;
+import org.broad.igv.feature.Range;
 import org.broad.igv.feature.MaximumContigGenomeException;
 import org.broad.igv.feature.RegionOfInterest;
 import org.broad.igv.feature.genome.*;
@@ -1975,6 +1976,14 @@ public class IGV implements IGVEventObserver {
         for (Track t : getAllTracks()) {
             if (t instanceof AlignmentTrack) {
                 ((AlignmentTrack) t).groupAlignments(option, tag);
+            }
+        }
+    }
+
+    public void groupAlignmentTracksByBaseAtPos(AlignmentTrack.GroupOption option, Range pos) {
+        for (Track t: getAllTracks()) {
+            if (t instanceof AlignmentTrack) {
+                ((AlignmentTrack) t).groupAlignmentsByBaseAtPos(option, pos);
             }
         }
     }


### PR DESCRIPTION
The right click menu now includes an option to group alignments by "base at (current position)".  Reads with a gap at the selected position or that do not overlap the position are placed in groups at the bottom.  By selecting a position with a heterozygous SNV, the reads are effectively phased into haplotypes.

This addresses suggestion 6 in #277.