### PR TITLE
Made indel size labels on by default

### DIFF
--- a/src/org/broad/igv/PreferenceManager.java
+++ b/src/org/broad/igv/PreferenceManager.java
@@ -1103,7 +1103,7 @@ public class PreferenceManager implements PropertyManager {
         defaultValues.put(SAM_SHOW_JUNCTION_FLANKINGREGIONS, "true");
         defaultValues.put(SAM_NOMESEQ_ENABLED, "false");
         defaultValues.put(SAM_COUNT_DELETED_BASES_COVERED, "false");
-        defaultValues.put(SAM_FLAG_LARGE_INDELS, "false");
+        defaultValues.put(SAM_FLAG_LARGE_INDELS, "true");
         defaultValues.put(SAM_LARGE_INDELS_THRESHOLD, "1");
         defaultValues.put(SAM_FLAG_CLIPPING, "false");
         defaultValues.put(SAM_CLIPPING_THRESHOLD, "0");


### PR DESCRIPTION
The size label for insertions and deletions is a useful feature
with little downside and should be on by default in my opinion.