### PR TITLE
Further RNA structure file format support

### DIFF
--- a/src/org/broad/igv/feature/BasePairFileUtils.java
+++ b/src/org/broad/igv/feature/BasePairFileUtils.java
@@ -1,0 +1,359 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2007-2015 Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.broad.igv.feature;
+
+
+import org.broad.igv.feature.basepair.BasePairFeature;
+import org.broad.igv.Globals;
+import org.broad.igv.util.ParsingUtils;
+import org.broad.igv.util.ResourceLocator;
+
+
+import java.awt.Color;
+import java.awt.Point;
+import java.io.*;
+import java.util.*;
+
+/**
+ * @author sbusan
+ */
+public class BasePairFileUtils {
+
+    // TODO: support bpseq, stockholm, other formats?
+    // TODO: warning dialog on file overwrite
+
+    static ArrayList<Point> loadDotBracket(String inFile) throws
+            FileNotFoundException, IOException {
+        ArrayList<Point> pairs = new ArrayList<>();
+
+        BufferedReader br = null;
+
+        try {
+            br = new BufferedReader(new FileReader(inFile));
+            String struct = "";
+
+            String nextLine;
+            while ((nextLine = br.readLine()) != null) {
+
+                // skip leading header lines if present
+                if (nextLine.startsWith(">") || nextLine.startsWith("#")) {
+                    continue;
+                }
+
+                String s = nextLine.trim();
+                if (s.chars().allMatch(Character::isLetter)) {
+                    // sequence line
+                    continue;
+                } else {
+                    // assumed structure line
+                    struct += s;
+                }
+            }
+
+            String leftBrackets = "([{<";
+            String rightBrackets = ")]}>";
+
+            ArrayList<LinkedList<Integer>> openIndices = new ArrayList<>();
+            for (int i = 0; i < leftBrackets.length(); ++i) {
+                openIndices.add(new LinkedList<>());
+            }
+
+            for (int i = 0; i < struct.length(); ++i) {
+                int n = leftBrackets.indexOf(struct.charAt(i));
+                int k = rightBrackets.indexOf(struct.charAt(i));
+                if (n >= 0) {
+                    openIndices.get(n).add(i);
+                } else if (k >= 0) {
+                    int left = i;
+                    int right = openIndices.get(k).pollLast();
+                    pairs.add(new Point(left, right));
+                }
+            }
+
+        } finally {
+            if (br != null) br.close();
+        }
+
+        /*BufferedReader br = null;
+        PrintWriter pw = null;
+
+        try {
+            br = new BufferedReader(new FileReader(iFile));
+            pw = new PrintWriter(new BufferedWriter(new FileWriter(outputFile)));
+
+            String nextLine;
+            while ((nextLine = br.readLine()) != null) {
+
+                if (nextLine.startsWith("#") || nextLine.startsWith("track") || nextLine.startsWith("browser")) {
+                    pw.println(nextLine);
+                    continue;
+                }
+
+                String[] tokens = Globals.whitespacePattern.split(nextLine);
+
+                String chr = tokens[2];
+                int start = Integer.parseInt(tokens[4]);
+                String end = tokens[5];
+                String name = tokens[12];
+                String score = "1000";
+                String strand = tokens[3];
+                String thickStart = tokens[6];
+                String thickEnd = tokens[7];
+                String itemRGB = ".";
+                int blockCount = Integer.parseInt(tokens[8]);
+
+                String exonStarts = tokens[9];
+                String[] stok = Globals.commaPattern.split(exonStarts);
+                String[] etok = Globals.commaPattern.split(tokens[10]);
+
+                String blockStarts = "";
+                String blockSizes = "";
+
+                for (int i = 0; i < blockCount; i++) {
+                    final int bs = Integer.parseInt(stok[i]);
+                    blockStarts += String.valueOf(bs - start);
+                    blockSizes += String.valueOf(Integer.parseInt(etok[i]) - bs);
+                    if (i != blockCount - 1) {
+                        blockStarts += ",";
+                        blockSizes += ",";
+                    }
+                }
+
+                pw.println(chr + "\t" + start + "\t" + end + "\t" + name + "\t" + score + "\t" + strand + "\t" +
+                        thickStart + "\t" + thickEnd + "\t" + itemRGB + "\t" + blockCount + "\t" + blockSizes + "\t" + blockStarts);
+            }
+
+        } finally {
+            if (br != null) br.close();
+            if (pw != null) pw.close();
+        }*/
+
+
+        return pairs;
+    }
+
+    static ArrayList<Point> loadConnectTable(String inFile) throws
+            FileNotFoundException, IOException {
+        ArrayList<Point> pairs = new ArrayList<>();
+
+        return pairs;
+    }
+
+    static ArrayList<ArrayList<Point>> loadPairingProb(String inFile) throws
+            FileNotFoundException, IOException {
+        ArrayList<Point> pairs = new ArrayList<>();
+        ArrayList<ArrayList<Point>> binnedPairs = new ArrayList<>();
+
+        return binnedPairs;
+    }
+
+
+    static void writeBasePairFile(String bpFile,
+                                  ArrayList<Color> colors,
+                                  ArrayList<LinkedList<BasePairFeature>> groupedArcs) throws IOException {
+        PrintWriter pw = null;
+
+        try {
+            pw = new PrintWriter(new BufferedWriter(new FileWriter(bpFile)));
+            // first write enumerated colors header
+            for (Color color : colors) {
+                pw.println("color:\t" + color.getRed() + "\t" + color.getGreen() + "\t" + color.getBlue());
+            }
+
+            // then write arc coordinates
+            int colorIndex = 0;
+            for (LinkedList<BasePairFeature> colorGroup : groupedArcs) {
+                for (BasePairFeature arc : colorGroup) {
+                    pw.println(arc.toStringNoColor() + "\t" + colorIndex);
+                }
+                colorIndex++;
+            }
+        } finally {
+            if (pw != null) pw.close();
+        }
+    }
+
+    /**
+     * Merge adjacent basepairs into helices.
+     *
+     * @param pairs
+     * @param chromosome
+     * @return
+     */
+    static LinkedList<BasePairFeature> pairsToHelices(ArrayList<Point> pairs,
+                                                      String chromosome) {
+        ArrayList<Point> bps = new ArrayList<>(pairs);
+        LinkedList<LinkedList<Point>> helixPairGroups = new LinkedList<>();
+
+        // FIXME: there should be a much faster and more elegant way to do this
+        while (bps.size() > 0) {
+            Point bp = bps.get(0);
+            LinkedList<Point> helixPairs = new LinkedList<>();
+            boolean[] removePairs = new boolean[bps.size()];
+            helixPairs.add(bp);
+            removePairs[0] = true;
+            boolean endOfList = false;
+            /* - ignore other pairs starting with this left nuc
+             * - if any base pairs exist starting one nuc downstream of current left nuc
+             *   and ending one nuc upstream of current right nuc, store index to remove
+             *   and append to growing helix
+             */
+            int i = 1;
+            int skippedCount = 0;
+            if (i < bps.size()) {
+                while (bps.get(i).x == bp.x) {
+                    i++;
+                    skippedCount++;
+                    if (i >= bps.size()) {
+                        endOfList = true;
+                        break;
+                    }
+                }
+            } else {
+                endOfList = true;
+            }
+            while (i < bps.size()) {
+                if (bps.get(i).x - bp.x > 1) {
+                    // reached the end of the helix
+                    helixPairGroups.add(helixPairs);
+                    // remove helix pairs
+                    ArrayList<Point> tmpBps = new ArrayList<>();
+                    for (int k = 0; k < bps.size(); k++) {
+                        if (!removePairs[k]) tmpBps.add(bps.get(k));
+                    }
+                    bps = tmpBps;
+                    break;
+                } else if (bps.get(i).y - bp.y == -1) {
+                    bp = bps.get(i);
+                    helixPairs.add(bp);
+                    removePairs[i] = true;
+                }
+                i++;
+                if (i >= bps.size()) {
+                    endOfList = true;
+                    break;
+                }
+            }
+            if (endOfList) {
+                helixPairGroups.add(helixPairs);
+                // remove helix pairs
+                ArrayList<Point> tmpBps = new ArrayList<>();
+                for (int k = 0; k < bps.size(); k++) {
+                    if (!removePairs[k]) tmpBps.add(bps.get(k));
+                }
+                bps = tmpBps;
+            }
+        }
+
+        // convert lists of adjacent pairs to BasePairFeatures
+        LinkedList<BasePairFeature> helices = new LinkedList<>();
+        for (LinkedList<Point> helixPairs : helixPairGroups) {
+            int startLeft = Integer.MAX_VALUE;
+            int startRight = 0;
+            int endLeft = Integer.MAX_VALUE;
+            int endRight = 0;
+
+            for (Point pair : helixPairs) {
+                if (pair.x < startLeft) startLeft = pair.x;
+                if (pair.x > startRight) startRight = pair.x;
+                if (pair.y < endLeft) endLeft = pair.y;
+                if (pair.y > endRight) endRight = pair.y;
+            }
+            helices.add(new BasePairFeature(chromosome,
+                    startLeft,
+                    startRight,
+                    endLeft,
+                    endRight,
+                    null));
+        }
+        return helices;
+    }
+
+
+    public static void dotBracketToBasePairFile(String inFile,
+                                                String bpFile,
+                                                String chromosome,
+                                                String strand,
+                                                int left) throws
+            FileNotFoundException, IOException {
+
+        ArrayList<Point> pairs = loadDotBracket(inFile);
+        // FIXME: transform coords here using left and strand
+        LinkedList<BasePairFeature> arcs = pairsToHelices(pairs, chromosome);
+        ArrayList<Color> colors = new ArrayList<>();
+        colors.add(Color.black);
+        ArrayList<LinkedList<BasePairFeature>> groupedArcs = new ArrayList<>();
+        groupedArcs.add(arcs); // list of length 1 for this case (arcs only have 1 color)
+        writeBasePairFile(bpFile, colors, groupedArcs);
+    }
+
+    public static void connectTableToBasePairFile(String inFile,
+                                                  String bpFile,
+                                                  String chromosome,
+                                                  String strand,
+                                                  int left) throws
+            FileNotFoundException, IOException {
+
+        ArrayList<Point> pairs = loadConnectTable(inFile);
+    }
+
+    public static void pairingProbToBasePairFile(String inFile,
+                                                 String bpFile,
+                                                 String chromosome,
+                                                 String strand,
+                                                 int left) throws
+            FileNotFoundException, IOException {
+
+        ArrayList<ArrayList<Point>> binnedPairs = loadPairingProb(inFile);
+    }
+
+
+    /**
+     * Convert a base pairing structure file in dot-bracket notation
+     * (also known as Vienna format) to an easily parseable .bp arcs file. Does not
+     * currently handle mapping coords to spliced transcripts.
+     *
+     * @param dbFile        Input file
+     * @param bpFile        Output file
+     * @param chromosome    Associated IGV chromosome
+     * @param strand        Associated strand ("+" or "-")
+     * @param left          Starting left-most position (0-based)
+     */
+
+
+    /**
+     * Convert a pairing probability file as output by RNAStructure
+     * and/or SuperFold to an easily parseable .bp arcs file. Does not
+     * currently handle mapping coords to spliced transcripts.
+     *
+     * @param dpFile        Input file
+     * @param bpFile        Output file
+     * @param chromosome    Associated IGV chromosome
+     * @param strand        Associated strand ("+" or "-")
+     * @param left          Starting left-most position (0-based)
+     */
+
+}

