### PR TITLE
Improve alignment display in "squished" mode

### DIFF
--- a/src/org/broad/igv/sam/AlignmentRenderer.java
+++ b/src/org/broad/igv/sam/AlignmentRenderer.java
@@ -776,7 +776,7 @@ public class AlignmentRenderer implements FeatureRenderer {
                 blockPxStart, blockPxWidth, y, h, locScale, overlapped, leftClipped, rightClipped);
 
         // Draw insertions.
-        drawInsertions(rowRect, alignment, context, renderOptions, alignmentCounts);
+        drawInsertions(rowRect, alignment, context, renderOptions, alignmentCounts, leaveMargin);
 
         // Draw basepairs / mismatches.
         if (locScale < 100) {
@@ -1007,7 +1007,7 @@ public class AlignmentRenderer implements FeatureRenderer {
         g.fillRect(pxLeft, pxTop, pxRight - pxLeft, pxH);
 
         // TODO -- record this "object" for popup text
-        if (isInsertion) {
+        if (isInsertion && pxH > 5) {
             g.fillRect(pxLeft - pxWing, pxTop, pxRight - pxLeft + 2 * pxWing, 2);
             g.fillRect(pxLeft - pxWing, pxTop + pxH - 2, pxRight - pxLeft + 2 * pxWing, 2);
         } // draw "wings" For insertions
@@ -1021,7 +1021,7 @@ public class AlignmentRenderer implements FeatureRenderer {
     }
 
     private void drawInsertions(Rectangle rect, Alignment alignment, RenderContext context, RenderOptions renderOptions,
-                                AlignmentCounts alignmentCounts) {
+                                AlignmentCounts alignmentCounts, boolean leaveMargin) {
 
         AlignmentBlock[] insertions = alignment.getInsertions();
         double origin = context.getOrigin();
@@ -1043,8 +1043,8 @@ public class AlignmentRenderer implements FeatureRenderer {
                 int x = (int) ((aBlock.getStart() - origin) / locScale);
                 int bpWidth = aBlock.getBases().length;
                 double pxWidthExact = ((double) bpWidth) / locScale;
-                int h = (int) Math.max(1, rect.getHeight() - 2);
-                int y = (int) (rect.getY() + (rect.getHeight() - h) / 2) - 1;
+                int h = (int) Math.max(1, rect.getHeight() - (leaveMargin ? 2 : 0));
+                int y = (int) (rect.getY() + (rect.getHeight() - h) / 2) - (leaveMargin ? 1 : 0);
 
                 // Don't draw out of clipping rect
                 if (x > rect.getMaxX()) {

--- a/src/org/broad/igv/sam/AlignmentRenderer.java
+++ b/src/org/broad/igv/sam/AlignmentRenderer.java
@@ -267,6 +267,8 @@ public class AlignmentRenderer implements FeatureRenderer {
 
         g = context.getGraphics2D("BASE");
 
+        g = context.getGraphics2D("STRAND");
+        g.setColor(Color.DARK_GRAY);
     }
 
     /**
@@ -535,7 +537,8 @@ public class AlignmentRenderer implements FeatureRenderer {
     /**
      * Draw a single ungapped block in an alignment.
      */
-    private void drawAlignmentBlock(Graphics2D blockGraphics, Graphics2D outlineGraphics, Graphics2D clippedGraphics,
+    private void drawAlignmentBlock(Graphics2D blockGraphics, Graphics2D outlineGraphics,
+                                    Graphics2D clippedGraphics, Graphics2D strandGraphics,
                                     boolean isNegativeStrand, int alignmentChromStart,
                                     int alignmentChromEnd, int blockChromStart, int blockChromEnd,
                                     int blockPxStart, int blockPxWidth, int y, int h, double locSale,
@@ -594,13 +597,12 @@ public class AlignmentRenderer implements FeatureRenderer {
         // If the block is too small for a pointed hexagon arrow, then indicate strand with a line.
         if (!tallEnoughForArrow) {
             int tH = Math.max(1, h - 1);
+
             if (leftmost && isNegativeStrand) {
-                blockGraphics.setColor(Color.DARK_GRAY);
-                blockGraphics.drawLine(blockPxStart, y, blockPxStart, y + tH);
+                strandGraphics.drawLine(blockPxStart, y, blockPxStart, y + tH);
             }
             if (rightmost && !isNegativeStrand) {
-                blockGraphics.setColor(Color.DARK_GRAY);
-                blockGraphics.drawLine(blockPxEnd, y, blockPxEnd, y + tH);
+                strandGraphics.drawLine(blockPxEnd, y, blockPxEnd, y + tH);
             }
         }
     }
@@ -669,6 +671,9 @@ public class AlignmentRenderer implements FeatureRenderer {
         Graphics2D clippedGraphics = context.getGraphic2DForColor(clippedColor);
         clippedGraphics.setStroke(new BasicStroke(1.5f));
 
+        // Get a graphics context for drawing strand indicators.
+        Graphics2D strandGraphics = context.getGraphics2D("STRAND");
+
         // Define a graphics context for indel labels.
         Graphics2D largeIndelGraphics = context.getGraphics2D("INDEL_LABEL");
         largeIndelGraphics.setFont(FontManager.getFont(Font.BOLD, h - 2));
@@ -733,7 +738,7 @@ public class AlignmentRenderer implements FeatureRenderer {
                         blockChromEnd = gapChromStart,
                         blockPxWidth = (int) Math.max(1, (blockChromEnd - blockChromStart) / locScale - 1),
                         blockPxEnd = blockPxStart + blockPxWidth;
-                drawAlignmentBlock(g, outlineGraphics, clippedGraphics, alignment.isNegativeStrand(),
+                drawAlignmentBlock(g, outlineGraphics, clippedGraphics, strandGraphics, alignment.isNegativeStrand(),
                         alignmentChromStart, alignmentChromEnd, blockChromStart, blockChromEnd,
                         blockPxStart, blockPxWidth, y, h, locScale, overlapped, leftClipped, rightClipped);
 
@@ -766,7 +771,7 @@ public class AlignmentRenderer implements FeatureRenderer {
         int blockPxStart = (int) ((blockChromStart - contextChromStart) / locScale),
                 blockChromEnd = (int) Math.min(contextChromEnd, alignmentChromEnd),
                 blockPxWidth = (int) Math.max(1, (blockChromEnd - blockChromStart) / locScale - 1);
-        drawAlignmentBlock(g, outlineGraphics, clippedGraphics, alignment.isNegativeStrand(),
+        drawAlignmentBlock(g, outlineGraphics, clippedGraphics, strandGraphics, alignment.isNegativeStrand(),
                 alignmentChromStart, alignmentChromEnd, blockChromStart, blockChromEnd,
                 blockPxStart, blockPxWidth, y, h, locScale, overlapped, leftClipped, rightClipped);
 

--- a/src/org/broad/igv/sam/AlignmentRenderer.java
+++ b/src/org/broad/igv/sam/AlignmentRenderer.java
@@ -669,7 +669,9 @@ public class AlignmentRenderer implements FeatureRenderer {
 
         // Get a graphics context for drawing clipping indicators.
         Graphics2D clippedGraphics = context.getGraphic2DForColor(clippedColor);
-        clippedGraphics.setStroke(new BasicStroke(1.5f));
+        if (h > 5) {
+            clippedGraphics.setStroke(new BasicStroke(1.5f));
+        }
 
         // Get a graphics context for drawing strand indicators.
         Graphics2D strandGraphics = context.getGraphics2D("STRAND");
@@ -745,16 +747,18 @@ public class AlignmentRenderer implements FeatureRenderer {
 
                 // Draw the gap line.
                 Graphics2D gapGraphics = context.getGraphics2D("GAP");
+                int ggOffset = 0;
                 if (gap.getType() == SAMAlignment.UNKNOWN) {
                     gapGraphics.setColor(unknownGapColor);
                 } else if (gap.getType() == SAMAlignment.SKIPPED_REGION) {
                     gapGraphics.setColor(skippedColor);
-                } else {
+                } else if (h > 5) {
                     gapGraphics = context.getGraphics2D("THICK_STROKE");
                     gapGraphics.setColor(deletionColor);
+                    ggOffset = 0;
                 }
 
-                gapGraphics.drawLine(blockPxEnd + 1, y + h / 2, gapPxEnd, y + h / 2);
+                gapGraphics.drawLine(blockPxEnd + ggOffset, y + h / 2, gapPxEnd - ggOffset, y + h / 2);
 
 
                 // Label the size of the deletion if it is "large" and the label fits.

--- a/src/org/broad/igv/sam/AlignmentRenderer.java
+++ b/src/org/broad/igv/sam/AlignmentRenderer.java
@@ -986,11 +986,12 @@ public class AlignmentRenderer implements FeatureRenderer {
 
         final int pxPad = 2;   // text padding in the label
         final int pxWing = 2;  // width of the cursor "wing"
+        final int minTextHeight = 8; // min height to draw text
 
         // Calculate the width required to draw the label
         Rectangle2D textBounds = g.getFontMetrics().getStringBounds(labelText, g);
         int pxTextW = 2 * pxPad + (int) textBounds.getWidth();
-        boolean doesTextFit = (pxTextW < pxWmax);
+        boolean doesTextFit = (pxH >= minTextHeight) && (pxTextW < pxWmax);
 
         if (!doesTextFit && !isInsertion) {
             return;

--- a/src/org/broad/igv/sam/AlignmentTrack.java
+++ b/src/org/broad/igv/sam/AlignmentTrack.java
@@ -163,7 +163,7 @@ public class AlignmentTrack extends AbstractTrack implements AlignmentTrackEvent
     private RenderOptions renderOptions = new RenderOptions();
 
     private int expandedHeight = 14;
-    private int maxSquishedHeight = 4;
+    private int maxSquishedHeight = 5;
     private int squishedHeight = maxSquishedHeight;
     private FeatureRenderer renderer;
 


### PR DESCRIPTION
Improve the display of alignments in "squished" mode:
1. Fix a bug with improper coloring of terminal alignment blocks as dark gray.
2. Drop indel size labels that are not legible in squished mode.
3. Drop the wings of the insertion "I" shape, which is not visible in squished mode.
4. Account for the lack of a margin when drawing insertion labels.
5. Use a thin gap line instead of a thick stroke.
6. Increase the "max squished height" from 4px to 5px to allow vertical centering of gap lines.

![squish-changes](https://cloud.githubusercontent.com/assets/7155109/21663950/3af4ba5e-d298-11e6-86f0-48128a9b11d3.png)
