### PR TITLE
Avoid mismatches in zero quality columns

### DIFF
--- a/src/org/broad/igv/sam/BaseAlignmentCounts.java
+++ b/src/org/broad/igv/sam/BaseAlignmentCounts.java
@@ -206,7 +206,6 @@ abstract public class BaseAlignmentCounts implements AlignmentCounts {
         Set<Integer> filteredSnps = knownSnps == null ? null : knownSnps.get(chr);
 
         if (filteredSnps == null || !filteredSnps.contains(pos + 1)) {
-
             float threshold = snpThreshold * (qualityWeight ? getTotalQuality(pos) : getTotalCount(pos));
             float mismatchQualitySum = 0;
 
@@ -218,7 +217,7 @@ abstract public class BaseAlignmentCounts implements AlignmentCounts {
                     }
 
                 }
-                return mismatchQualitySum >= threshold;
+                return (mismatchQualitySum >= threshold) && (threshold > 0); // (threshold > 0) avoids mismatch call in columns with all 0 quality
             }
         }
         return false;


### PR DESCRIPTION
When the "Quality weight allele fraction" option is selected, columns
in which all reads have 0 quality value were always shown as mismatch,
even if the reads had the reference basepair.  This change explicitly
avoids calling a mismatch in 0 quality columns.

Before this change, in a BAM file where all quality scores are 0, the coverage track looks like:
![allvar](https://cloud.githubusercontent.com/assets/7155109/21209958/69e38880-c22c-11e6-88c3-b4cb0836dd70.png)

With the modification, the coverage track looks like:
![novar](https://cloud.githubusercontent.com/assets/7155109/21209966/7a87c14c-c22c-11e6-8494-a0f3407ee60a.png)

