### PR TITLE
Tweaks to the "hide small indels" options

### DIFF
--- a/src/org/broad/igv/sam/AlignmentRenderer.java
+++ b/src/org/broad/igv/sam/AlignmentRenderer.java
@@ -667,7 +667,7 @@ public class AlignmentRenderer implements FeatureRenderer {
         boolean hideSmallIndelsBP = PreferenceManager.getInstance().getAsBoolean(PreferenceManager.SAM_HIDE_SMALL_INDEL_BP);
         int indelThresholdBP = PreferenceManager.getInstance().getAsInt(PreferenceManager.SAM_SMALL_INDEL_BP_THRESHOLD);
         boolean hideSmallIndelsPixel = PreferenceManager.getInstance().getAsBoolean(PreferenceManager.SAM_HIDE_SMALL_INDEL_PIXEL);
-        int indexThresholdPixel = PreferenceManager.getInstance().getAsInt(PreferenceManager.SAM_SMALL_INDELS_PIXEL_THRESHOLD);
+        int indelThresholdPixel = PreferenceManager.getInstance().getAsInt(PreferenceManager.SAM_SMALL_INDELS_PIXEL_THRESHOLD);
 
 
         // Scale and position of the alignment rendering.
@@ -746,7 +746,7 @@ public class AlignmentRenderer implements FeatureRenderer {
 
                 // Draw the gap if it is sufficiently large at the current zoom.
                 boolean drawGap = ((!hideSmallIndelsBP || gapChromWidth > indelThresholdBP) &&
-                        (!hideSmallIndelsPixel || gapPxWidth >= indexThresholdPixel));
+                        (!hideSmallIndelsPixel || gapPxWidth >= indelThresholdPixel));
                 if (!drawGap) {
                     continue;
                 }
@@ -1130,7 +1130,7 @@ public class AlignmentRenderer implements FeatureRenderer {
             boolean hideSmallIndelsBP = PreferenceManager.getInstance().getAsBoolean(PreferenceManager.SAM_HIDE_SMALL_INDEL_BP);
             int indelThresholdBP = PreferenceManager.getInstance().getAsInt(PreferenceManager.SAM_SMALL_INDEL_BP_THRESHOLD);
             boolean hideSmallIndelsPixel = PreferenceManager.getInstance().getAsBoolean(PreferenceManager.SAM_HIDE_SMALL_INDEL_PIXEL);
-            int indexThresholdPixel = PreferenceManager.getInstance().getAsInt(PreferenceManager.SAM_SMALL_INDELS_PIXEL_THRESHOLD);
+            int indelThresholdPixel = PreferenceManager.getInstance().getAsInt(PreferenceManager.SAM_SMALL_INDELS_PIXEL_THRESHOLD);
 
 
             for (AlignmentBlock aBlock : insertions) {
@@ -1148,7 +1148,7 @@ public class AlignmentRenderer implements FeatureRenderer {
                 }
 
                 if ((!hideSmallIndelsBP || aBlock.getBases().length > indelThresholdBP) &&
-                        (!hideSmallIndelsPixel || pxWidth >= indexThresholdPixel)) {
+                        (!hideSmallIndelsPixel || pxWidth >= indelThresholdPixel)) {
                     if (renderOptions.isFlagLargeIndels() && aBlock.getBases().length > renderOptions.getLargeInsertionsThreshold()) {
                         drawLargeIndelLabel(gLargeInsertion, true, Globals.DECIMAL_FORMAT.format(aBlock.getBases().length), x - 1, y, h, pxWidth);
                     } else {

--- a/src/org/broad/igv/sam/AlignmentRenderer.java
+++ b/src/org/broad/igv/sam/AlignmentRenderer.java
@@ -1136,7 +1136,8 @@ public class AlignmentRenderer implements FeatureRenderer {
             for (AlignmentBlock aBlock : insertions) {
 
                 int x = (int) ((aBlock.getStart() - origin) / locScale);
-                int pxWidth = (int) (aBlock.getBases().length / locScale);
+                int bpWidth = aBlock.getBases().length;
+                int pxWidth = (int) (bpWidth / locScale);
                 int h = (int) Math.max(1, rect.getHeight() - 2);
                 int y = (int) (rect.getY() + (rect.getHeight() - h) / 2) - 1;
 
@@ -1147,10 +1148,10 @@ public class AlignmentRenderer implements FeatureRenderer {
                     continue;
                 }
 
-                if ((!hideSmallIndelsBP || aBlock.getBases().length > indelThresholdBP) &&
+                if ((!hideSmallIndelsBP || bpWidth > indelThresholdBP) &&
                         (!hideSmallIndelsPixel || pxWidth >= indelThresholdPixel)) {
-                    if (renderOptions.isFlagLargeIndels() && aBlock.getBases().length > renderOptions.getLargeInsertionsThreshold()) {
-                        drawLargeIndelLabel(gLargeInsertion, true, Globals.DECIMAL_FORMAT.format(aBlock.getBases().length), x - 1, y, h, pxWidth);
+                    if (renderOptions.isFlagLargeIndels() && bpWidth > renderOptions.getLargeInsertionsThreshold()) {
+                        drawLargeIndelLabel(gLargeInsertion, true, Globals.DECIMAL_FORMAT.format(bpWidth), x - 1, y, h, pxWidth);
                     } else {
                         gSmallInsertion.fillRect(x - 2, y, 4, 2);
                         gSmallInsertion.fillRect(x - 1, y, 2, h);

--- a/src/org/broad/igv/sam/AlignmentRenderer.java
+++ b/src/org/broad/igv/sam/AlignmentRenderer.java
@@ -667,7 +667,7 @@ public class AlignmentRenderer implements FeatureRenderer {
         boolean hideSmallIndelsBP = PreferenceManager.getInstance().getAsBoolean(PreferenceManager.SAM_HIDE_SMALL_INDEL_BP);
         int indelThresholdBP = PreferenceManager.getInstance().getAsInt(PreferenceManager.SAM_SMALL_INDEL_BP_THRESHOLD);
         boolean hideSmallIndelsPixel = PreferenceManager.getInstance().getAsBoolean(PreferenceManager.SAM_HIDE_SMALL_INDEL_PIXEL);
-        int indelThresholdPixel = PreferenceManager.getInstance().getAsInt(PreferenceManager.SAM_SMALL_INDELS_PIXEL_THRESHOLD);
+        double indelThresholdPixel = (double) PreferenceManager.getInstance().getAsInt(PreferenceManager.SAM_SMALL_INDELS_PIXEL_THRESHOLD);
 
 
         // Scale and position of the alignment rendering.
@@ -735,8 +735,8 @@ public class AlignmentRenderer implements FeatureRenderer {
                 int gapChromStart = (int) gap.getStart(),
                         gapChromWidth = (int) gap.getnBases(),
                         gapChromEnd = gapChromStart + gapChromWidth,
-                        gapPxWidth = (int) Math.max(1, gapChromWidth / locScale),
                         gapPxEnd = (int) ((Math.min(contextChromEnd, gapChromEnd) - contextChromStart) / locScale);
+                double gapPxWidthExact = ((double) gapChromWidth) / locScale;
 
                 if (gapChromEnd <= contextChromStart) { // gap ends before the visible context
                     continue; // move to next gap
@@ -746,7 +746,7 @@ public class AlignmentRenderer implements FeatureRenderer {
 
                 // Draw the gap if it is sufficiently large at the current zoom.
                 boolean drawGap = ((!hideSmallIndelsBP || gapChromWidth > indelThresholdBP) &&
-                        (!hideSmallIndelsPixel || gapPxWidth >= indelThresholdPixel));
+                        (!hideSmallIndelsPixel || gapPxWidthExact >= indelThresholdPixel));
                 if (!drawGap) {
                     continue;
                 }
@@ -1130,14 +1130,12 @@ public class AlignmentRenderer implements FeatureRenderer {
             boolean hideSmallIndelsBP = PreferenceManager.getInstance().getAsBoolean(PreferenceManager.SAM_HIDE_SMALL_INDEL_BP);
             int indelThresholdBP = PreferenceManager.getInstance().getAsInt(PreferenceManager.SAM_SMALL_INDEL_BP_THRESHOLD);
             boolean hideSmallIndelsPixel = PreferenceManager.getInstance().getAsBoolean(PreferenceManager.SAM_HIDE_SMALL_INDEL_PIXEL);
-            int indelThresholdPixel = PreferenceManager.getInstance().getAsInt(PreferenceManager.SAM_SMALL_INDELS_PIXEL_THRESHOLD);
-
+            double indelThresholdPixel = (double) PreferenceManager.getInstance().getAsInt(PreferenceManager.SAM_SMALL_INDELS_PIXEL_THRESHOLD);
 
             for (AlignmentBlock aBlock : insertions) {
-
                 int x = (int) ((aBlock.getStart() - origin) / locScale);
                 int bpWidth = aBlock.getBases().length;
-                int pxWidth = (int) (bpWidth / locScale);
+                double pxWidthExact = ((double) bpWidth) / locScale;
                 int h = (int) Math.max(1, rect.getHeight() - 2);
                 int y = (int) (rect.getY() + (rect.getHeight() - h) / 2) - 1;
 
@@ -1149,9 +1147,9 @@ public class AlignmentRenderer implements FeatureRenderer {
                 }
 
                 if ((!hideSmallIndelsBP || bpWidth > indelThresholdBP) &&
-                        (!hideSmallIndelsPixel || pxWidth >= indelThresholdPixel)) {
+                        (!hideSmallIndelsPixel || pxWidthExact >= indelThresholdPixel)) {
                     if (renderOptions.isFlagLargeIndels() && bpWidth > renderOptions.getLargeInsertionsThreshold()) {
-                        drawLargeIndelLabel(gLargeInsertion, true, Globals.DECIMAL_FORMAT.format(bpWidth), x - 1, y, h, pxWidth);
+                        drawLargeIndelLabel(gLargeInsertion, true, Globals.DECIMAL_FORMAT.format(bpWidth), x - 1, y, h, (int) pxWidthExact);
                     } else {
                         gSmallInsertion.fillRect(x - 2, y, 4, 2);
                         gSmallInsertion.fillRect(x - 1, y, 2, h);

--- a/src/org/broad/igv/sam/AlignmentRenderer.java
+++ b/src/org/broad/igv/sam/AlignmentRenderer.java
@@ -745,7 +745,7 @@ public class AlignmentRenderer implements FeatureRenderer {
                 }
 
                 // Draw the gap if it is sufficiently large at the current zoom.
-                boolean drawGap = ((!hideSmallIndelsBP || gapChromWidth > indelThresholdBP) &&
+                boolean drawGap = ((!hideSmallIndelsBP || gapChromWidth >= indelThresholdBP) &&
                         (!hideSmallIndelsPixel || gapPxWidthExact >= indelThresholdPixel));
                 if (!drawGap) {
                     continue;
@@ -1146,7 +1146,7 @@ public class AlignmentRenderer implements FeatureRenderer {
                     continue;
                 }
 
-                if ((!hideSmallIndelsBP || bpWidth > indelThresholdBP) &&
+                if ((!hideSmallIndelsBP || bpWidth >= indelThresholdBP) &&
                         (!hideSmallIndelsPixel || pxWidthExact >= indelThresholdPixel)) {
                     if (renderOptions.isFlagLargeIndels() && bpWidth > renderOptions.getLargeInsertionsThreshold()) {
                         drawLargeIndelLabel(gLargeInsertion, true, Globals.DECIMAL_FORMAT.format(bpWidth), x - 1, y, h, (int) pxWidthExact);

--- a/src/org/broad/igv/ui/PreferencesEditor.java
+++ b/src/org/broad/igv/ui/PreferencesEditor.java
@@ -1350,7 +1350,7 @@ public class PreferencesEditor extends javax.swing.JDialog {
                                 panel9.setLayout(new FlowLayout(FlowLayout.LEFT, 0, 5));
 
                                 //---- hideIndelsBasesCB ----
-                                hideIndelsBasesCB.setText("Hide indels smaller than: ");
+                                hideIndelsBasesCB.setText("Hide indels < ");
                                 hideIndelsBasesCB.addActionListener(e -> hideIndelsBasesCBActionPerformed(e));
                                 panel9.add(hideIndelsBasesCB);
 
@@ -1378,7 +1378,7 @@ public class PreferencesEditor extends javax.swing.JDialog {
                             panel36.setLayout(new FlowLayout(FlowLayout.LEFT, 0, 0));
 
                             //---- hideIndelsPixelsCB ----
-                            hideIndelsPixelsCB.setText("Hide indels smaller than: ");
+                            hideIndelsPixelsCB.setText("Hide indels < ");
                             hideIndelsPixelsCB.addActionListener(e -> hideIndelsPixelsCBActionPerformed(e));
                             panel36.add(hideIndelsPixelsCB);
 

--- a/src/org/broad/igv/ui/PreferencesEditor.jfd
+++ b/src/org/broad/igv/ui/PreferencesEditor.jfd
@@ -3736,7 +3736,7 @@
                     <string>javax.swing.JCheckBox</string>
                     <void method="setProperty">
                      <string>text</string>
-                     <string>Hide indels smaller than: </string>
+                     <string>Hide indels < </string>
                     </void>
                     <void property="name">
                      <string>hideIndelsBasesCB</string>
@@ -3824,7 +3824,7 @@
                   <string>javax.swing.JCheckBox</string>
                   <void method="setProperty">
                    <string>text</string>
-                   <string>Hide indels smaller than: </string>
+                   <string>Hide indels < </string>
                   </void>
                   <void property="name">
                    <string>hideIndelsPixelsCB</string>


### PR DESCRIPTION
Make a few minor changes to the "hide small indels" options (in decreasing order of importance):

* Be consistent with less than vs less than or equal for the pixel and basepair options.  The option is labeled as "hide indels small than X" which means "less than".
* Update the wording of the options to be explicit with the less than symbol.
* Treat pixel width as a double instead of an integer for comparison to the pixel width threshold to avoid any confusion about whether the pixel width is rounded up/down or clamped to a minimum of 1px.
* Code readability improvements.