### PR TITLE
Add Ctrl+L and Cmd+L hotkey to focus on search box

### DIFF
--- a/src/org/broad/igv/ui/IGV.java
+++ b/src/org/broad/igv/ui/IGV.java
@@ -489,6 +489,11 @@ public class IGV implements IGVEventObserver {
         return contentPane.getCommandBar().getSelectableGenomeIDs();
     }
 
+    // Set the focus on the command bar search box
+    public void focusSearchBox() {
+        contentPane.getCommandBar().focusSearchBox();
+    }
+
 
     public void doDefineGenome(javax.swing.ProgressMonitor monitor) {
 

--- a/src/org/broad/igv/ui/IGVCommandBar.java
+++ b/src/org/broad/igv/ui/IGVCommandBar.java
@@ -647,7 +647,7 @@ public class IGVCommandBar extends javax.swing.JPanel implements IGVEventObserve
         locationPanel.add(Box.createHorizontalStrut(5), JideBoxLayout.FIX);
 
         searchTextField = new JTextField();
-        searchTextField.setToolTipText("Enter a gene of locus, e.f. EGFR,   chr1,   or chr1:100,000-200,000");
+        searchTextField.setToolTipText("Enter a gene or locus, e.f. EGFR,   chr1,   or chr1:100,000-200,000");
         searchTextField.setMaximumSize(new java.awt.Dimension(250, 15));
         searchTextField.setMinimumSize(new java.awt.Dimension(100, 28));
         searchTextField.setPreferredSize(new java.awt.Dimension(230, 28));

--- a/src/org/broad/igv/ui/IGVCommandBar.java
+++ b/src/org/broad/igv/ui/IGVCommandBar.java
@@ -941,6 +941,11 @@ public class IGVCommandBar extends javax.swing.JPanel implements IGVEventObserve
         }
     }
 
+    // Set the focus in the search box
+    public void focusSearchBox() {
+        searchTextField.requestFocusInWindow();
+    }
+
     private void goButtonActionPerformed(java.awt.event.ActionEvent evt) {    // GEN-FIRST:event_goButtonActionPerformed
         String searchText = searchTextField.getText();
         searchByLocus(searchText);

--- a/src/org/broad/igv/ui/event/GlobalKeyDispatcher.java
+++ b/src/org/broad/igv/ui/event/GlobalKeyDispatcher.java
@@ -151,6 +151,18 @@ public class GlobalKeyDispatcher implements KeyEventDispatcher {
         inputMap.put(prevExonKey, "prevExon");
         actionMap.put("prevExon", prevExonAction);
 
+        // Set the focus to the "search" box
+        final KeyStroke searchBoxKeyCtrl = KeyStroke.getKeyStroke(KeyEvent.VK_L, KeyEvent.CTRL_MASK, false);
+        final KeyStroke searchBoxKeyMeta = KeyStroke.getKeyStroke(KeyEvent.VK_L, KeyEvent.META_MASK, false);
+        final Action searchBoxAction = new EnableWrappedAction(new AbstractAction() {
+            public void actionPerformed(ActionEvent e) {
+                igv.focusSearchBox();
+            };
+        });
+        inputMap.put(searchBoxKeyCtrl, "focusSearch");
+        inputMap.put(searchBoxKeyMeta, "focusSearch");
+        actionMap.put("focusSearch", searchBoxAction);
+
         // Show extras menu
         final KeyStroke extrasKey = KeyStroke.getKeyStroke(KeyEvent.VK_T, KeyEvent.ALT_MASK, false);
         final Action extrasAction = new EnableWrappedAction(new AbstractAction() {


### PR DESCRIPTION
Add Ctrl+L and Cmd+L hotkeys to set the cursor focus in the gene/locus
search box as is standard in web browsers.