### PR TITLE
Add BAM alignment track "collapsed" mode

### DIFF
--- a/src/org/broad/igv/sam/AlignmentRenderer.java
+++ b/src/org/broad/igv/sam/AlignmentRenderer.java
@@ -678,7 +678,7 @@ public class AlignmentRenderer implements FeatureRenderer {
 
         // Define a graphics context for indel labels.
         Graphics2D largeIndelGraphics = context.getGraphics2D("INDEL_LABEL");
-        largeIndelGraphics.setFont(FontManager.getFont(Font.BOLD, h-1));
+        largeIndelGraphics.setFont(FontManager.getFont(Font.BOLD, h-2));
 
         // Get a graphics context for drawing individual basepairs.
         Graphics2D bpGraphics = context.getGraphics2D("BASE");
@@ -941,7 +941,7 @@ public class AlignmentRenderer implements FeatureRenderer {
                           DisplayStatus bisstatus) {
         if (((dY >= 12) && (dX >= dY)) && (!bisulfiteMode || (bisulfiteMode && bisstatus.equals(DisplayStatus.CHARACTER)))) {
             g.setColor(color);
-            GraphicUtils.drawCenteredText(new char[]{c}, pX, pY-1, dX, dY, g);
+            GraphicUtils.drawCenteredText(new char[]{c}, pX, pY, dX, dY, g);
         } else {
 
             int pX0i = pX, dXi = dX;
@@ -987,7 +987,7 @@ public class AlignmentRenderer implements FeatureRenderer {
                                      int pxTop, int pxH, int pxWmax, AlignmentBlock insertionBlock) {
 
         final int pxPad = 2;   // text padding in the label
-        final int pxWing = 2;  // width of the cursor "wing"
+        final int pxWing = (pxH > 10 ? 2 : 1);  // width of the cursor "wing"
         final int minTextHeight = 8; // min height to draw text
 
         // Calculate the width required to draw the label
@@ -1008,7 +1008,6 @@ public class AlignmentRenderer implements FeatureRenderer {
         g.setColor(isInsertion ? purple : Color.white);
         g.fillRect(pxLeft, pxTop, pxRight - pxLeft, pxH);
 
-        // TODO -- record this "object" for popup text
         if (isInsertion && pxH > 5) {
             g.fillRect(pxLeft - pxWing, pxTop, pxRight - pxLeft + 2 * pxWing, 2);
             g.fillRect(pxLeft - pxWing, pxTop + pxH - 2, pxRight - pxLeft + 2 * pxWing, 2);
@@ -1016,7 +1015,7 @@ public class AlignmentRenderer implements FeatureRenderer {
 
         if (doesTextFit) {
             g.setColor(isInsertion ? Color.white : purple);
-            GraphicUtils.drawCenteredText(labelText, pxLeft, pxTop+1, pxW, pxH, g);
+            GraphicUtils.drawCenteredText(labelText, pxLeft, pxTop, pxW, pxH, g);
         } // draw the text if it fits
 
         if (insertionBlock != null) insertionBlock.setPixelRange(pxLeft, pxRight);
@@ -1060,14 +1059,14 @@ public class AlignmentRenderer implements FeatureRenderer {
                     if (flagLargeIndels && bpWidth > largeInsertionsThreshold) {
                         drawLargeIndelLabel(context.getGraphics2D("INDEL_LABEL"), true, Globals.DECIMAL_FORMAT.format(bpWidth), x - 1, y, h, (int) pxWidthExact, aBlock);
                     } else {
-
+                        int pxWing = (h > 10 ? 2 : (h > 5) ? 1 : 0);
                         Graphics2D g = context.getGraphics();
                         g.setColor(purple);
-                        g.fillRect(x - 2, y, 4, 2);
-                        g.fillRect(x - 1, y, 2, h);
-                        g.fillRect(x - 2, y + h - 2, 4, 2);
+                        g.fillRect(x, y, 2, h);
+                        g.fillRect(x - pxWing, y, 2 + 2*pxWing, 2);
+                        g.fillRect(x - pxWing, y + h - 2, 2 + 2*pxWing, 2);
 
-                        aBlock.setPixelRange(x - 2, x + 4);
+                        aBlock.setPixelRange(x - pxWing, x + 2 + pxWing);
                     }
                 }
             }

--- a/src/org/broad/igv/sam/AlignmentRenderer.java
+++ b/src/org/broad/igv/sam/AlignmentRenderer.java
@@ -586,11 +586,11 @@ public class AlignmentRenderer implements FeatureRenderer {
             }
             if (leftmost && leftClipped) {
                 clippedGraphics.drawLine(xPoly[0], yPoly[0], xPoly[1], yPoly[1]);
-                clippedGraphics.drawLine(xPoly[5], yPoly[5], xPoly[0], yPoly[0]);
+                clippedGraphics.drawLine(xPoly[5], yPoly[5]-1, xPoly[0], yPoly[0]);
             }
             if (rightmost && rightClipped) {
                 clippedGraphics.drawLine(xPoly[2], yPoly[2], xPoly[3], yPoly[3]);
-                clippedGraphics.drawLine(xPoly[3], yPoly[3], xPoly[4], yPoly[4]);
+                clippedGraphics.drawLine(xPoly[3], yPoly[3], xPoly[4], yPoly[4]-1);
             }
         }
 
@@ -670,7 +670,7 @@ public class AlignmentRenderer implements FeatureRenderer {
         // Get a graphics context for drawing clipping indicators.
         Graphics2D clippedGraphics = context.getGraphic2DForColor(clippedColor);
         if (h > 5) {
-            clippedGraphics.setStroke(new BasicStroke(1.5f));
+            clippedGraphics.setStroke(new BasicStroke(1.2f));
         }
 
         // Get a graphics context for drawing strand indicators.

--- a/src/org/broad/igv/sam/AlignmentRenderer.java
+++ b/src/org/broad/igv/sam/AlignmentRenderer.java
@@ -678,13 +678,13 @@ public class AlignmentRenderer implements FeatureRenderer {
 
         // Define a graphics context for indel labels.
         Graphics2D largeIndelGraphics = context.getGraphics2D("INDEL_LABEL");
-        largeIndelGraphics.setFont(FontManager.getFont(Font.BOLD, h - 2));
+        largeIndelGraphics.setFont(FontManager.getFont(Font.BOLD, h-1));
 
         // Get a graphics context for drawing individual basepairs.
         Graphics2D bpGraphics = context.getGraphics2D("BASE");
         int dX = (int) Math.max(1, (1.0 / locScale));
         if (dX >= 8) {
-            Font f = FontManager.getFont(Font.BOLD, Math.min(dX, 12));
+            Font f = FontManager.getFont(Font.BOLD, Math.min(dX, h));
             bpGraphics.setFont(f);
         }
 
@@ -795,7 +795,7 @@ public class AlignmentRenderer implements FeatureRenderer {
                         break; // done examining blocks
                     }
 
-                    drawBases(context, bpGraphics, rowRect, alignment, aBlock, alignmentCounts, alignmentColor, renderOptions);
+                    drawBases(context, bpGraphics, rowRect, alignment, aBlock, alignmentCounts, alignmentColor, leaveMargin, renderOptions);
                 }
             }
         }
@@ -812,6 +812,7 @@ public class AlignmentRenderer implements FeatureRenderer {
      * @param block
      * @param alignmentCounts
      * @param alignmentColor
+     * @param leaveMargin
      * @param renderOptions
      */
     private void drawBases(RenderContext context,
@@ -821,6 +822,7 @@ public class AlignmentRenderer implements FeatureRenderer {
                            AlignmentBlock block,
                            AlignmentCounts alignmentCounts,
                            Color alignmentColor,
+                           boolean leaveMargin,
                            RenderOptions renderOptions) {
 
         boolean isSoftClipped = block.isSoftClipped();
@@ -914,7 +916,7 @@ public class AlignmentRenderer implements FeatureRenderer {
                         // In "quick consensus" mode, only show mismatches at positions with a consistent alternative basepair.
                         (!quickConsensus || alignmentCounts.isConsensusMismatch(loc, reference[idx], chr, snpThreshold))
                         ) {
-                    drawBase(g, color, c, pX, pY, dX, dY, bisulfiteMode, bisstatus);
+                    drawBase(g, color, c, pX, pY, dX, dY - (leaveMargin ? 2 : 0), bisulfiteMode, bisstatus);
                 }
             }
         }
@@ -937,9 +939,9 @@ public class AlignmentRenderer implements FeatureRenderer {
      */
     private void drawBase(Graphics2D g, Color color, char c, int pX, int pY, int dX, int dY, boolean bisulfiteMode,
                           DisplayStatus bisstatus) {
-        if (((dY >= 12) && (dX >= 8)) && (!bisulfiteMode || (bisulfiteMode && bisstatus.equals(DisplayStatus.CHARACTER)))) {
+        if (((dY >= 12) && (dX >= dY)) && (!bisulfiteMode || (bisulfiteMode && bisstatus.equals(DisplayStatus.CHARACTER)))) {
             g.setColor(color);
-            GraphicUtils.drawCenteredText(new char[]{c}, pX, pY + 1, dX, dY - 2, g);
+            GraphicUtils.drawCenteredText(new char[]{c}, pX, pY-1, dX, dY, g);
         } else {
 
             int pX0i = pX, dXi = dX;
@@ -957,11 +959,7 @@ public class AlignmentRenderer implements FeatureRenderer {
 
             if (color != null) {
                 g.setColor(color);
-                if (dY < 10) {
-                    g.fillRect(pX0i, pY, dXi, dY);
-                } else {
-                    g.fillRect(pX0i, pY + 1, dW, dY - 3);
-                }
+                g.fillRect(pX0i, pY, dXi, dY);
             }
         }
     }
@@ -1018,7 +1016,7 @@ public class AlignmentRenderer implements FeatureRenderer {
 
         if (doesTextFit) {
             g.setColor(isInsertion ? Color.white : purple);
-            g.drawString(labelText, pxLeft + pxPad, pxTop + pxH - 2);
+            GraphicUtils.drawCenteredText(labelText, pxLeft, pxTop+1, pxW, pxH, g);
         } // draw the text if it fits
 
         if (insertionBlock != null) insertionBlock.setPixelRange(pxLeft, pxRight);

--- a/src/org/broad/igv/sam/AlignmentRenderer.java
+++ b/src/org/broad/igv/sam/AlignmentRenderer.java
@@ -552,13 +552,13 @@ public class AlignmentRenderer implements FeatureRenderer {
 
         boolean leftmost = (blockChromStart == alignmentChromStart),
                 rightmost = (blockChromEnd == alignmentChromEnd),
-                tallEnoughForArrow = h > 8;
+                tallEnoughForArrow = h > 6;
 
         if (h == 1) {
             blockGraphics.drawLine(blockPxStart, y, blockPxEnd, y);
         } else {
             Shape blockShape;
-            int arrowPxWidth = Math.min(5, blockPxWidth / 6);
+            int arrowPxWidth = Math.min(Math.min(5,h/2), blockPxWidth / 6);
             if (!overlapped) {
                 int delta = Math.max(0, (int) (arrowPxWidth + 1 - AlignmentPacker.MIN_ALIGNMENT_SPACING / locSale));
                 if (leftmost && isNegativeStrand && tallEnoughForArrow) blockPxStart += delta;

--- a/src/org/broad/igv/sam/AlignmentTrack.java
+++ b/src/org/broad/igv/sam/AlignmentTrack.java
@@ -163,6 +163,7 @@ public class AlignmentTrack extends AbstractTrack implements AlignmentTrackEvent
     private RenderOptions renderOptions = new RenderOptions();
 
     private int expandedHeight = 14;
+    private int collapsedHeight = 9;
     private int maxSquishedHeight = 5;
     private int squishedHeight = maxSquishedHeight;
     private FeatureRenderer renderer;
@@ -309,7 +310,15 @@ public class AlignmentTrack extends AbstractTrack implements AlignmentTrackEvent
     }
 
     private int getRowHeight() {
-        return getDisplayMode() == DisplayMode.EXPANDED ? expandedHeight : squishedHeight;
+        if (getDisplayMode() == DisplayMode.EXPANDED) {
+            return expandedHeight;
+        }
+        else if (getDisplayMode() == DisplayMode.COLLAPSED) {
+            return collapsedHeight;
+        }
+        else {
+            return squishedHeight;
+        }
     }
 
     private int getNLevels() {
@@ -397,7 +406,7 @@ public class AlignmentTrack extends AbstractTrack implements AlignmentTrackEvent
         }
 
         Rectangle visibleRect = context.getVisibleRect();
-        final boolean leaveMargin = getDisplayMode() == DisplayMode.EXPANDED;
+        final boolean leaveMargin = (getDisplayMode() != DisplayMode.SQUISHED);
 
 
         maximumHeight = Integer.MAX_VALUE;
@@ -407,7 +416,11 @@ public class AlignmentTrack extends AbstractTrack implements AlignmentTrackEvent
         double h;
         if (getDisplayMode() == DisplayMode.EXPANDED) {
             h = expandedHeight;
-        } else {
+        }
+        else if (getDisplayMode() == DisplayMode.COLLAPSED) {
+            h = collapsedHeight;
+        }
+        else {
 
             int visHeight = visibleRect.height;
             int depth = dataManager.getNLevels();


### PR DESCRIPTION
Introduce a "collapsed" mode for BAM alignment tracks that is intermediate between expanded and squished.  In collapsed mode, the individuals reads are drawn at about half the height as in expanded mode.  This also revealed some opportunities to improve the rendering logic to be more robust.

The collapsed mode looks as follows:
![ecs](https://cloud.githubusercontent.com/assets/7155109/21704338/7fdcddd8-d36d-11e6-88e2-144fde9270b0.png)

![ecs-zoom](https://cloud.githubusercontent.com/assets/7155109/21704340/830c2658-d36d-11e6-9abc-a6364c7843a8.png)