--- a/src/org/broad/igv/feature/BasePairFileUtils.java
+++ b/src/org/broad/igv/feature/BasePairFileUtils.java
@@ -33,11 +33,10 @@ import org.broad.igv.Globals;
 import java.awt.Color;
 import java.awt.Point;
 import java.io.*;
-import java.lang.reflect.Array;
 import java.util.*;
 
 
-// workaround to allow multiple return from loadDotBracket() and loadConnectTable()
+// multiple return from loadDotBracket() and loadConnectTable()
 class SeqLenAndPairs {
     public int seqLen;
     public  ArrayList<Point> pairs;
@@ -47,7 +46,7 @@ class SeqLenAndPairs {
     }
 }
 
-// workaround to allow multiple return from loadPairingProb
+// multiple return from loadPairingProb()
 class SeqLenAndBinnedPairs {
     public int seqLen;
     public  ArrayList<ArrayList<Point>> binnedPairs;
@@ -68,6 +67,8 @@ public class BasePairFileUtils {
     // TODO: warning dialog on file overwrite
 
     /**
+     * Convert RNA-based transcript coordinates to stranded chromosome coords for
+     * base-pairing arcs.
      *
      * @param arcs
      * @param seqLen
@@ -83,40 +84,30 @@ public class BasePairFileUtils {
                                                     int newLeft,
                                                     String strand){
         LinkedList<BasePairFeature> transArcs = new LinkedList<>();
-        if (strand == "+"){
-            for (BasePairFeature arc : arcs){
-                String chr = arc.getChr();
-                int startLeft = arc.getStartLeft() + newLeft - 1;
-                int startRight = arc.getStartRight() + newLeft - 1;
-                int endLeft = arc.getEndLeft() + newLeft - 1;
-                int endRight = arc.getEndRight() + newLeft - 1;
-                Color color = arc.getColor();
-                BasePairFeature transArc = new BasePairFeature(chr,
-                                                               startLeft,
-                                                               startRight,
-                                                               endLeft,
-                                                               endRight,
-                                                               color);
-                transArcs.add(transArc);
+        for (BasePairFeature arc : arcs){
+            String chr = arc.getChr();
+            Color color = arc.getColor();
+            int startLeft, startRight, endLeft, endRight;
+            if (strand == "+"){
+                startLeft = arc.getStartLeft() + newLeft - 1;
+                startRight = arc.getStartRight() + newLeft - 1;
+                endLeft = arc.getEndLeft() + newLeft - 1;
+                endRight = arc.getEndRight() + newLeft - 1;
+            } else if (strand == "-"){
+                startLeft = seqLen - arc.getEndRight() + newLeft;
+                startRight = seqLen - arc.getEndLeft() + newLeft;
+                endLeft = seqLen - arc.getStartRight() + newLeft;
+                endRight = seqLen - arc.getStartLeft() + newLeft;
+            } else {
+                throw new RuntimeException("Unrecognized strand (options: \"+\",\"-\")");
             }
-        } else if (strand == "-"){
-            for (BasePairFeature arc : arcs){
-                String chr = arc.getChr();
-                int startLeft = seqLen - arc.getEndRight() + newLeft;
-                int startRight = seqLen - arc.getEndLeft() + newLeft;
-                int endLeft = seqLen - arc.getStartRight() + newLeft;
-                int endRight = seqLen - arc.getStartLeft() + newLeft;
-                Color color = arc.getColor();
-                BasePairFeature transArc = new BasePairFeature(chr,
-                                                               startLeft,
-                                                               startRight,
-                                                               endLeft,
-                                                               endRight,
-                                                               color);
-                transArcs.add(transArc);
-            }
-        } else {
-            throw new RuntimeException("Unrecognized strand (options: \"+\",\"-\")");
+            BasePairFeature transArc = new BasePairFeature(chr,
+                                                           startLeft,
+                                                           startRight,
+                                                           endLeft,
+                                                           endRight,
+                                                           color);
+            transArcs.add(transArc);
         }
         return transArcs;
     }
@@ -282,10 +273,7 @@ public class BasePairFileUtils {
 
     /**
      * Merge adjacent basepairs into helices. This makes assumptions about input pair list order.
-     *
-     * @param pairs
-     * @param chromosome
-     * @return
+
      */
     static LinkedList<BasePairFeature> pairsToHelices(ArrayList<Point> pairs,
                                                       String chromosome) {
@@ -376,7 +364,12 @@ public class BasePairFileUtils {
         return helices;
     }
 
-
+    /**
+     * Convert a base pairing structure file in dot-bracket notation
+     * (also known as Vienna format) to an easily parseable .bp arcs file. Does not
+     * currently handle mapping coords to spliced transcripts.
+     *
+     */
     public static void dotBracketToBasePairFile(String inFile,
                                                 String bpFile,
                                                 String chromosome,
@@ -396,6 +389,12 @@ public class BasePairFileUtils {
         writeBasePairFile(bpFile, colors, groupedArcs);
     }
 
+    /**
+     * Convert a connectivity table file as output by RNAStructure
+     * to an easily parseable .bp arcs file. Does not
+     * currently handle mapping coords to spliced transcripts.
+
+     */
     public static void connectTableToBasePairFile(String inFile,
                                                   String bpFile,
                                                   String chromosome,
@@ -415,6 +414,12 @@ public class BasePairFileUtils {
         writeBasePairFile(bpFile, colors, groupedArcs);
     }
 
+    /**
+     * Convert a pairing probability file as output by RNAStructure
+     * and/or SuperFold to an easily parseable .bp arcs file. Does not
+     * currently handle mapping coords to spliced transcripts.
+
+     */
     public static void pairingProbToBasePairFile(String inFile,
                                                  String bpFile,
                                                  String chromosome,
@@ -438,29 +443,8 @@ public class BasePairFileUtils {
     }
 
 
-    /**
-     * Convert a base pairing structure file in dot-bracket notation
-     * (also known as Vienna format) to an easily parseable .bp arcs file. Does not
-     * currently handle mapping coords to spliced transcripts.
-     *
-     * @param dbFile        Input file
-     * @param bpFile        Output file
-     * @param chromosome    Associated IGV chromosome
-     * @param strand        Associated strand ("+" or "-")
-     * @param left          Starting left-most position (0-based)
-     */
 
 
-    /**
-     * Convert a pairing probability file as output by RNAStructure
-     * and/or SuperFold to an easily parseable .bp arcs file. Does not
-     * currently handle mapping coords to spliced transcripts.
-     *
-     * @param dpFile        Input file
-     * @param bpFile        Output file
-     * @param chromosome    Associated IGV chromosome
-     * @param strand        Associated strand ("+" or "-")
-     * @param left          Starting left-most position (0-based)
-     */
+
 
 }

--- a/src/org/broad/igv/feature/ShapeFileUtils.java
+++ b/src/org/broad/igv/feature/ShapeFileUtils.java
@@ -1,0 +1,162 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2007-2015 Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.broad.igv.feature;
+
+
+import org.broad.igv.Globals;
+
+
+import java.io.*;
+import java.lang.reflect.Array;
+import java.util.*;
+
+
+class LocAndVal {
+    public int loc;
+    public double val;
+    public LocAndVal(int loc, double val) {
+        this.loc = loc;
+        this.val = val;
+    }
+}
+
+
+
+/**
+ * @author sbusan
+ */
+public class ShapeFileUtils {
+
+    static LinkedList<LocAndVal> transformProfile(LinkedList<LocAndVal> profile,
+                                                  int seqLen,
+                                                  int newLeft,
+                                                  String strand){
+        LinkedList<LocAndVal> transProfile = new LinkedList<>();
+        for (LocAndVal d : profile){
+            int loc = d.loc;
+            double val = d.val;
+            if (strand == "+"){
+                loc = loc + newLeft - 1;
+            } else if (strand == "-"){
+                loc = seqLen - loc + newLeft;
+            } else {
+                throw new RuntimeException("Unrecognized strand (options: \"+\",\"-\")");
+            }
+            transProfile.add(new LocAndVal(loc, val));
+        }
+        return transProfile;
+    }
+
+    static LinkedList<LocAndVal> loadShape(String inFile) throws
+            FileNotFoundException, IOException {
+        // TODO: add error messages for misformatted file
+        LinkedList<LocAndVal> profile = new LinkedList<>();
+
+        BufferedReader br = null;
+
+        try {
+            br = new BufferedReader(new FileReader(inFile));
+
+            String nextLine;
+            while ((nextLine = br.readLine()) != null) {
+                String[] s = Globals.whitespacePattern.split(nextLine.trim());
+                int loc = Integer.parseInt(s[0]);
+                double val = Double.parseDouble(s[1]);
+                if (val < -998) {
+                    val = Double.NaN;
+                }
+                profile.add(new LocAndVal(loc, val));
+            }
+        } finally {
+            if (br != null) br.close();
+        }
+
+        return profile;
+    }
+
+
+    static void writeWigFile(String wigFile,
+                             String chrom,
+                             LinkedList<LocAndVal> profile) throws IOException {
+        PrintWriter pw = null;
+
+        try {
+            pw = new PrintWriter(new BufferedWriter(new FileWriter(wigFile)));
+            // write header
+            pw.println("variableStep chrom="+chrom);
+
+            // write locs and values
+            for (LocAndVal d : profile) {
+                int loc = d.loc;
+                double val = d.val;
+                if (!Double.isNaN(val)){
+                    pw.println(""+loc+"\t"+String.format("%.6f",val));
+                }
+            }
+        } finally {
+            if (pw != null) pw.close();
+        }
+    }
+
+
+    public static void shapeToWigFile(String inFile,
+                                      String wigFile,
+                                      String chromosome,
+                                      String strand,
+                                      int left) throws
+            FileNotFoundException, IOException {
+
+        LinkedList<LocAndVal> profile = loadShape(inFile);
+        profile = transformProfile(profile, profile.size(), left, strand);
+        writeWigFile(wigFile, chromosome, profile);
+    }
+
+    /**
+     * Convert a base pairing structure file in dot-bracket notation
+     * (also known as Vienna format) to an easily parseable .bp arcs file. Does not
+     * currently handle mapping coords to spliced transcripts.
+     *
+     * @param dbFile        Input file
+     * @param bpFile        Output file
+     * @param chromosome    Associated IGV chromosome
+     * @param strand        Associated strand ("+" or "-")
+     * @param left          Starting left-most position (0-based)
+     */
+
+
+    /**
+     * Convert a pairing probability file as output by RNAStructure
+     * and/or SuperFold to an easily parseable .bp arcs file. Does not
+     * currently handle mapping coords to spliced transcripts.
+     *
+     * @param dpFile        Input file
+     * @param bpFile        Output file
+     * @param chromosome    Associated IGV chromosome
+     * @param strand        Associated strand ("+" or "-")
+     * @param left          Starting left-most position (0-based)
+     */
+
+}

--- a/src/org/broad/igv/feature/basepair/BasePairFeature.java
+++ b/src/org/broad/igv/feature/basepair/BasePairFeature.java
@@ -70,4 +70,12 @@ public class BasePairFeature implements Feature{
     public int getEnd() {
         return endRight;
     }
+
+    public String toStringNoColor() {
+        return getChr() + "\t" + startLeft + "\t" + startRight + "\t" + endLeft + "\t" + endRight;
+    }
+
+    public String toString() {
+        return toStringNoColor() + "\t" + color;
+    }
 }

--- a/src/org/broad/igv/feature/basepair/BasePairFeature.java
+++ b/src/org/broad/igv/feature/basepair/BasePairFeature.java
@@ -71,6 +71,17 @@ public class BasePairFeature implements Feature{
         return endRight;
     }
 
+    public int getStartLeft() { return startLeft; }
+
+    public int getStartRight() { return startRight; }
+
+    public int getEndLeft() { return endLeft; }
+
+    public int getEndRight() { return endRight; }
+
+    public Color getColor() { return color; }
+
+
     public String toStringNoColor() {
         return getChr() + "\t" + startLeft + "\t" + startRight + "\t" + endLeft + "\t" + endRight;
     }

--- a/src/org/broad/igv/feature/basepair/BasePairFileParser.java
+++ b/src/org/broad/igv/feature/basepair/BasePairFileParser.java
@@ -32,37 +32,37 @@ public class BasePairFileParser {
             // read lines specifying arc colors
             nextLine = reader.readLine();
             rowCounter++;
-            while (nextLine.substring(0,6).equals("color:")){
-                String[] tokens = Globals.tabPattern.split(nextLine, -1);
+            while (nextLine.substring(0, 6).equals("color:")) {
+                String[] tokens = Globals.singleTabMultiSpacePattern.split(nextLine, -1);
                 int r = Integer.parseInt(tokens[1]);
                 int g = Integer.parseInt(tokens[2]);
                 int b = Integer.parseInt(tokens[3]);
-                Color color = new Color(r,g,b,255);
+                Color color = new Color(r, g, b, 255);
                 colors.add(color);
                 nextLine = reader.readLine();
                 rowCounter++;
             }
 
-            for (Color color : colors){
+            for (Color color : colors) {
                 rowsByColor.put(color, new ArrayList());
             }
 
             while (nextLine != null) {
 
-                String[] tokens = Globals.tabPattern.split(nextLine, -1);
+                String[] tokens = Globals.singleTabMultiSpacePattern.split(nextLine, -1);
 
                 int nTokens = tokens.length;
 
                 String chr = (genome == null ? tokens[0] : genome.getCanonicalChrName(tokens[0]));   // TODO Future use
 
-                int startLeftNuc = Integer.parseInt(tokens[1])-1; // stick to IGV's 0-based coordinate convention
-                int startRightNuc = Integer.parseInt(tokens[2])-1;
-                int endLeftNuc = Integer.parseInt(tokens[3])-1;
-                int endRightNuc = Integer.parseInt(tokens[4])-1;
+                int startLeftNuc = Integer.parseInt(tokens[1]) - 1; // stick to IGV's 0-based coordinate convention
+                int startRightNuc = Integer.parseInt(tokens[2]) - 1;
+                int endLeftNuc = Integer.parseInt(tokens[3]) - 1;
+                int endRightNuc = Integer.parseInt(tokens[4]) - 1;
                 Color color = colors.get(Integer.parseInt(tokens[5]));
 
                 BasePairFeature feature;
-                if (startLeftNuc <= endRightNuc){
+                if (startLeftNuc <= endRightNuc) {
                     feature = new BasePairFeature(chr,
                             Math.min(startLeftNuc, startRightNuc),
                             Math.max(startLeftNuc, startRightNuc),

--- a/src/org/broad/igv/feature/basepair/BasePairFileParser.java
+++ b/src/org/broad/igv/feature/basepair/BasePairFileParser.java
@@ -17,9 +17,7 @@ public class BasePairFileParser {
 
     static Logger log = Logger.getLogger(BasePairFileParser.class);
 
-    BasePairTrack track;
-
-    public BasePairTrack loadTrack(ResourceLocator locator, Genome genome) {
+    public static BasePairData loadData(ResourceLocator locator, Genome genome) {
         AsciiLineReader reader = null;
 
         List<Color> colors = new ArrayList();
@@ -106,8 +104,7 @@ public class BasePairFileParser {
         //    System.out.println(row);
         //}
 
-        track = new BasePairTrack(basePairData, locator.getTrackName());
-        return track;
+        return basePairData;
     }
 
 }

--- a/src/org/broad/igv/feature/basepair/BasePairFileParser.java
+++ b/src/org/broad/igv/feature/basepair/BasePairFileParser.java
@@ -33,7 +33,7 @@ public class BasePairFileParser {
             nextLine = reader.readLine();
             rowCounter++;
             while (nextLine.substring(0, 6).equals("color:")) {
-                String[] tokens = Globals.singleTabMultiSpacePattern.split(nextLine, -1);
+                String[] tokens = Globals.whitespacePattern.split(nextLine, -1);
                 int r = Integer.parseInt(tokens[1]);
                 int g = Integer.parseInt(tokens[2]);
                 int b = Integer.parseInt(tokens[3]);
@@ -49,9 +49,7 @@ public class BasePairFileParser {
 
             while (nextLine != null) {
 
-                String[] tokens = Globals.singleTabMultiSpacePattern.split(nextLine, -1);
-
-                int nTokens = tokens.length;
+                String[] tokens = Globals.whitespacePattern.split(nextLine, -1);
 
                 String chr = (genome == null ? tokens[0] : genome.getCanonicalChrName(tokens[0]));   // TODO Future use
 
@@ -85,7 +83,7 @@ public class BasePairFileParser {
 
             }
 
-            basePairData.finish();   // Insure features are sorted by start position, important for rendering optimization
+            basePairData.finish();   // ensure features are sorted by start position, important for rendering optimization
 
         } catch (Exception e) {
             log.error("Error parsing base pair file", e);

--- a/src/org/broad/igv/feature/basepair/BasePairRenderer.java
+++ b/src/org/broad/igv/feature/basepair/BasePairRenderer.java
@@ -57,8 +57,6 @@ public class BasePairRenderer {
 
                 //System.out.println("Color: "+data.colors[i]);
                 int arcCount = 0;
-                // TODO: only render arcs whose interior overlaps the viewing area - i.e. if an arc starts left of the window and ends right of the window, should still render
-
 
                 //System.out.println("In arcRenderer.draw(): ");
                 //System.out.println("    track.width = " + trackRectangle.width);
@@ -103,9 +101,10 @@ public class BasePairRenderer {
     /**
      * Draw a filled arc between two regions of equal length
      *
-     * @param startLeft  the starting position of the feature, whether on-screen or not
-     * @param endLeft    the ending position of the feature, whether on-screen or not
-     * @param pixelWidth  the width of the arc in pixels
+     * @param startLeft  the starting position of the feature, whether on-screen or not (outer left corner of arc)
+     * @param startRight (inner left corner of arc)
+     * @param endLeft    the ending position of the feature, whether on-screen or not (inner right corner of arc)
+     * @param endRight   (outer right corner of arc)
      * @param trackRectangle
      * @param context
      * @param featureColor       the color specified for this feature.  May be null.

--- a/src/org/broad/igv/feature/basepair/BasePairRenderer.java
+++ b/src/org/broad/igv/feature/basepair/BasePairRenderer.java
@@ -12,6 +12,7 @@ import java.awt.*;
 import java.awt.geom.GeneralPath;
 
 // TODO: add vertical scaling option so arcs fit on track, or clip arcs outside of track rect?
+// TODO: add visualization for very zoomed-out views
 
 public class BasePairRenderer {
 
@@ -44,7 +45,7 @@ public class BasePairRenderer {
         int end = (int) (origin + trackRectangle.width * nucsPerPixel) + 1;
         if (end <= start) return;
 
-        // TODO: should make this a function (ugh no multiple value return from java functions)
+        // TODO: make this a function
 
         java.util.List<BasePairFeature> featureList = data.getFeatures(context.getChr());
 

--- a/src/org/broad/igv/feature/basepair/BasePairTrack.java
+++ b/src/org/broad/igv/feature/basepair/BasePairTrack.java
@@ -1,9 +1,11 @@
 package org.broad.igv.feature.basepair;
 
 import org.apache.log4j.Logger;
+import org.broad.igv.feature.genome.*;
 import org.broad.igv.renderer.*;
 import org.broad.igv.track.AbstractTrack;
 import org.broad.igv.track.RenderContext;
+import org.broad.igv.util.ResourceLocator;
 
 import java.awt.*;
 
@@ -19,9 +21,9 @@ public class BasePairTrack extends AbstractTrack {
     private BasePairRenderer basePairRenderer = new BasePairRenderer();
     private BasePairData basePairData;
 
-    public BasePairTrack(BasePairData data, String name) {
-        super(name);
-        basePairData = data;
+    public BasePairTrack(ResourceLocator locator, String id, String name, Genome genome) {
+        super(locator, id, name);
+        basePairData = BasePairFileParser.loadData(locator, genome);
     }
 
     public void render(RenderContext context, Rectangle rect) {

--- a/src/org/broad/igv/track/TrackLoader.java
+++ b/src/org/broad/igv/track/TrackLoader.java
@@ -47,7 +47,7 @@ import org.broad.igv.dev.db.SQLCodecSource;
 import org.broad.igv.dev.db.SampleInfoSQLReader;
 import org.broad.igv.dev.db.SegmentedSQLReader;
 import org.broad.igv.exceptions.DataLoadException;
-import org.broad.igv.feature.basepair.BasePairFileParser;
+import org.broad.igv.feature.basepair.BasePairTrack;
 import org.broad.igv.feature.CachingFeatureSource;
 import org.broad.igv.feature.GisticFileParser;
 import org.broad.igv.feature.MutationTrackLoader;
@@ -1235,8 +1235,10 @@ public class TrackLoader {
 
 
     private void loadBasePairFile(ResourceLocator locator, List<Track> newTracks, Genome genome) throws IOException {
-        BasePairFileParser parser = new BasePairFileParser();
-        newTracks.add(parser.loadTrack(locator, genome)); // should create one track from the given file
+        String name = locator.getTrackName();
+        String path = locator.getPath();
+        String id = path + "_" + name;
+        newTracks.add(new BasePairTrack(locator, id, name, genome));
     }
 
     public static boolean isIndexed(ResourceLocator locator, Genome genome) {

--- a/src/org/broad/igv/track/TrackLoader.java
+++ b/src/org/broad/igv/track/TrackLoader.java
@@ -1262,7 +1262,7 @@ public class TrackLoader {
         //int new_start = dialog.getNewStart();
         //String strand = dialog.getStrand();
         //String chrom = "HIV-1_NL4-3";
-        String chrom = "dummy_chrom";
+        String chrom = "tmRNA";
         String strand = "+";
         int left = 1;
         if (fileType == "connectTable") {

--- a/src/org/broad/igv/ui/util/ConvertFileDialog.java
+++ b/src/org/broad/igv/ui/util/ConvertFileDialog.java
@@ -1,0 +1,247 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2007-2015 Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+/*
+ * Created by JFormDesigner on Tue Nov 15 14:22:59 EST 2016
+ */
+
+package org.broad.igv.ui.util;
+
+import org.broad.igv.Globals;
+import org.broad.igv.PreferenceManager;
+import org.broad.igv.ui.IGV;
+
+import java.awt.*;
+import java.awt.event.*;
+import java.text.NumberFormat;
+import javax.swing.*;
+import javax.swing.border.*;
+import javax.swing.text.DefaultFormatterFactory;
+import javax.swing.text.NumberFormatter;
+
+import java.util.*;
+
+/**
+ * Before converting .shape, .map, .ct, .db, or .dp files (associated with individual RNAs)
+ * to IGV-loadable formats, allow the user to select the applicable chromosome,
+ * coordinate offset, and strand, since that information is not present in those files.
+ *
+ * @author sbusan
+ */
+public class ConvertFileDialog extends JDialog {
+
+    ConvertOptions opts = new ConvertOptions();
+
+    private ConvertFileDialog(Frame owner, String message, java.util.List<String> chromosomes) {
+        super(owner);
+        this.setModal(true);
+        initComponents();
+        label.setText("<html>" + message + "</html>");
+        okButton.setText("Continue");
+
+        // FIXME: limit input to empty string or integer
+        /*NumberFormat format = NumberFormat.getInstance();
+        NumberFormatter formatter = new NumberFormatter(format);
+        formatter.setValueClass(Integer.class);
+        formatter.setMinimum(0);
+        formatter.setMaximum(Integer.MAX_VALUE);
+        formatter.setAllowsInvalid(false);
+        DefaultFormatterFactory factory = new DefaultFormatterFactory(formatter);
+        startTextField.setFormatterFactory(factory);*/
+
+        DefaultComboBoxModel boxModel = new DefaultComboBoxModel();
+        for (String chrom : chromosomes){
+            boxModel.addElement(chrom);
+        }
+        chromBox.setModel(boxModel);
+
+        getRootPane().setDefaultButton(okButton);
+    }
+
+    public static ConvertOptions showConvertFileDialog(String message) {
+        ConvertFileDialog dlg = new ConvertFileDialog(IGV.getMainFrame(),
+                                                      message,
+                                                      IGV.getInstance().getGenomeManager().getCurrentGenome().getAllChromosomeNames());
+        dlg.setVisible(true);
+        dlg.opts.chrom = dlg.chromBox.getSelectedItem().toString();
+        dlg.opts.start = Integer.parseInt(dlg.startTextField.getText());
+        if (dlg.reverseRadio.isSelected()) dlg.opts.strand = "-";
+        return dlg.opts;
+    }
+
+    private void cancelButtonActionPerformed(ActionEvent e) {
+        opts.doConvert = false;
+        setVisible(false);
+    }
+
+    private void okButtonActionPerformed(ActionEvent e) {
+        opts.doConvert = true;
+        setVisible(false);
+    }
+
+    private void initComponents() {
+        // JFormDesigner - Component initialization - DO NOT MODIFY  //GEN-BEGIN:initComponents
+        // Generated using JFormDesigner non-commercial license
+        dialogPane = new JPanel();
+        contentPanel = new JPanel();
+        label = new JLabel();
+        forwardRadio = new JRadioButton();
+        reverseRadio = new JRadioButton();
+        label1 = new JLabel();
+        label2 = new JLabel();
+        label3 = new JLabel();
+        startTextField = new JFormattedTextField();
+        chromBox = new JComboBox();
+        buttonBar = new JPanel();
+        cancelButton = new JButton();
+        okButton = new JButton();
+
+        //======== this ========
+        setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
+        setResizable(false);
+        Container contentPane = getContentPane();
+        contentPane.setLayout(new BorderLayout());
+
+        //======== dialogPane ========
+        {
+            dialogPane.setBorder(new EmptyBorder(12, 12, 12, 12));
+            dialogPane.setLayout(new BorderLayout());
+
+            //======== contentPanel ========
+            {
+                contentPanel.setLayout(null);
+
+                //---- label ----
+                label.setText("text");
+                label.setFont(label.getFont().deriveFont(label.getFont().getStyle() & ~Font.BOLD));
+                contentPanel.add(label);
+                label.setBounds(0, 0, 415, 140);
+
+                //---- forwardRadio ----
+                forwardRadio.setText("Forward");
+                forwardRadio.setSelected(true);
+                contentPanel.add(forwardRadio);
+                forwardRadio.setBounds(65, 180, forwardRadio.getPreferredSize().width, 23);
+
+                //---- reverseRadio ----
+                reverseRadio.setText("Reverse");
+                contentPanel.add(reverseRadio);
+                reverseRadio.setBounds(145, 180, reverseRadio.getPreferredSize().width, 23);
+
+                //---- label1 ----
+                label1.setText("Strand:");
+                label1.setHorizontalAlignment(SwingConstants.RIGHT);
+                contentPanel.add(label1);
+                label1.setBounds(5, 185, label1.getPreferredSize().width, 15);
+
+                //---- label2 ----
+                label2.setText("Chr:");
+                label2.setHorizontalAlignment(SwingConstants.RIGHT);
+                contentPanel.add(label2);
+                label2.setBounds(10, 155, 42, 15);
+
+                //---- label3 ----
+                label3.setText("Start:");
+                label3.setHorizontalAlignment(SwingConstants.RIGHT);
+                contentPanel.add(label3);
+                label3.setBounds(5, 215, 49, 15);
+
+                //---- startTextField ----
+                startTextField.setText("1");
+                contentPanel.add(startTextField);
+                startTextField.setBounds(65, 210, 165, startTextField.getPreferredSize().height);
+
+                //---- chromBox ----
+                chromBox.setMaximumRowCount(100);
+                contentPanel.add(chromBox);
+                chromBox.setBounds(65, 150, 165, chromBox.getPreferredSize().height);
+
+                { // compute preferred size
+                    Dimension preferredSize = new Dimension();
+                    for(int i = 0; i < contentPanel.getComponentCount(); i++) {
+                        Rectangle bounds = contentPanel.getComponent(i).getBounds();
+                        preferredSize.width = Math.max(bounds.x + bounds.width, preferredSize.width);
+                        preferredSize.height = Math.max(bounds.y + bounds.height, preferredSize.height);
+                    }
+                    Insets insets = contentPanel.getInsets();
+                    preferredSize.width += insets.right;
+                    preferredSize.height += insets.bottom;
+                    contentPanel.setMinimumSize(preferredSize);
+                    contentPanel.setPreferredSize(preferredSize);
+                }
+            }
+            dialogPane.add(contentPanel, BorderLayout.CENTER);
+
+            //======== buttonBar ========
+            {
+                buttonBar.setBorder(new EmptyBorder(12, 0, 0, 0));
+                buttonBar.setLayout(new GridBagLayout());
+                ((GridBagLayout)buttonBar.getLayout()).columnWidths = new int[] {0, 0, 80};
+                ((GridBagLayout)buttonBar.getLayout()).columnWeights = new double[] {1.0, 0.0, 0.0};
+
+                //---- cancelButton ----
+                cancelButton.setText("Cancel");
+                cancelButton.addActionListener(e -> cancelButtonActionPerformed(e));
+                buttonBar.add(cancelButton, new GridBagConstraints(1, 0, 1, 1, 0.0, 0.0,
+                    GridBagConstraints.CENTER, GridBagConstraints.BOTH,
+                    new Insets(0, 0, 5, 5), 0, 0));
+
+                //---- okButton ----
+                okButton.setText("OK");
+                okButton.addActionListener(e -> okButtonActionPerformed(e));
+                buttonBar.add(okButton, new GridBagConstraints(2, 0, 1, 1, 0.0, 0.0,
+                    GridBagConstraints.CENTER, GridBagConstraints.BOTH,
+                    new Insets(0, 0, 5, 0), 0, 0));
+            }
+            dialogPane.add(buttonBar, BorderLayout.SOUTH);
+        }
+        contentPane.add(dialogPane, BorderLayout.CENTER);
+        setSize(450, 355);
+        setLocationRelativeTo(getOwner());
+
+        //---- buttonGroup1 ----
+        ButtonGroup buttonGroup1 = new ButtonGroup();
+        buttonGroup1.add(forwardRadio);
+        buttonGroup1.add(reverseRadio);
+        // JFormDesigner - End of component initialization  //GEN-END:initComponents
+    }
+
+    // JFormDesigner - Variables declaration - DO NOT MODIFY  //GEN-BEGIN:variables
+    // Generated using JFormDesigner non-commercial license
+    private JPanel dialogPane;
+    private JPanel contentPanel;
+    private JLabel label;
+    private JRadioButton forwardRadio;
+    private JRadioButton reverseRadio;
+    private JLabel label1;
+    private JLabel label2;
+    private JLabel label3;
+    private JFormattedTextField startTextField;
+    private JComboBox chromBox;
+    private JPanel buttonBar;
+    private JButton cancelButton;
+    private JButton okButton;
+    // JFormDesigner - End of variables declaration  //GEN-END:variables
+}

--- a/src/org/broad/igv/ui/util/ConvertFileDialog.jfd
+++ b/src/org/broad/igv/ui/util/ConvertFileDialog.jfd
@@ -1,0 +1,481 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<java version="1.8.0_76-release" class="java.beans.XMLDecoder">
+ <object class="com.jformdesigner.model.FormModel">
+  <void property="contentType">
+   <string>form/swing</string>
+  </void>
+  <void property="root">
+   <object class="com.jformdesigner.model.FormRoot">
+    <void method="add">
+     <object class="com.jformdesigner.model.FormWindow">
+      <string>javax.swing.JDialog</string>
+      <object class="com.jformdesigner.model.FormLayoutManager">
+       <class>java.awt.BorderLayout</class>
+      </object>
+      <void method="setProperty">
+       <string>defaultCloseOperation</string>
+       <int>2</int>
+      </void>
+      <void method="setProperty">
+       <string>$sizePolicy</string>
+       <int>1</int>
+      </void>
+      <void method="setProperty">
+       <string>resizable</string>
+       <boolean>false</boolean>
+      </void>
+      <void method="add">
+       <object class="com.jformdesigner.model.FormContainer">
+        <string>javax.swing.JPanel</string>
+        <object class="com.jformdesigner.model.FormLayoutManager">
+         <class>java.awt.BorderLayout</class>
+        </object>
+        <void method="setProperty">
+         <string>border</string>
+         <object class="javax.swing.border.EmptyBorder">
+          <int>12</int>
+          <int>12</int>
+          <int>12</int>
+          <int>12</int>
+         </object>
+        </void>
+        <void property="name">
+         <string>dialogPane</string>
+        </void>
+        <void method="add">
+         <object class="com.jformdesigner.model.FormContainer">
+          <string>javax.swing.JPanel</string>
+          <object class="com.jformdesigner.model.FormLayoutManager">
+           <class>com.jformdesigner.runtime.NullLayout</class>
+          </object>
+          <void property="name">
+           <string>contentPanel</string>
+          </void>
+          <void method="add">
+           <object class="com.jformdesigner.model.FormComponent">
+            <string>javax.swing.JLabel</string>
+            <void method="setProperty">
+             <string>text</string>
+             <string>text</string>
+            </void>
+            <void method="setProperty">
+             <string>font</string>
+             <object class="com.jformdesigner.model.SwingDerivedFont">
+              <null/>
+              <int>65536</int>
+              <int>0</int>
+              <boolean>false</boolean>
+             </object>
+            </void>
+            <void property="name">
+             <string>label</string>
+            </void>
+           </object>
+           <object class="com.jformdesigner.model.FormLayoutConstraints">
+            <class>com.jformdesigner.runtime.NullConstraints</class>
+            <void method="setProperty">
+             <string>x</string>
+             <int>0</int>
+            </void>
+            <void method="setProperty">
+             <string>y</string>
+             <int>0</int>
+            </void>
+            <void method="setProperty">
+             <string>width</string>
+             <int>415</int>
+            </void>
+            <void method="setProperty">
+             <string>height</string>
+             <int>140</int>
+            </void>
+           </object>
+          </void>
+          <void method="add">
+           <object class="com.jformdesigner.model.FormComponent">
+            <string>javax.swing.JRadioButton</string>
+            <void method="setProperty">
+             <string>text</string>
+             <string>Forward</string>
+            </void>
+            <void method="setProperty">
+             <string>selected</string>
+             <boolean>true</boolean>
+            </void>
+            <void method="setProperty">
+             <string>$buttonGroup</string>
+             <object class="com.jformdesigner.model.FormReference">
+              <string>buttonGroup1</string>
+             </object>
+            </void>
+            <void property="name">
+             <string>forwardRadio</string>
+            </void>
+           </object>
+           <object class="com.jformdesigner.model.FormLayoutConstraints">
+            <class>com.jformdesigner.runtime.NullConstraints</class>
+            <void method="setProperty">
+             <string>x</string>
+             <int>65</int>
+            </void>
+            <void method="setProperty">
+             <string>y</string>
+             <int>180</int>
+            </void>
+            <void method="setProperty">
+             <string>height</string>
+             <int>23</int>
+            </void>
+           </object>
+          </void>
+          <void method="add">
+           <object class="com.jformdesigner.model.FormComponent">
+            <string>javax.swing.JRadioButton</string>
+            <void method="setProperty">
+             <string>text</string>
+             <string>Reverse</string>
+            </void>
+            <void method="setProperty">
+             <string>$buttonGroup</string>
+             <object class="com.jformdesigner.model.FormReference">
+              <string>buttonGroup1</string>
+             </object>
+            </void>
+            <void property="name">
+             <string>reverseRadio</string>
+            </void>
+           </object>
+           <object class="com.jformdesigner.model.FormLayoutConstraints">
+            <class>com.jformdesigner.runtime.NullConstraints</class>
+            <void method="setProperty">
+             <string>x</string>
+             <int>145</int>
+            </void>
+            <void method="setProperty">
+             <string>y</string>
+             <int>180</int>
+            </void>
+            <void method="setProperty">
+             <string>height</string>
+             <int>23</int>
+            </void>
+           </object>
+          </void>
+          <void method="add">
+           <object class="com.jformdesigner.model.FormComponent">
+            <string>javax.swing.JLabel</string>
+            <void method="setProperty">
+             <string>text</string>
+             <string>Strand:</string>
+            </void>
+            <void method="setProperty">
+             <string>horizontalAlignment</string>
+             <int>4</int>
+            </void>
+            <void property="name">
+             <string>label1</string>
+            </void>
+           </object>
+           <object class="com.jformdesigner.model.FormLayoutConstraints">
+            <class>com.jformdesigner.runtime.NullConstraints</class>
+            <void method="setProperty">
+             <string>x</string>
+             <int>5</int>
+            </void>
+            <void method="setProperty">
+             <string>y</string>
+             <int>185</int>
+            </void>
+            <void method="setProperty">
+             <string>height</string>
+             <int>15</int>
+            </void>
+           </object>
+          </void>
+          <void method="add">
+           <object class="com.jformdesigner.model.FormComponent">
+            <string>javax.swing.JLabel</string>
+            <void method="setProperty">
+             <string>text</string>
+             <string>Chr:</string>
+            </void>
+            <void method="setProperty">
+             <string>horizontalAlignment</string>
+             <int>4</int>
+            </void>
+            <void property="name">
+             <string>label2</string>
+            </void>
+           </object>
+           <object class="com.jformdesigner.model.FormLayoutConstraints">
+            <class>com.jformdesigner.runtime.NullConstraints</class>
+            <void method="setProperty">
+             <string>width</string>
+             <int>42</int>
+            </void>
+            <void method="setProperty">
+             <string>height</string>
+             <int>15</int>
+            </void>
+            <void method="setProperty">
+             <string>x</string>
+             <int>10</int>
+            </void>
+            <void method="setProperty">
+             <string>y</string>
+             <int>155</int>
+            </void>
+           </object>
+          </void>
+          <void method="add">
+           <object class="com.jformdesigner.model.FormComponent">
+            <string>javax.swing.JLabel</string>
+            <void method="setProperty">
+             <string>text</string>
+             <string>Start:</string>
+            </void>
+            <void method="setProperty">
+             <string>horizontalAlignment</string>
+             <int>4</int>
+            </void>
+            <void property="name">
+             <string>label3</string>
+            </void>
+           </object>
+           <object class="com.jformdesigner.model.FormLayoutConstraints">
+            <class>com.jformdesigner.runtime.NullConstraints</class>
+            <void method="setProperty">
+             <string>width</string>
+             <int>49</int>
+            </void>
+            <void method="setProperty">
+             <string>height</string>
+             <int>15</int>
+            </void>
+            <void method="setProperty">
+             <string>x</string>
+             <int>5</int>
+            </void>
+            <void method="setProperty">
+             <string>y</string>
+             <int>215</int>
+            </void>
+           </object>
+          </void>
+          <void method="add">
+           <object class="com.jformdesigner.model.FormComponent">
+            <string>javax.swing.JFormattedTextField</string>
+            <void method="setProperty">
+             <string>text</string>
+             <string>1</string>
+            </void>
+            <void property="name">
+             <string>startTextField</string>
+            </void>
+           </object>
+           <object class="com.jformdesigner.model.FormLayoutConstraints">
+            <class>com.jformdesigner.runtime.NullConstraints</class>
+            <void method="setProperty">
+             <string>x</string>
+             <int>65</int>
+            </void>
+            <void method="setProperty">
+             <string>y</string>
+             <int>210</int>
+            </void>
+            <void method="setProperty">
+             <string>width</string>
+             <int>165</int>
+            </void>
+           </object>
+          </void>
+          <void method="add">
+           <object class="com.jformdesigner.model.FormComponent">
+            <string>javax.swing.JComboBox</string>
+            <void method="setProperty">
+             <string>maximumRowCount</string>
+             <int>100</int>
+            </void>
+            <void property="name">
+             <string>chromBox</string>
+            </void>
+           </object>
+           <object class="com.jformdesigner.model.FormLayoutConstraints">
+            <class>com.jformdesigner.runtime.NullConstraints</class>
+            <void method="setProperty">
+             <string>x</string>
+             <int>65</int>
+            </void>
+            <void method="setProperty">
+             <string>y</string>
+             <int>150</int>
+            </void>
+            <void method="setProperty">
+             <string>width</string>
+             <int>165</int>
+            </void>
+           </object>
+          </void>
+         </object>
+         <object class="com.jformdesigner.model.FormLayoutConstraints">
+          <class>java.lang.String</class>
+          <void method="setProperty">
+           <string>value</string>
+           <string>Center</string>
+          </void>
+         </object>
+        </void>
+        <void method="add">
+         <object class="com.jformdesigner.model.FormContainer">
+          <string>javax.swing.JPanel</string>
+          <object class="com.jformdesigner.model.FormLayoutManager">
+           <class>java.awt.GridBagLayout</class>
+           <void method="setProperty">
+            <string>$columnSpecs</string>
+            <string>0:1.0, 0, 80</string>
+           </void>
+           <void method="setProperty">
+            <string>$rowSpecs</string>
+            <string>0, 0</string>
+           </void>
+           <void method="setProperty">
+            <string>$hGap</string>
+            <int>5</int>
+           </void>
+           <void method="setProperty">
+            <string>$vGap</string>
+            <int>5</int>
+           </void>
+          </object>
+          <void method="setProperty">
+           <string>border</string>
+           <object class="javax.swing.border.EmptyBorder">
+            <int>12</int>
+            <int>0</int>
+            <int>0</int>
+            <int>0</int>
+           </object>
+          </void>
+          <void property="name">
+           <string>buttonBar</string>
+          </void>
+          <void method="add">
+           <object class="com.jformdesigner.model.FormComponent">
+            <string>javax.swing.JButton</string>
+            <void method="setProperty">
+             <string>text</string>
+             <string>Cancel</string>
+            </void>
+            <void property="name">
+             <string>cancelButton</string>
+            </void>
+            <void method="addEvent">
+             <object class="com.jformdesigner.model.FormEvent">
+              <string>java.awt.event.ActionListener</string>
+              <string>actionPerformed</string>
+              <string>cancelButtonActionPerformed</string>
+              <boolean>true</boolean>
+             </object>
+            </void>
+           </object>
+           <object class="com.jformdesigner.model.FormLayoutConstraints">
+            <class>com.jformdesigner.runtime.GridBagConstraintsEx</class>
+            <void method="setProperty">
+             <string>gridx</string>
+             <int>1</int>
+            </void>
+           </object>
+          </void>
+          <void method="add">
+           <object class="com.jformdesigner.model.FormComponent">
+            <string>javax.swing.JButton</string>
+            <void method="setProperty">
+             <string>text</string>
+             <string>OK</string>
+            </void>
+            <void property="name">
+             <string>okButton</string>
+            </void>
+            <void method="addEvent">
+             <object class="com.jformdesigner.model.FormEvent">
+              <string>java.awt.event.ActionListener</string>
+              <string>actionPerformed</string>
+              <string>okButtonActionPerformed</string>
+              <boolean>true</boolean>
+             </object>
+            </void>
+           </object>
+           <object class="com.jformdesigner.model.FormLayoutConstraints">
+            <class>com.jformdesigner.runtime.GridBagConstraintsEx</class>
+            <void method="setProperty">
+             <string>gridx</string>
+             <int>2</int>
+            </void>
+            <void method="setProperty">
+             <string>gridy</string>
+             <int>0</int>
+            </void>
+           </object>
+          </void>
+         </object>
+         <object class="com.jformdesigner.model.FormLayoutConstraints">
+          <class>java.lang.String</class>
+          <void method="setProperty">
+           <string>value</string>
+           <string>South</string>
+          </void>
+         </object>
+        </void>
+       </object>
+       <object class="com.jformdesigner.model.FormLayoutConstraints">
+        <class>java.lang.String</class>
+        <void method="setProperty">
+         <string>value</string>
+         <string>Center</string>
+        </void>
+       </object>
+      </void>
+      <void property="name">
+       <string>this</string>
+      </void>
+     </object>
+     <object class="com.jformdesigner.model.FormLayoutConstraints">
+      <null/>
+      <void method="setProperty">
+       <string>location</string>
+       <object class="java.awt.Point">
+        <int>0</int>
+        <int>0</int>
+       </object>
+      </void>
+      <void method="setProperty">
+       <string>size</string>
+       <object class="java.awt.Dimension">
+        <int>450</int>
+        <int>355</int>
+       </object>
+      </void>
+     </object>
+    </void>
+    <void method="add">
+     <object class="com.jformdesigner.model.FormNonVisual">
+      <string>javax.swing.ButtonGroup</string>
+      <void property="name">
+       <string>buttonGroup1</string>
+      </void>
+     </object>
+     <object class="com.jformdesigner.model.FormLayoutConstraints">
+      <null/>
+      <void method="setProperty">
+       <string>location</string>
+       <object class="java.awt.Point">
+        <int>0</int>
+        <int>316</int>
+       </object>
+      </void>
+     </object>
+    </void>
+   </object>
+  </void>
+ </object>
+</java>

--- a/src/org/broad/igv/ui/util/ConvertOptions.java
+++ b/src/org/broad/igv/ui/util/ConvertOptions.java
@@ -1,0 +1,34 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2007-2015 Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+
+package org.broad.igv.ui.util;
+
+public class ConvertOptions {
+    public boolean doConvert = false;
+    public String chrom = "";
+    public String strand = "+";
+    public int start = 1;
+}


### PR DESCRIPTION
This PR is mainly aimed at simplifying loading RNA base pair info or chemical probing data from other programs.

Added semi-automated file conversion on load for
.ct (connectivity table format),
.db/.dbn (dot-bracket notation),
.dp (pairing probability)
.shape/.map (chemical probing reactivity profile)

Upon attempting to open a file with one of these extensions, a dialog appears allowing the user to select the applicable chromosome and specify a new strand and start coordinate if needed (this information is typically not present in any of these input file formats, since they focus on single RNAs). A new file is written (.bp for base pair structure info or .wig for reactivity profile), then that file is loaded.

It's not perfect, but I think this will simplify things so people don't have to run separate scripts.

- Steve Busan

