### PR TITLE
Amw highlight read clipping

### DIFF
--- a/src/org/broad/igv/PreferenceManager.java
+++ b/src/org/broad/igv/PreferenceManager.java
@@ -130,6 +130,9 @@ public class PreferenceManager implements PropertyManager {
 
     public static final String SAM_FLAG_LARGE_INDELS = "SAM.FLAG_LARGE_INDELS";
     public static final String SAM_LARGE_INDELS_THRESHOLD = "SAM.LARGE_INSERTIONS_THRESOLD";
+    
+    public static final String SAM_FLAG_CLIPPING = "SAM.FLAG_CLIPPING";
+    public static final String SAM_CLIPPING_THRESHOLD = "SAM.CLIPPING_THRESHOLD";
 
     public static final String SAM_SHOW_GROUP_SEPARATOR = "SAM.SHOW_GROUP_SEPARATOR";
     public static final String SAM_COMPLETE_READS_ONLY = "SAM.COMPLETE_READS_ONLY";
@@ -1090,6 +1093,8 @@ public class PreferenceManager implements PropertyManager {
         defaultValues.put(SAM_COUNT_DELETED_BASES_COVERED, "false");
         defaultValues.put(SAM_FLAG_LARGE_INDELS, "false");
         defaultValues.put(SAM_LARGE_INDELS_THRESHOLD, "1");
+        defaultValues.put(SAM_FLAG_CLIPPING, "false");
+        defaultValues.put(SAM_CLIPPING_THRESHOLD, "0");
         defaultValues.put(SAM_SORT_OPTION, "NUCLEOTIDE");
         defaultValues.put(SAM_SHOW_GROUP_SEPARATOR, "true");
         defaultValues.put(SAM_COMPLETE_READS_ONLY, "false");

--- a/src/org/broad/igv/sam/AlignmentRenderer.java
+++ b/src/org/broad/igv/sam/AlignmentRenderer.java
@@ -668,6 +668,7 @@ public class AlignmentRenderer implements FeatureRenderer {
             outlineGraphics = context.getGraphic2DForColor(OUTLINE_COLOR);
         }
 
+        // Get a graphics context for drawing clipping indicators.
         Graphics2D clippedGraphics = context.getGraphic2DForColor(clippedColor);
         clippedGraphics.setStroke(new BasicStroke(1.5f));
 
@@ -687,9 +688,12 @@ public class AlignmentRenderer implements FeatureRenderer {
         AlignmentBlock firstBlock = blocks[0], lastBlock = blocks[blocks.length - 1];
         int alignmentChromStart = (int) firstBlock.getStart(),
                 alignmentChromEnd = (int) (lastBlock.getStart() + lastBlock.getLength());
+        /* Clipping */
+        boolean flagClipping = prefs.getAsBoolean(PreferenceManager.SAM_FLAG_CLIPPING);
+        int clippingThreshold = prefs.getAsInt(PreferenceManager.SAM_CLIPPING_THRESHOLD);
         int[] clipping = SAMAlignment.getClipping(alignment.getCigarString());
-        boolean leftClipped = (clipping[0] + clipping[1]) > 0;
-        boolean rightClipped = (clipping[2] + clipping[3]) > 0;
+        boolean leftClipped = flagClipping && ((clipping[0] + clipping[1]) > clippingThreshold);
+        boolean rightClipped = flagClipping && ((clipping[2] + clipping[3]) > clippingThreshold);
 
         // BED-style coordinate for the visible context.  Do not draw outside the context.
         int contextChromStart = (int) context.getOrigin(),

--- a/src/org/broad/igv/sam/AlignmentRenderer.java
+++ b/src/org/broad/igv/sam/AlignmentRenderer.java
@@ -67,6 +67,9 @@ public class AlignmentRenderer implements FeatureRenderer {
     private static Color largeISizeColor = new Color(150, 0, 0);
     private static final Color OUTLINE_COLOR = new Color(185, 185, 185);
 
+    // Clipping colors
+    private static Color clippedColor = new Color(255, 20, 147);
+
     // Indel colors
     private static Color purple = new Color(118, 24, 220);
     private static Color deletionColor = Color.black;
@@ -534,11 +537,11 @@ public class AlignmentRenderer implements FeatureRenderer {
     /**
      * Draw a single ungapped block in an alignment.
      */
-    private void drawAlignmentBlock(Graphics2D blockGraphics, Graphics2D outlineGraphics,
+    private void drawAlignmentBlock(Graphics2D blockGraphics, Graphics2D outlineGraphics, Graphics2D clippedGraphics,
                                     boolean isNegativeStrand, int alignmentChromStart,
                                     int alignmentChromEnd, int blockChromStart, int blockChromEnd,
                                     int blockPxStart, int blockPxWidth, int y, int h, double locSale,
-                                    boolean overlapped) {
+                                    boolean overlapped, boolean leftClipped, boolean rightClipped) {
 
         if (blockPxWidth == 0) {
             return;
@@ -549,7 +552,6 @@ public class AlignmentRenderer implements FeatureRenderer {
         boolean leftmost = (blockChromStart == alignmentChromStart),
                 rightmost = (blockChromEnd == alignmentChromEnd),
                 tallEnoughForArrow = h > 8;
-
 
         if (h == 1) {
             blockGraphics.drawLine(blockPxStart, y, blockPxEnd, y);
@@ -580,6 +582,14 @@ public class AlignmentRenderer implements FeatureRenderer {
             blockGraphics.fill(blockShape);
             if (outlineGraphics != null) {
                 outlineGraphics.draw(blockShape);
+            }
+            if (leftmost && leftClipped) {
+                clippedGraphics.drawLine(xPoly[0], yPoly[0], xPoly[1], yPoly[1]);
+                clippedGraphics.drawLine(xPoly[5], yPoly[5], xPoly[0], yPoly[0]);
+            }
+            if (rightmost && rightClipped) {
+                clippedGraphics.drawLine(xPoly[2], yPoly[2], xPoly[3], yPoly[3]);
+                clippedGraphics.drawLine(xPoly[3], yPoly[3], xPoly[4], yPoly[4]);
             }
         }
 
@@ -658,6 +668,8 @@ public class AlignmentRenderer implements FeatureRenderer {
             outlineGraphics = context.getGraphic2DForColor(OUTLINE_COLOR);
         }
 
+        Graphics2D clippedGraphics = context.getGraphic2DForColor(clippedColor);
+        clippedGraphics.setStroke(new BasicStroke(1.5f));
 
         // Define a graphics context for indel labels.
         Graphics2D largeIndelGraphics = context.getGraphics2D("INDEL_LABEL");
@@ -675,6 +687,9 @@ public class AlignmentRenderer implements FeatureRenderer {
         AlignmentBlock firstBlock = blocks[0], lastBlock = blocks[blocks.length - 1];
         int alignmentChromStart = (int) firstBlock.getStart(),
                 alignmentChromEnd = (int) (lastBlock.getStart() + lastBlock.getLength());
+        int[] clipping = SAMAlignment.getClipping(alignment.getCigarString());
+        boolean leftClipped = (clipping[0] + clipping[1]) > 0;
+        boolean rightClipped = (clipping[2] + clipping[3]) > 0;
 
         // BED-style coordinate for the visible context.  Do not draw outside the context.
         int contextChromStart = (int) context.getOrigin(),
@@ -712,9 +727,9 @@ public class AlignmentRenderer implements FeatureRenderer {
                         blockChromEnd = gapChromStart,
                         blockPxWidth = (int) Math.max(1, (blockChromEnd - blockChromStart) / locScale - 1),
                         blockPxEnd = blockPxStart + blockPxWidth;
-                drawAlignmentBlock(g, outlineGraphics, alignment.isNegativeStrand(),
+                drawAlignmentBlock(g, outlineGraphics, clippedGraphics, alignment.isNegativeStrand(),
                         alignmentChromStart, alignmentChromEnd, blockChromStart, blockChromEnd,
-                        blockPxStart, blockPxWidth, y, h, locScale, overlapped);
+                        blockPxStart, blockPxWidth, y, h, locScale, overlapped, leftClipped, rightClipped);
 
 
                 // Draw the gap line.
@@ -745,9 +760,9 @@ public class AlignmentRenderer implements FeatureRenderer {
         int blockPxStart = (int) ((blockChromStart - contextChromStart) / locScale),
                 blockChromEnd = (int) Math.min(contextChromEnd, alignmentChromEnd),
                 blockPxWidth = (int) Math.max(1, (blockChromEnd - blockChromStart) / locScale - 1);
-        drawAlignmentBlock(g, outlineGraphics, alignment.isNegativeStrand(),
+        drawAlignmentBlock(g, outlineGraphics, clippedGraphics, alignment.isNegativeStrand(),
                 alignmentChromStart, alignmentChromEnd, blockChromStart, blockChromEnd,
-                blockPxStart, blockPxWidth, y, h, locScale, overlapped);
+                blockPxStart, blockPxWidth, y, h, locScale, overlapped, leftClipped, rightClipped);
 
         // Draw insertions.
         drawInsertions(rowRect, alignment, context, renderOptions);
@@ -844,7 +859,6 @@ public class AlignmentRenderer implements FeatureRenderer {
         } else if (bisulfiteMode) {
             bisinfo = new BisulfiteBaseInfo(reference, baseAlignment, block, renderOptions.bisulfiteContext);
         }
-
 
         for (int loc = start; loc < end; loc++) {
             int idx = loc - start;

--- a/src/org/broad/igv/sam/SAMAlignment.java
+++ b/src/org/broad/igv/sam/SAMAlignment.java
@@ -1015,7 +1015,7 @@ public abstract class SAMAlignment implements Alignment {
     }
 
 
-    private int[] getClipping(String cigarString) {
+    public static int[] getClipping(String cigarString) {
         // Identify the number of hard and soft clipped bases.
         Matcher lclipMatcher = Pattern.compile("^(([0-9]+)H)?(([0-9]+)S)?").matcher(cigarString);
         Matcher rclipMatcher = Pattern.compile("(([0-9]+)S)?(([0-9]+)H)?$").matcher(cigarString);

--- a/src/org/broad/igv/ui/PreferencesEditor.java
+++ b/src/org/broad/igv/ui/PreferencesEditor.java
@@ -262,6 +262,10 @@ public class PreferencesEditor extends javax.swing.JDialog {
         samFlagIndelsCB = new JCheckBox();
         samFlagIndelsThresholdField = new JTextField();
         label31 = new JLabel();
+        panel10clip = new JPanel();
+        samFlagClippingCB = new JCheckBox();
+        samFlagClippingThresholdField = new JTextField();
+        label31clip = new JLabel();
         panel9 = new JPanel();
         hideIndelsBasesCB = new JCheckBox();
         hideIndelsBasesField = new JTextField();
@@ -1175,7 +1179,7 @@ public class PreferencesEditor extends javax.swing.JDialog {
 
                                 //======== panel13 ========
                                 {
-                                    panel13.setLayout(new GridLayout(6, 0));
+                                    panel13.setLayout(new GridLayout(7, 0));
 
                                     //======== panel31 ========
                                     {
@@ -1324,9 +1328,8 @@ public class PreferencesEditor extends javax.swing.JDialog {
                                         //---- samFlagIndelsThresholdField ----
                                         samFlagIndelsThresholdField.setPreferredSize(new Dimension(60, 26));
                                         samFlagIndelsThresholdField.addActionListener(e -> {
-			samFlagIndelsThresholdFieldActionPerformed(e);
-			samFlagIndelsThresholdFieldActionPerformed(e);
-		});
+                                            samFlagIndelsThresholdFieldActionPerformed(e);
+                                        });
                                         samFlagIndelsThresholdField.addFocusListener(new FocusAdapter() {
                                             @Override
                                             public void focusLost(FocusEvent e) {
@@ -1340,6 +1343,35 @@ public class PreferencesEditor extends javax.swing.JDialog {
                                         panel10.add(label31);
                                     }
                                     panel13.add(panel10);
+
+                                    //======== panel10clip ========
+                                    {
+                                        panel10clip.setBorder(null);
+                                        panel10clip.setLayout(new FlowLayout(FlowLayout.LEFT, 0, 5));
+
+                                        //---- samFlagClippingCB ----
+                                        samFlagClippingCB.setText("Flag clipping > ");
+                                        samFlagClippingCB.addActionListener(e -> samFlagClippingCBActionPerformed(e));
+                                        panel10clip.add(samFlagClippingCB);
+
+                                        //---- samFlagClippingThresholdField ----
+                                        samFlagClippingThresholdField.setPreferredSize(new Dimension(60, 26));
+                                        samFlagClippingThresholdField.addActionListener(e -> {
+                                            samFlagClippingThresholdFieldActionPerformed(e);
+                                        });
+                                        samFlagClippingThresholdField.addFocusListener(new FocusAdapter() {
+                                            @Override
+                                            public void focusLost(FocusEvent e) {
+                                                samFlagClippingThresholdFieldFocusLost(e);
+                                            }
+                                        });
+                                        panel10clip.add(samFlagClippingThresholdField);
+
+                                        //---- label31clip ----
+                                        label31clip.setText(" bases");
+                                        panel10clip.add(label31clip);
+                                    }
+                                    panel13.add(panel10clip);
 
                                     //======== panel9 ========
                                     {
@@ -2813,6 +2845,32 @@ public class PreferencesEditor extends javax.swing.JDialog {
         }
     }
 
+    private void samFlagClippingCBActionPerformed(ActionEvent e) {
+        final boolean flagClipping = samFlagClippingCB.isSelected();
+        updatedPreferenceMap.put(PreferenceManager.SAM_FLAG_CLIPPING, String.valueOf(flagClipping));
+        samFlagClippingThresholdField.setEnabled(flagClipping);
+    }
+
+
+    private void samFlagClippingThresholdFieldFocusLost(FocusEvent e) {
+        samFlagClippingThresholdFieldActionPerformed(null);
+    }
+
+    private void samFlagClippingThresholdFieldActionPerformed(ActionEvent e) {
+        String clippingThreshold = samFlagClippingThresholdField.getText().trim();
+        try {
+            int tmp = Integer.parseInt(clippingThreshold);
+            if (tmp < 0) {
+                inputValidated = false;
+                MessageUtils.showMessage("Clipping threshold must be a non-negative integer.");
+            } else {
+                updatedPreferenceMap.put(PreferenceManager.SAM_CLIPPING_THRESHOLD, clippingThreshold);
+            }
+        } catch (NumberFormatException numberFormatException) {
+            inputValidated = false;
+            MessageUtils.showMessage("Clipping threshold must be a non-negative integer.");
+        }
+    }
 
     private void hideIndelsBasesCBActionPerformed(ActionEvent e) {
         final boolean flagInsertions = hideIndelsBasesCB.isSelected();
@@ -3904,6 +3962,10 @@ public class PreferencesEditor extends javax.swing.JDialog {
         samFlagIndelsThresholdField.setText(prefMgr.get(PreferenceManager.SAM_LARGE_INDELS_THRESHOLD));
         samFlagIndelsThresholdField.setEnabled(samFlagIndelsCB.isSelected());
 
+        samFlagClippingCB.setSelected(prefMgr.getAsBoolean(PreferenceManager.SAM_FLAG_CLIPPING));
+        samFlagClippingThresholdField.setText(prefMgr.get(PreferenceManager.SAM_CLIPPING_THRESHOLD));
+        samFlagClippingThresholdField.setEnabled(samFlagClippingCB.isSelected());
+
         hideIndelsBasesCB.setSelected(prefMgr.getAsBoolean(PreferenceManager.SAM_HIDE_SMALL_INDEL_BP));
         hideIndelsBasesField.setText(prefMgr.get(PreferenceManager.SAM_SMALL_INDEL_BP_THRESHOLD));
         hideIndelsBasesField.setEnabled(hideIndelsBasesCB.isSelected());
@@ -4105,6 +4167,10 @@ public class PreferencesEditor extends javax.swing.JDialog {
     private JCheckBox samFlagIndelsCB;
     private JTextField samFlagIndelsThresholdField;
     private JLabel label31;
+    private JPanel panel10clip;
+    private JCheckBox samFlagClippingCB;
+    private JTextField samFlagClippingThresholdField;
+    private JLabel label31clip;
     private JPanel panel9;
     private JCheckBox hideIndelsBasesCB;
     private JTextField hideIndelsBasesField;

--- a/src/org/broad/igv/ui/PreferencesEditor.jfd
+++ b/src/org/broad/igv/ui/PreferencesEditor.jfd
@@ -3753,6 +3753,100 @@
                         <int>0</int>
                        </void>
                       </object>
+                      <void method="setProperty">
+                       <string>border</string>
+                       <object class="com.jformdesigner.model.FormObject" field="NULL_VALUE"/>
+                      </void>
+                      <void property="name">
+                       <string>panel10clip</string>
+                      </void>
+                      <void method="add">
+                       <object class="com.jformdesigner.model.FormComponent">
+                        <string>javax.swing.JCheckBox</string>
+                        <void method="setProperty">
+                         <string>text</string>
+                         <string>Flag clipping &gt; </string>
+                        </void>
+                        <void property="name">
+                         <string>samFlagClippingCB</string>
+                        </void>
+                        <void method="addEvent">
+                         <object class="com.jformdesigner.model.FormEvent">
+                          <string>java.awt.event.ActionListener</string>
+                          <string>actionPerformed</string>
+                          <string>samFlagClippingCBActionPerformed</string>
+                          <boolean>true</boolean>
+                         </object>
+                        </void>
+                       </object>
+                      </void>
+                      <void method="add">
+                       <object class="com.jformdesigner.model.FormComponent">
+                        <string>javax.swing.JTextField</string>
+                        <void method="setProperty">
+                         <string>preferredSize</string>
+                         <object class="java.awt.Dimension">
+                          <int>60</int>
+                          <int>26</int>
+                         </object>
+                        </void>
+                        <void property="name">
+                         <string>samFlagClippingThresholdField</string>
+                        </void>
+                        <void method="addEvent">
+                         <object class="com.jformdesigner.model.FormEvent">
+                          <string>java.awt.event.ActionListener</string>
+                          <string>actionPerformed</string>
+                          <string>samFlagClippingThresholdFieldActionPerformed</string>
+                          <boolean>true</boolean>
+                         </object>
+                        </void>
+                        <void method="addEvent">
+                         <object class="com.jformdesigner.model.FormEvent">
+                          <string>java.awt.event.FocusListener</string>
+                          <string>focusLost</string>
+                          <string>samFlagClippingThresholdFieldFocusLost</string>
+                          <boolean>true</boolean>
+                         </object>
+                        </void>
+                        <void method="addEvent">
+                         <object class="com.jformdesigner.model.FormEvent">
+                          <string>java.awt.event.ActionListener</string>
+                          <string>actionPerformed</string>
+                          <string>samFlagClippingThresholdFieldActionPerformed</string>
+                          <boolean>true</boolean>
+                         </object>
+                        </void>
+                       </object>
+                      </void>
+                      <void method="add">
+                       <object class="com.jformdesigner.model.FormComponent">
+                        <string>javax.swing.JLabel</string>
+                        <void method="setProperty">
+                         <string>text</string>
+                         <string> bases</string>
+                        </void>
+                        <void property="name">
+                         <string>label31clip</string>
+                        </void>
+                       </object>
+                      </void>
+                     </object>
+                    </void>
+                    <void method="add">
+                     <object class="com.jformdesigner.model.FormContainer">
+                      <string>javax.swing.JPanel</string>
+                      <object class="com.jformdesigner.model.FormLayoutManager">
+                       <class>java.awt.FlowLayout</class>
+                       <void method="setProperty">
+                        <string>alignment</string>
+                        <int>0</int>
+                       </void>
+                       <void method="setProperty">
+                        <string>hgap</string>
+                        <int>0</int>
+                       </void>
+                      </object>
                       <void property="name">
                        <string>panel9</string>
                       </void>


### PR DESCRIPTION
Highlight read clipping, which often indicates a structural variant, with a pink
mark at the edges of read alignment that are clipped by more than a specified
number of basepairs.

As an example, here is the same data on the left and right with clipping >5bp
highlighted on the right.  The clipped reads mark 4 structural variant breakpoints.
![show-read-clipping](https://cloud.githubusercontent.com/assets/7155109/21255285/cd28bcbe-c31f-11e6-9122-e0d18b3a4c80.png)


Address idea 4 from #277.