### PR TITLE
Select all text in search box upon Ctrl/Cmd+L

### DIFF
--- a/src/org/broad/igv/ui/IGVCommandBar.java
+++ b/src/org/broad/igv/ui/IGVCommandBar.java
@@ -944,6 +944,7 @@ public class IGVCommandBar extends javax.swing.JPanel implements IGVEventObserve
     // Set the focus in the search box
     public void focusSearchBox() {
         searchTextField.requestFocusInWindow();
+        searchTextField.selectAll();
     }
 
     private void goButtonActionPerformed(java.awt.event.ActionEvent evt) {    // GEN-FIRST:event_goButtonActionPerformed


### PR DESCRIPTION
To more closely match web browser Ctrl+L behavior, select all of
the text in the search box when Ctrl+L is pressed while in the box.