### PR TITLE
Trigger refresh when large insertion settings change

### DIFF
--- a/src/org/broad/igv/PreferenceManager.java
+++ b/src/org/broad/igv/PreferenceManager.java
@@ -1415,7 +1415,9 @@ public class PreferenceManager implements PropertyManager {
             PreferenceManager.SAM_FILTER_SECONDARY_ALIGNMENTS,
             PreferenceManager.SAM_FILTER_SUPPLEMENTARY_ALIGNMENTS,
             PreferenceManager.SAM_JUNCTION_MIN_FLANKING_WIDTH,
-            PreferenceManager.SAM_JUNCTION_MIN_COVERAGE
+            PreferenceManager.SAM_JUNCTION_MIN_COVERAGE,
+            PreferenceManager.SAM_FLAG_LARGE_INSERTIONS,
+            PreferenceManager.SAM_LARGE_INSERTIONS_THRESHOLD
     );
 
 

--- a/src/org/broad/igv/sam/AlignmentTrack.java
+++ b/src/org/broad/igv/sam/AlignmentTrack.java
@@ -882,6 +882,7 @@ public class AlignmentTrack extends AbstractTrack implements AlignmentTrackEvent
                 break;
             case RELOAD:
                 clearCaches();
+                setRenderOptions(new RenderOptions());
                 break;
         }
 


### PR DESCRIPTION
Trigger a new render of the alignment tracks when the configuration
settings that define a "large insertion" are changed.

Also, update the options used to render an alignment track when the track
is sent an explicit "reload" notification.  This is important, as
preferences that affect rendering could have changed since the reload
options were initialized.

Without these changes, IGV had to be closed and re-opened for settings
that affect large insertion labels to come into effect.