### PR TITLE
BasePairTrack better track menu integration

### DIFF
--- a/src/org/broad/igv/feature/BasePairFileUtils.java
+++ b/src/org/broad/igv/feature/BasePairFileUtils.java
@@ -451,8 +451,8 @@ public class BasePairFileUtils {
         colors.add(new Color(113, 195, 209));
         colors.add(new Color(51, 114, 38));
         ArrayList<String> colorLabels = new ArrayList<String>();
-        colorLabels.add("PP <= 10%");
-        colorLabels.add("30% < PP <= 10%");
+        colorLabels.add("PP 10-30%");
+        colorLabels.add("PP 30-80%");
         colorLabels.add("Pairing probability > 80%");
         writeBasePairFile(bpFile, colors, colorLabels, groupedArcs);
     }

--- a/src/org/broad/igv/feature/BasePairFileUtils.java
+++ b/src/org/broad/igv/feature/BasePairFileUtils.java
@@ -88,7 +88,7 @@ public class BasePairFileUtils {
         LinkedList<BasePairFeature> transArcs = new LinkedList<BasePairFeature>();
         for (BasePairFeature arc : arcs) {
             String chr = arc.getChr();
-            Color color = arc.getColor();
+            int colorIndex = arc.getColorIndex();
             int startLeft, startRight, endLeft, endRight;
             if (strand == "+") {
                 startLeft = arc.getStartLeft() + newLeft - 1;
@@ -108,7 +108,7 @@ public class BasePairFileUtils {
                     startRight,
                     endLeft,
                     endRight,
-                    color);
+                    colorIndex);
             transArcs.add(transArc);
         }
         return transArcs;
@@ -264,7 +264,7 @@ public class BasePairFileUtils {
             int colorIndex = 0;
             for (LinkedList<BasePairFeature> colorGroup : groupedArcs) {
                 for (BasePairFeature arc : colorGroup) {
-                    pw.println(arc.toStringNoColor() + "\t" + colorIndex);
+                    pw.println(arc.toString(colors.get(colorIndex)));
                 }
                 colorIndex++;
             }
@@ -360,7 +360,7 @@ public class BasePairFileUtils {
                     startRight,
                     endLeft,
                     endRight,
-                    null));
+                    0));
         }
         return helices;
     }

--- a/src/org/broad/igv/feature/BasePairFileUtils.java
+++ b/src/org/broad/igv/feature/BasePairFileUtils.java
@@ -451,8 +451,8 @@ public class BasePairFileUtils {
         colors.add(new Color(113, 195, 209));
         colors.add(new Color(51, 114, 38));
         ArrayList<String> colorLabels = new ArrayList<String>();
-        colorLabels.add("PP 10-30%");
-        colorLabels.add("PP 30-80%");
+        colorLabels.add("PP 10 - 30%");
+        colorLabels.add("PP 30 - 80%");
         colorLabels.add("Pairing probability > 80%");
         writeBasePairFile(bpFile, colors, colorLabels, groupedArcs);
     }

--- a/src/org/broad/igv/feature/BasePairFileUtils.java
+++ b/src/org/broad/igv/feature/BasePairFileUtils.java
@@ -203,7 +203,6 @@ public class BasePairFileUtils {
 
     static SeqLenAndBinnedPairs loadPairingProb(String inFile) throws
             FileNotFoundException, IOException {
-        // TODO: add probability threshold color legend to track dropdown menu
         // TODO: support alternate thresholds, interactive threshold update from track UI?
 
         ArrayList<ArrayList<Point>> binnedPairs = new ArrayList<ArrayList<Point>>();
@@ -250,21 +249,32 @@ public class BasePairFileUtils {
 
     static void writeBasePairFile(String bpFile,
                                   ArrayList<Color> colors,
+                                  ArrayList<String> colorLabels,
                                   ArrayList<LinkedList<BasePairFeature>> groupedArcs) throws IOException {
         PrintWriter pw = null;
 
         try {
             pw = new PrintWriter(new BufferedWriter(new FileWriter(bpFile)));
             // first write enumerated colors header
-            for (Color color : colors) {
-                pw.println("color:\t" + color.getRed() + "\t" + color.getGreen() + "\t" + color.getBlue());
+            for (int i=0; i<colors.size(); ++i) {
+                Color color = colors.get(i);
+                String label = "";
+                try {
+                    label = colorLabels.get(i);
+                } catch (IndexOutOfBoundsException e) {
+                } catch (NullPointerException e) {
+                }
+                pw.println("color:\t" + color.getRed() +
+                                 "\t" + color.getGreen() +
+                                 "\t" + color.getBlue() +
+                                 "\t" + label);
             }
 
-            // then write arc coordinates
+            // then write arc coordinates and color index
             int colorIndex = 0;
             for (LinkedList<BasePairFeature> colorGroup : groupedArcs) {
                 for (BasePairFeature arc : colorGroup) {
-                    pw.println(arc.toString(colors.get(colorIndex)));
+                    pw.println(arc.toString() + "\t" + colorIndex);
                 }
                 colorIndex++;
             }
@@ -386,7 +396,7 @@ public class BasePairFileUtils {
         colors.add(Color.black);
         ArrayList<LinkedList<BasePairFeature>> groupedArcs = new ArrayList<LinkedList<BasePairFeature>>();
         groupedArcs.add(arcs); // list of length 1 for this case (arcs only have 1 color)
-        writeBasePairFile(bpFile, colors, groupedArcs);
+        writeBasePairFile(bpFile, colors, null, groupedArcs);
     }
 
     /**
@@ -410,7 +420,7 @@ public class BasePairFileUtils {
         colors.add(Color.black);
         ArrayList<LinkedList<BasePairFeature>> groupedArcs = new ArrayList<LinkedList<BasePairFeature>>();
         groupedArcs.add(arcs); // list of length 1 for this case (arcs only have 1 color)
-        writeBasePairFile(bpFile, colors, groupedArcs);
+        writeBasePairFile(bpFile, colors, null, groupedArcs);
     }
 
     /**
@@ -434,10 +444,17 @@ public class BasePairFileUtils {
                     seqLen, left, strand));
         }
         ArrayList<Color> colors = new ArrayList<Color>();
-        colors.add(new Color(255, 204, 0));
-        colors.add(new Color(72, 143, 205));
-        colors.add(new Color(81, 184, 72));
-        writeBasePairFile(bpFile, colors, groupedArcs);
+        //colors.add(new Color(255, 204, 0));
+        //colors.add(new Color(72, 143, 205));
+        //colors.add(new Color(81, 184, 72));
+        colors.add(new Color(255, 218, 125));
+        colors.add(new Color(113, 195, 209));
+        colors.add(new Color(51, 114, 38));
+        ArrayList<String> colorLabels = new ArrayList<String>();
+        colorLabels.add("PP <= 10%");
+        colorLabels.add("30% < PP <= 10%");
+        colorLabels.add("Pairing probability > 80%");
+        writeBasePairFile(bpFile, colors, colorLabels, groupedArcs);
     }
 
 

--- a/src/org/broad/igv/feature/basepair/BasePairData.java
+++ b/src/org/broad/igv/feature/basepair/BasePairData.java
@@ -4,7 +4,6 @@ package org.broad.igv.feature.basepair;
 
 import org.broad.igv.feature.FeatureUtils;
 
-import java.awt.*; // does this have Color definition?
 import java.util.ArrayList;
 import java.util.List;
 import java.util.HashMap;

--- a/src/org/broad/igv/feature/basepair/BasePairFeature.java
+++ b/src/org/broad/igv/feature/basepair/BasePairFeature.java
@@ -85,7 +85,4 @@ public class BasePairFeature implements Feature{
         return getChr() + "\t" + startLeft + "\t" + startRight + "\t" + endLeft + "\t" + endRight;
     }
 
-    public String toString(Color color) {
-        return toString() + "\t" + color;
-    }
 }

--- a/src/org/broad/igv/feature/basepair/BasePairFeature.java
+++ b/src/org/broad/igv/feature/basepair/BasePairFeature.java
@@ -40,11 +40,11 @@ public class BasePairFeature implements Feature{
     int startRight;
     int endLeft;
     int endRight;
-    Color color;
+    int colorIndex;
 
-    public BasePairFeature(String chr,  int startLeft, int startRight, int endLeft, int endRight,  Color color) {
+    public BasePairFeature(String chr,  int startLeft, int startRight, int endLeft, int endRight,  int colorIndex) {
         this.chr = chr;
-        this.color = color;
+        this.colorIndex = colorIndex;
         this.endLeft = endLeft;
         this.endRight = endRight;
         this.startLeft = startLeft;
@@ -79,14 +79,13 @@ public class BasePairFeature implements Feature{
 
     public int getEndRight() { return endRight; }
 
-    public Color getColor() { return color; }
+    public int getColorIndex() { return colorIndex; }
 
-
-    public String toStringNoColor() {
+    public String toString() {
         return getChr() + "\t" + startLeft + "\t" + startRight + "\t" + endLeft + "\t" + endRight;
     }
 
-    public String toString() {
-        return toStringNoColor() + "\t" + color;
+    public String toString(Color color) {
+        return toString() + "\t" + color;
     }
 }

--- a/src/org/broad/igv/feature/basepair/BasePairFileParser.java
+++ b/src/org/broad/igv/feature/basepair/BasePairFileParser.java
@@ -4,25 +4,20 @@ import org.apache.log4j.Logger;
 import org.broad.igv.Globals;
 import org.broad.igv.exceptions.ParserException;
 import org.broad.igv.feature.genome.Genome;
+import org.broad.igv.ui.color.ColorUtilities;
 import org.broad.igv.util.ParsingUtils;
 import org.broad.igv.util.ResourceLocator;
 import htsjdk.tribble.readers.AsciiLineReader;
 
 import java.awt.*;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
 
 public class BasePairFileParser {
 
     static Logger log = Logger.getLogger(BasePairFileParser.class);
 
-    public static BasePairData loadData(ResourceLocator locator, Genome genome) {
+    public static void loadData(ResourceLocator locator, Genome genome,
+                                BasePairData basePairData, BasePairTrack.RenderOptions renderOptions) {
         AsciiLineReader reader = null;
-
-        List<Color> colors = new ArrayList();
-        HashMap<Color, List<Object>> rowsByColor = new HashMap<Color, List<Object>>();
-        BasePairData basePairData = new BasePairData();
 
         String nextLine = null;
         int rowCounter = 0;
@@ -38,13 +33,9 @@ public class BasePairFileParser {
                 int g = Integer.parseInt(tokens[2]);
                 int b = Integer.parseInt(tokens[3]);
                 Color color = new Color(r, g, b, 255);
-                colors.add(color);
+                renderOptions.colors.add(ColorUtilities.colorToString(color));
                 nextLine = reader.readLine();
                 rowCounter++;
-            }
-
-            for (Color color : colors) {
-                rowsByColor.put(color, new ArrayList());
             }
 
             while (nextLine != null) {
@@ -57,7 +48,7 @@ public class BasePairFileParser {
                 int startRightNuc = Integer.parseInt(tokens[2]) - 1;
                 int endLeftNuc = Integer.parseInt(tokens[3]) - 1;
                 int endRightNuc = Integer.parseInt(tokens[4]) - 1;
-                Color color = colors.get(Integer.parseInt(tokens[5]));
+                int colorIndex = Integer.parseInt(tokens[5]);
 
                 BasePairFeature feature;
                 if (startLeftNuc <= endRightNuc) {
@@ -66,14 +57,14 @@ public class BasePairFileParser {
                             Math.max(startLeftNuc, startRightNuc),
                             Math.min(endLeftNuc, endRightNuc),
                             Math.max(endLeftNuc, endRightNuc),
-                            color);
+                            colorIndex);
                 } else {
                     feature = new BasePairFeature(chr,
                             Math.min(endLeftNuc, endRightNuc),
                             Math.max(endLeftNuc, endRightNuc),
                             Math.min(startLeftNuc, startRightNuc),
                             Math.max(startLeftNuc, startRightNuc),
-                            color);
+                            colorIndex);
                 }
 
                 basePairData.addFeature(feature);
@@ -102,7 +93,6 @@ public class BasePairFileParser {
         //    System.out.println(row);
         //}
 
-        return basePairData;
     }
 
 }

--- a/src/org/broad/igv/feature/basepair/BasePairFileParser.java
+++ b/src/org/broad/igv/feature/basepair/BasePairFileParser.java
@@ -7,9 +7,11 @@ import org.broad.igv.feature.genome.Genome;
 import org.broad.igv.ui.color.ColorUtilities;
 import org.broad.igv.util.ParsingUtils;
 import org.broad.igv.util.ResourceLocator;
+import org.broad.igv.util.StringUtils;
 import htsjdk.tribble.readers.AsciiLineReader;
 
 import java.awt.*;
+import java.util.Arrays;
 
 public class BasePairFileParser {
 
@@ -32,8 +34,14 @@ public class BasePairFileParser {
                 int r = Integer.parseInt(tokens[1]);
                 int g = Integer.parseInt(tokens[2]);
                 int b = Integer.parseInt(tokens[3]);
+                String label = "";
+                try {
+                    label = StringUtils.join(Arrays.copyOfRange(tokens, 4, tokens.length), " ");
+                } catch (IndexOutOfBoundsException e) {
+                }
                 Color color = new Color(r, g, b, 255);
                 renderOptions.colors.add(ColorUtilities.colorToString(color));
+                renderOptions.colorLabels.add(label);
                 nextLine = reader.readLine();
                 rowCounter++;
             }

--- a/src/org/broad/igv/feature/basepair/BasePairRenderer.java
+++ b/src/org/broad/igv/feature/basepair/BasePairRenderer.java
@@ -14,17 +14,11 @@ import org.broad.igv.ui.color.ColorUtilities;
 import java.awt.*;
 import java.awt.geom.GeneralPath;
 
-// TODO: add vertical scaling option so arcs fit on track, or clip arcs outside of track rect?
 // TODO: add visualization for very zoomed-out views
 
 public class BasePairRenderer {
 
     private static Logger log = Logger.getLogger(BasePairRenderer.class);
-
-    // TODO: move these to BasePairTrack and pass as params to rendering funcs?
-    //Color ARC_COLOR_A = new Color(50, 50, 150, 140); //transparent dull blue
-    //Color ARC_COLOR_B = new Color(150, 50, 50, 140); //transparent dull red
-    //Color ARC_COLOR_C = new Color(50, 0, 50, 250);
 
     // central horizontal line color
     //Color COLOR_CENTERLINE = new Color(0, 0, 0, 100);
@@ -76,7 +70,6 @@ public class BasePairRenderer {
                     else if (feature.endRight < context.getOrigin()) continue;
                     else if (feature.colorIndex != colorIndex) continue;
 
-                    //System.out.println("Color: "+data.colors[i]);
                     //arcCount++;
 
                     double startLeftPix = (feature.startLeft - origin) / nucsPerPixel;
@@ -84,18 +77,11 @@ public class BasePairRenderer {
                     double endLeftPix = (feature.endLeft - origin) / nucsPerPixel;
                     double endRightPix = (feature.endRight + 1.0 - origin) / nucsPerPixel;
 
-                    //System.out.println("colorIndex: " + feature.colorIndex);
-
                     Color color = ColorUtilities.stringToColor(renderOptions.colors.get(feature.colorIndex));
 
                     drawArc(startLeftPix, startRightPix, endLeftPix, endRightPix,
                             trackRectangle, context, color,
                             renderOptions.getArcDirection(), heightScale, drawOutline);
-
-
-                    //drawArc(10, 210, 50, trackRectangle, context, ARC_COLOR_B);
-                    //drawArc(300, 500, 50, trackRectangle, context, ARC_COLOR_A);
-
 
                     //System.out.println("Drew "+arcCount+" arcs");
                 }

--- a/src/org/broad/igv/feature/basepair/BasePairRenderer.java
+++ b/src/org/broad/igv/feature/basepair/BasePairRenderer.java
@@ -8,6 +8,7 @@ import org.apache.log4j.Logger;
 import org.broad.igv.feature.basepair.BasePairTrack.*;
 import org.broad.igv.PreferenceManager;
 import org.broad.igv.track.RenderContext;
+import org.broad.igv.ui.color.ColorUtilities;
 
 
 import java.awt.*;
@@ -21,12 +22,12 @@ public class BasePairRenderer {
     private static Logger log = Logger.getLogger(BasePairRenderer.class);
 
     // TODO: move these to BasePairTrack and pass as params to rendering funcs?
-    Color ARC_COLOR_A = new Color(50, 50, 150, 140); //transparent dull blue
-    Color ARC_COLOR_B = new Color(150, 50, 50, 140); //transparent dull red
-    Color ARC_COLOR_C = new Color(50, 0, 50, 250);
+    //Color ARC_COLOR_A = new Color(50, 50, 150, 140); //transparent dull blue
+    //Color ARC_COLOR_B = new Color(150, 50, 50, 140); //transparent dull red
+    //Color ARC_COLOR_C = new Color(50, 0, 50, 250);
 
     // central horizontal line color
-    Color COLOR_CENTERLINE = new Color(0, 0, 0, 100);
+    //Color COLOR_CENTERLINE = new Color(0, 0, 0, 100);
 
     public void draw(BasePairData data, RenderContext context, Rectangle trackRectangle,
                      RenderOptions renderOptions) {
@@ -38,7 +39,6 @@ public class BasePairRenderer {
         //The location of the last base that is loaded
         int end = (int) (origin + trackRectangle.width * nucsPerPixel) + 1;
         if (end <= start) return;
-
 
         java.util.List<BasePairFeature> featureList = data.getFeatures(context.getChr());
 
@@ -66,23 +66,28 @@ public class BasePairRenderer {
 
             boolean drawOutline = true;
 
+            //int arcCount = 0;
             for (BasePairFeature feature : featureList) {
 
                 if (feature.startLeft > context.getEndLocation()) break;
                 else if (feature.endRight < context.getOrigin()) continue;
 
                 //System.out.println("Color: "+data.colors[i]);
-                //int arcCount = 0;
+                //arcCount++;
 
                 double startLeftPix = (feature.startLeft - origin) / nucsPerPixel;
                 double startRightPix = (feature.startRight + 1.0 - origin) / nucsPerPixel;
                 double endLeftPix = (feature.endLeft - origin) / nucsPerPixel;
                 double endRightPix = (feature.endRight + 1.0 - origin) / nucsPerPixel;
 
+                //System.out.println("colorIndex: " + feature.colorIndex);
+
+                Color color = ColorUtilities.stringToColor(renderOptions.colors.get(feature.colorIndex));
+
                 drawArc(startLeftPix, startRightPix, endLeftPix, endRightPix,
-                        trackRectangle, context, feature.color,
+                        trackRectangle, context, color,
                         renderOptions.getArcDirection(), heightScale, drawOutline);
-                //arcCount++;
+
 
                 //drawArc(10, 210, 50, trackRectangle, context, ARC_COLOR_B);
                 //drawArc(300, 500, 50, trackRectangle, context, ARC_COLOR_A);
@@ -120,7 +125,7 @@ public class BasePairRenderer {
         if (featureColor != null) {
             color = featureColor;
         } else {
-            color = ARC_COLOR_A;
+            color = new Color(50, 50, 150, 140);
         }
 
         Graphics2D g2D = context.getGraphic2DForColor(color);
@@ -147,8 +152,6 @@ public class BasePairRenderer {
         } else {
             y = (int) trackRectangle.getMinY();
         }
-
-        // FIXME: float scale results in vanishing thin lines when zoomed out. May need to render outlines to fix.
 
         // Define all control points
         // Use a minimum arc width of 1 pixel

--- a/src/org/broad/igv/feature/basepair/BasePairRenderer.java
+++ b/src/org/broad/igv/feature/basepair/BasePairRenderer.java
@@ -23,20 +23,29 @@ public class BasePairRenderer {
     Color ARC_COLOR_C = new Color(50, 0, 50, 250);
 
     int dir = -1; // 1 for up, -1 for down
-    boolean scaleToTrackHeight = false;
+    boolean fitHeight = false; // scale arc heights to fit current track height
+    double heightScale = 1.0;
 
     // central horizontal line color
     Color COLOR_CENTERLINE = new Color(0, 0, 0, 100);
 
-    public int getDirection(){
+    public int getDirection() {
         return dir;
     }
 
-    public void setDirection(int d){
+    public void setDirection(int d) {
         dir = d;
     }
 
-    public void draw(BasePairData data, RenderContext context, Rectangle trackRectangle){
+    public boolean getFitHeight() {
+        return fitHeight;
+    }
+
+    public void setFitHeight(boolean b) {
+        fitHeight = b;
+    }
+
+    public void draw(BasePairData data, RenderContext context, Rectangle trackRectangle) {
 
         double nucsPerPixel = context.getScale();
         double origin = context.getOrigin();
@@ -52,20 +61,30 @@ public class BasePairRenderer {
 
         if (featureList != null) {
 
+            // compute arc height scaling factor
+            if (fitHeight) {
+                // find widest arc with a center point within the current viewing window
+                double maxHeight = 1f;
+                for (BasePairFeature feature : featureList) {
+                    if (feature.startLeft > context.getEndLocation()) break;
+                    else if (feature.endRight < context.getOrigin()) continue;
+
+                    double height = (feature.endRight - feature.startLeft) / 2f;
+                    double center = feature.startLeft + height;
+                    if (center < context.getEndLocation() || center >= context.getOrigin()) {
+                        if (height > maxHeight) maxHeight = height;
+                    }
+                }
+                heightScale = (trackRectangle.getHeight()*nucsPerPixel) / maxHeight;
+            }
+
             for (BasePairFeature feature : featureList) {
 
-                if(feature.startLeft > context.getEndLocation()) break;
-                else if(feature.endRight < context.getOrigin()) continue;
+                if (feature.startLeft > context.getEndLocation()) break;
+                else if (feature.endRight < context.getOrigin()) continue;
 
                 //System.out.println("Color: "+data.colors[i]);
                 int arcCount = 0;
-
-                //System.out.println("In arcRenderer.draw(): ");
-                //System.out.println("    track.width = " + trackRectangle.width);
-                //System.out.println("    nucsPerPixel = " + nucsPerPixel);
-                //System.out.println("    origin = " + origin);
-                //System.out.println("    start = " + start);
-                //System.out.println("    end = " + end);
 
                 double startLeftPix = (feature.startLeft - origin) / nucsPerPixel;
                 double startRightPix = (feature.startRight + 1.0 - origin) / nucsPerPixel;
@@ -74,12 +93,6 @@ public class BasePairRenderer {
 
                 drawArc(startLeftPix, startRightPix, endLeftPix, endRightPix, trackRectangle, context, feature.color);
                 arcCount++;
-
-                //System.out.println("    leftStart = " + leftStartNucPix);
-                //System.out.println("    leftEnd = " + leftEndNucPix);
-                //System.out.println("    rightStart = " + rightStartNucPix);
-                //System.out.println("    rightEnd = " + rightEndNucPix);
-                //System.out.println("    arcWidth = " + arcWidthPix);
 
                 //drawArc(10, 210, 50, trackRectangle, context, ARC_COLOR_B);
                 //drawArc(300, 500, 50, trackRectangle, context, ARC_COLOR_A);
@@ -98,18 +111,16 @@ public class BasePairRenderer {
     }
 
 
-
-
     /**
      * Draw a filled arc between two regions of equal length
      *
-     * @param startLeft  the starting position of the feature, whether on-screen or not (outer left corner of arc)
-     * @param startRight (inner left corner of arc)
-     * @param endLeft    the ending position of the feature, whether on-screen or not (inner right corner of arc)
-     * @param endRight   (outer right corner of arc)
+     * @param startLeft      the starting position of the feature, whether on-screen or not (outer left corner of arc)
+     * @param startRight     (inner left corner of arc)
+     * @param endLeft        the ending position of the feature, whether on-screen or not (inner right corner of arc)
+     * @param endRight       (outer right corner of arc)
      * @param trackRectangle
      * @param context
-     * @param featureColor       the color specified for this feature.  May be null.
+     * @param featureColor   the color specified for this feature.  May be null.
      */
     protected void drawArc(double startLeft, double startRight, double endLeft, double endRight,
                            Rectangle trackRectangle, RenderContext context, Color featureColor) {
@@ -126,23 +137,27 @@ public class BasePairRenderer {
             g2D.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
             g2D.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
         }
-        //Height of top of an arc of maximum depth
-        int maxPossibleArcHeight = (trackRectangle.height - 1) / 2;
 
         // Equation by G. Adam Stanislav from http://www.whizkidtech.redprince.net/bezier/circle/
-        double handleLengthFactor = 4f*((double)Math.sqrt(2f)-1f)/3f;
+        double handleLengthFactor = 4f * ((double) Math.sqrt(2f) - 1f) / 3f;
 
-        double outerRadius = (double) (endRight-startLeft)/2.0;
-        double innerRadius = (double) (endLeft-startRight)/2.0;
+        double outerRadius = (double) (endRight - startLeft) / 2.0;
+        double innerRadius = (double) (endLeft - startRight) / 2.0;
 
-        double arcWidth = Math.max(1.0, startRight-startLeft);
+        double arcWidth = Math.max(1.0, startRight - startLeft);
 
         int y = 0;
-        if (dir>0){
+        if (dir > 0) {
             y = (int) trackRectangle.getMaxY();
         } else {
             y = (int) trackRectangle.getMinY();
         }
+
+        double hs = 1f;
+        if (fitHeight) {
+            hs = heightScale;
+        }
+
 
         // Define all control points
         // Use a minimum arc width of 1 pixel
@@ -150,19 +165,19 @@ public class BasePairRenderer {
         int outerLY = y;
 
         int outerLC1X = (int) (trackRectangle.getX() + outerLX);
-        int outerLC1Y = (int) (outerLY - dir * handleLengthFactor*outerRadius);
+        int outerLC1Y = (int) (outerLY - dir * handleLengthFactor * outerRadius * hs);
 
-        int outerLC2X = (int) (trackRectangle.getX() + outerLX+outerRadius - handleLengthFactor*outerRadius);
-        int outerLC2Y = (int) (outerLY - dir * outerRadius);
+        int outerLC2X = (int) (trackRectangle.getX() + outerLX + outerRadius - handleLengthFactor * outerRadius);
+        int outerLC2Y = (int) (outerLY - dir * outerRadius * hs);
 
-        int outerCenterX = (int) (trackRectangle.getX() + outerLX+outerRadius);
-        int outerCenterY = (int) (outerLY - dir * outerRadius);
+        int outerCenterX = (int) (trackRectangle.getX() + outerLX + outerRadius);
+        int outerCenterY = (int) (outerLY - dir * outerRadius * hs);
 
-        int outerRC1X = (int) (trackRectangle.getX() + outerLX+outerRadius + handleLengthFactor*outerRadius);
-        int outerRC1Y = (int) (outerLY - dir * outerRadius);
+        int outerRC1X = (int) (trackRectangle.getX() + outerLX + outerRadius + handleLengthFactor * outerRadius);
+        int outerRC1Y = (int) (outerLY - dir * outerRadius * hs);
 
         int outerRC2X = (int) (trackRectangle.getX() + endRight);
-        int outerRC2Y = (int) (outerLY - dir * handleLengthFactor*outerRadius);
+        int outerRC2Y = (int) (outerLY - dir * handleLengthFactor * outerRadius * hs);
 
         int outerRX = (int) (trackRectangle.getX() + endRight);
         int outerRY = outerLY;
@@ -171,24 +186,24 @@ public class BasePairRenderer {
         int innerRY = outerLY;
 
         int innerRC1X = (int) (trackRectangle.getX() + innerRX);
-        int innerRC1Y = (int) (outerLY - dir * handleLengthFactor*innerRadius);
+        int innerRC1Y = (int) (outerLY - dir * handleLengthFactor * innerRadius * hs);
 
-        int innerRC2X = (int) (trackRectangle.getX() + outerLX + outerRadius + handleLengthFactor*innerRadius);
-        int innerRC2Y = (int) (outerCenterY + dir * arcWidth);
+        int innerRC2X = (int) (trackRectangle.getX() + outerLX + outerRadius + handleLengthFactor * innerRadius);
+        int innerRC2Y = (int) (outerCenterY + dir * arcWidth * hs);
 
         int innerCenterX = (int) (trackRectangle.getX() + outerLX + outerRadius);
-        int innerCenterY = (int) (outerCenterY + dir * arcWidth);
+        int innerCenterY = (int) (outerCenterY + dir * arcWidth * hs);
 
-        int innerLC1X = (int) (trackRectangle.getX() + outerLX + outerRadius - handleLengthFactor*innerRadius);
-        int innerLC1Y = (int) (outerCenterY + dir * arcWidth);
+        int innerLC1X = (int) (trackRectangle.getX() + outerLX + outerRadius - handleLengthFactor * innerRadius);
+        int innerLC1Y = (int) (outerCenterY + dir * arcWidth * hs);
 
         int innerLC2X = (int) (trackRectangle.getX() + startLeft + arcWidth);
-        int innerLC2Y = (int) (outerLY - dir * handleLengthFactor*innerRadius);
+        int innerLC2Y = (int) (outerLY - dir * handleLengthFactor * innerRadius * hs);
 
         int innerLX = (int) (trackRectangle.getX() + startLeft + arcWidth);
         int innerLY = outerLY;
 
-        if (false){
+        if (false) {
             GeneralPath arcCage = new GeneralPath();
             arcCage.moveTo(outerLX, outerLY); // outer left
             arcCage.lineTo(outerLC1X, outerLC1Y);
@@ -213,7 +228,7 @@ public class BasePairRenderer {
         }
 
         // Create path
-        if (true){
+        if (true) {
             GeneralPath arcPath = new GeneralPath();
             arcPath.moveTo(outerLX, outerLY); // outer left
             arcPath.curveTo(outerLC1X, outerLC1Y,

--- a/src/org/broad/igv/feature/basepair/BasePairRenderer.java
+++ b/src/org/broad/igv/feature/basepair/BasePairRenderer.java
@@ -23,6 +23,7 @@ public class BasePairRenderer {
     Color ARC_COLOR_C = new Color(50, 0, 50, 250);
 
     int dir = -1; // 1 for up, -1 for down
+    boolean scaleToTrackHeight = false;
 
     // central horizontal line color
     Color COLOR_CENTERLINE = new Color(0, 0, 0, 100);

--- a/src/org/broad/igv/feature/basepair/BasePairRenderer.java
+++ b/src/org/broad/igv/feature/basepair/BasePairRenderer.java
@@ -67,33 +67,38 @@ public class BasePairRenderer {
             boolean drawOutline = true;
 
             //int arcCount = 0;
-            for (BasePairFeature feature : featureList) {
 
-                if (feature.startLeft > context.getEndLocation()) break;
-                else if (feature.endRight < context.getOrigin()) continue;
+            // render in order of indexed colors
+            for (int colorIndex=0; colorIndex<renderOptions.colors.size(); ++colorIndex) {
+                for (BasePairFeature feature : featureList) {
 
-                //System.out.println("Color: "+data.colors[i]);
-                //arcCount++;
+                    if (feature.startLeft > context.getEndLocation()) break;
+                    else if (feature.endRight < context.getOrigin()) continue;
+                    else if (feature.colorIndex != colorIndex) continue;
 
-                double startLeftPix = (feature.startLeft - origin) / nucsPerPixel;
-                double startRightPix = (feature.startRight + 1.0 - origin) / nucsPerPixel;
-                double endLeftPix = (feature.endLeft - origin) / nucsPerPixel;
-                double endRightPix = (feature.endRight + 1.0 - origin) / nucsPerPixel;
+                    //System.out.println("Color: "+data.colors[i]);
+                    //arcCount++;
 
-                //System.out.println("colorIndex: " + feature.colorIndex);
+                    double startLeftPix = (feature.startLeft - origin) / nucsPerPixel;
+                    double startRightPix = (feature.startRight + 1.0 - origin) / nucsPerPixel;
+                    double endLeftPix = (feature.endLeft - origin) / nucsPerPixel;
+                    double endRightPix = (feature.endRight + 1.0 - origin) / nucsPerPixel;
 
-                Color color = ColorUtilities.stringToColor(renderOptions.colors.get(feature.colorIndex));
+                    //System.out.println("colorIndex: " + feature.colorIndex);
 
-                drawArc(startLeftPix, startRightPix, endLeftPix, endRightPix,
-                        trackRectangle, context, color,
-                        renderOptions.getArcDirection(), heightScale, drawOutline);
+                    Color color = ColorUtilities.stringToColor(renderOptions.colors.get(feature.colorIndex));
 
-
-                //drawArc(10, 210, 50, trackRectangle, context, ARC_COLOR_B);
-                //drawArc(300, 500, 50, trackRectangle, context, ARC_COLOR_A);
+                    drawArc(startLeftPix, startRightPix, endLeftPix, endRightPix,
+                            trackRectangle, context, color,
+                            renderOptions.getArcDirection(), heightScale, drawOutline);
 
 
-                //System.out.println("Drew "+arcCount+" arcs");
+                    //drawArc(10, 210, 50, trackRectangle, context, ARC_COLOR_B);
+                    //drawArc(300, 500, 50, trackRectangle, context, ARC_COLOR_A);
+
+
+                    //System.out.println("Drew "+arcCount+" arcs");
+                }
             }
         }
         //System.out.println("");

--- a/src/org/broad/igv/feature/basepair/BasePairTrack.java
+++ b/src/org/broad/igv/feature/basepair/BasePairTrack.java
@@ -81,9 +81,10 @@ public class BasePairTrack extends AbstractTrack {
         ArcDirection arcDirection;
         @XmlAttribute
         boolean fitHeight; // scale arc heights to fit current track height
-        @XmlAttribute
+        @XmlElement
         List<String> colors; // needs to be String, not Color so XML conversion works happily
-        @XmlAttribute
+        // FIXME: use XmlAdapter or something to allow using Color class
+        @XmlElement
         List<String> colorLabels; // menu legend labels for each color
 
         RenderOptions() {

--- a/src/org/broad/igv/feature/basepair/BasePairTrack.java
+++ b/src/org/broad/igv/feature/basepair/BasePairTrack.java
@@ -49,21 +49,20 @@ public class BasePairTrack extends AbstractTrack {
         return null;
     }
 
-    public ArcDirection getArcDirection(){ return renderOptions.getArcDirection(); }
+    /*public ArcDirection getArcDirection(){ return renderOptions.getArcDirection(); }
 
     public void setArcDirection(ArcDirection d){ renderOptions.setArcDirection(d); }
 
     public boolean getFitHeight() { return renderOptions.getFitHeight(); }
 
-    public void setFitHeight(boolean b) { renderOptions.setFitHeight(b); }
+    public void setFitHeight(boolean b) { renderOptions.setFitHeight(b); }*/
 
-    @SubtlyImportant
-    private RenderOptions getRenderOptions() {
+    public RenderOptions getRenderOptions() {
         return this.renderOptions;
     }
 
     @XmlElement(name = RenderOptions.NAME)
-    private void setRenderOptions(RenderOptions renderOptions) {
+    public void setRenderOptions(RenderOptions renderOptions) {
         this.renderOptions = renderOptions;
     }
 
@@ -97,6 +96,24 @@ public class BasePairTrack extends AbstractTrack {
         public ArcDirection getArcDirection() { return arcDirection; }
 
         public void setArcDirection(ArcDirection d) { this.arcDirection = d; }
+
+        public List<String> getColors() { return this.colors; }
+
+        public void setColors(List<String> l) { this.colors = l; }
+
+        public List<String> getColorLabels() { return this.colorLabels; }
+
+        public void setColorLabels(List<String> l) { this.colorLabels = l; }
+
+        public String getColor(int i) { return this.colors.get(i); }
+
+        public void setColor(int i, String s) { this.colors.set(i, s); }
+
+        public String getColorLabel(int i) { return this.colorLabels.get(i); }
+
+        public void setColorLabel(int i, String s) { this.colorLabels.set(i, s); }
+
+
     }
 
     @SubtlyImportant

--- a/src/org/broad/igv/feature/basepair/BasePairTrack.java
+++ b/src/org/broad/igv/feature/basepair/BasePairTrack.java
@@ -8,11 +8,11 @@ import org.broad.igv.session.SubtlyImportant;
 import org.broad.igv.track.AbstractTrack;
 import org.broad.igv.track.RenderContext;
 import org.broad.igv.util.ResourceLocator;
-import org.broad.igv.util.collections.CollUtils;
 
 import javax.xml.bind.annotation.*;
 import java.awt.*;
-import java.util.Map;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Show base-pairing arcs
@@ -26,17 +26,19 @@ public class BasePairTrack extends AbstractTrack {
     private static Logger log = Logger.getLogger(BasePairTrack.class);
 
     private BasePairRenderer basePairRenderer = new BasePairRenderer();
-    private BasePairData basePairData;
+    private BasePairData basePairData = new BasePairData();
 
     public enum ArcDirection {
         UP, DOWN
     }
 
     private RenderOptions renderOptions = new RenderOptions();
-    
+
     public BasePairTrack(ResourceLocator locator, String id, String name, Genome genome) {
         super(locator, id, name);
-        basePairData = BasePairFileParser.loadData(locator, genome);
+        BasePairFileParser.loadData(locator, genome,
+                                    basePairData, renderOptions);
+        // WIP: store colors and color labels in RenderOptions
     }
 
     public void render(RenderContext context, Rectangle rect) {
@@ -74,31 +76,18 @@ public class BasePairTrack extends AbstractTrack {
         @XmlAttribute
         ArcDirection arcDirection;
         @XmlAttribute
-        boolean fitHeight;
-
+        boolean fitHeight; // scale arc heights to fit current track height
+        @XmlAttribute
+        List<String> colors; // needs to be String, not Color so XML conversion works happily
+        @XmlAttribute
+        List<String> colorLabels; // menu legend labels for each color
 
         RenderOptions() {
-            // TODO: load some options from global PreferenceManager like AlignmentTrack?
+            // TODO: load some options from global PreferenceManager like AlignmentTrack does?
             arcDirection = ArcDirection.DOWN;
-            fitHeight = false; // scale arc heights to fit current track height
-            System.out.println(">>>>>>>  BasePairTrack.RenderOptions bare constructor called <<<<<<<");
-        }
-
-        // copied these from AlignmentTrack.RenderOptions, might not be used?
-        private <T extends Enum<T>> T getFromMap(Map<String, String> attributes, String key, Class<T> clazz, T defaultValue) {
-            String value = attributes.get(key);
-            if (value == null) {
-                return defaultValue;
-            }
-            return CollUtils.<T>valueOf(clazz, value, defaultValue);
-        }
-
-        private String getFromMap(Map<String, String> attributes, String key, String defaultValue) {
-            String value = attributes.get(key);
-            if (value == null) {
-                return defaultValue;
-            }
-            return value;
+            fitHeight = false;
+            colors = new ArrayList();
+            colorLabels = new ArrayList();
         }
 
         public boolean getFitHeight() { return fitHeight; }

--- a/src/org/broad/igv/feature/basepair/BasePairTrack.java
+++ b/src/org/broad/igv/feature/basepair/BasePairTrack.java
@@ -41,4 +41,9 @@ public class BasePairTrack extends AbstractTrack {
     public void setDirection(int d){
         basePairRenderer.setDirection(d);
     }
+
+    public boolean getFitHeight() { return basePairRenderer.getFitHeight(); }
+
+    public void setFitHeight(boolean b) { basePairRenderer.setFitHeight(b); }
+
 }

--- a/src/org/broad/igv/feature/basepair/BasePairTrack.java
+++ b/src/org/broad/igv/feature/basepair/BasePairTrack.java
@@ -7,6 +7,7 @@ import org.broad.igv.session.IGVSessionReader;
 import org.broad.igv.session.SubtlyImportant;
 import org.broad.igv.track.AbstractTrack;
 import org.broad.igv.track.RenderContext;
+import org.broad.igv.ui.color.ColorUtilities;
 import org.broad.igv.util.ResourceLocator;
 
 import javax.xml.bind.annotation.*;
@@ -38,7 +39,6 @@ public class BasePairTrack extends AbstractTrack {
         super(locator, id, name);
         BasePairFileParser.loadData(locator, genome,
                                     basePairData, renderOptions);
-        // WIP: store colors and color labels in RenderOptions
     }
 
     public void render(RenderContext context, Rectangle rect) {
@@ -49,13 +49,18 @@ public class BasePairTrack extends AbstractTrack {
         return null;
     }
 
-    /*public ArcDirection getArcDirection(){ return renderOptions.getArcDirection(); }
-
-    public void setArcDirection(ArcDirection d){ renderOptions.setArcDirection(d); }
-
-    public boolean getFitHeight() { return renderOptions.getFitHeight(); }
-
-    public void setFitHeight(boolean b) { renderOptions.setFitHeight(b); }*/
+    public void changeColor(Color currentColor, String currentLabel, Color newColor) {
+        String currentColorString = ColorUtilities.colorToString(currentColor);
+        String newColorString = ColorUtilities.colorToString(newColor);
+        for (int i=0; i<renderOptions.getColors().size(); ++i) {
+            String colorString = renderOptions.getColors().get(i);
+            String label = renderOptions.getColorLabels().get(i);
+            if (!currentColorString.equals(colorString) || !currentLabel.equals(label)) {
+                continue;
+            }
+            renderOptions.setColor(i, newColorString);
+        }
+    }
 
     public RenderOptions getRenderOptions() {
         return this.renderOptions;
@@ -112,7 +117,6 @@ public class BasePairTrack extends AbstractTrack {
         public String getColorLabel(int i) { return this.colorLabels.get(i); }
 
         public void setColorLabel(int i, String s) { this.colorLabels.set(i, s); }
-
 
     }
 

--- a/src/org/broad/igv/feature/basepair/BasePairTrack.java
+++ b/src/org/broad/igv/feature/basepair/BasePairTrack.java
@@ -3,10 +3,12 @@ package org.broad.igv.feature.basepair;
 import org.apache.log4j.Logger;
 import org.broad.igv.feature.genome.*;
 import org.broad.igv.renderer.*;
+import org.broad.igv.session.SubtlyImportant;
 import org.broad.igv.track.AbstractTrack;
 import org.broad.igv.track.RenderContext;
 import org.broad.igv.util.ResourceLocator;
 
+import javax.xml.bind.annotation.*;
 import java.awt.*;
 
 /**
@@ -21,29 +23,68 @@ public class BasePairTrack extends AbstractTrack {
     private BasePairRenderer basePairRenderer = new BasePairRenderer();
     private BasePairData basePairData;
 
+    public enum ArcDirection {
+        UP, DOWN
+    }
+
+    private RenderOptions renderOptions = new RenderOptions();
+
+    // FIXME: store and load arc direction, fitHeight options in session files, like AlignmentTrack
     public BasePairTrack(ResourceLocator locator, String id, String name, Genome genome) {
         super(locator, id, name);
         basePairData = BasePairFileParser.loadData(locator, genome);
     }
 
     public void render(RenderContext context, Rectangle rect) {
-        basePairRenderer.draw(basePairData, context, rect);
+        basePairRenderer.draw(basePairData, context, rect, renderOptions);
     }
 
     public Renderer getRenderer() {
         return null;
     }
 
-    public int getDirection(){
-        return basePairRenderer.getDirection();
+    public ArcDirection getArcDirection(){ return renderOptions.getArcDirection(); }
+
+    public void setArcDirection(ArcDirection d){ renderOptions.setArcDirection(d); }
+
+    public boolean getFitHeight() { return renderOptions.getFitHeight(); }
+
+    public void setFitHeight(boolean b) { renderOptions.setFitHeight(b); }
+
+    @SubtlyImportant
+    private RenderOptions getRenderOptions() {
+        return this.renderOptions;
     }
 
-    public void setDirection(int d){
-        basePairRenderer.setDirection(d);
+    @XmlElement(name = RenderOptions.NAME)
+    private void setRenderOptions(RenderOptions renderOptions) {
+        this.renderOptions = renderOptions;
     }
 
-    public boolean getFitHeight() { return basePairRenderer.getFitHeight(); }
+    @XmlType(name = RenderOptions.NAME)
+    @XmlAccessorType(XmlAccessType.NONE)
+    public static class RenderOptions {
 
-    public void setFitHeight(boolean b) { basePairRenderer.setFitHeight(b); }
+        public static final String NAME = "RenderOptions";
 
+        @XmlAttribute
+        ArcDirection arcDirection;
+        @XmlAttribute
+        boolean fitHeight;
+
+
+        RenderOptions() {
+            // TODO: load some options from global PreferenceManager like AlignmentTrack
+            arcDirection = ArcDirection.DOWN;
+            fitHeight = false; // scale arc heights to fit current track height
+        }
+
+        public boolean getFitHeight() { return fitHeight; }
+
+        public void setFitHeight(boolean b) { this.fitHeight = b; }
+
+        public ArcDirection getArcDirection() { return arcDirection; }
+
+        public void setArcDirection(ArcDirection d) { this.arcDirection = d; }
+    }
 }

--- a/src/org/broad/igv/track/AbstractTrack.java
+++ b/src/org/broad/igv/track/AbstractTrack.java
@@ -30,6 +30,7 @@ package org.broad.igv.track;
 import org.apache.log4j.Logger;
 import org.broad.igv.Globals;
 import org.broad.igv.PreferenceManager;
+import org.broad.igv.feature.basepair.BasePairTrack;
 import org.broad.igv.gwas.GWASTrack;
 import org.broad.igv.renderer.*;
 import org.broad.igv.sam.AlignmentTrack;
@@ -64,7 +65,7 @@ import java.util.List;
  */
 @XmlType(factoryClass = IGVSessionReader.class, factoryMethod = "getNextTrack")
 @XmlAccessorType(XmlAccessType.NONE)
-@XmlSeeAlso({CoverageTrack.class, AlignmentTrack.class, DataSourceTrack.class, GWASTrack.class, FeatureTrack.class, MergedTracks.class})
+@XmlSeeAlso({CoverageTrack.class, AlignmentTrack.class, DataSourceTrack.class, GWASTrack.class, FeatureTrack.class, MergedTracks.class, BasePairTrack.class})
 public abstract class AbstractTrack implements Track {
 
     private static Logger log = Logger.getLogger(AbstractTrack.class);

--- a/src/org/broad/igv/track/TrackMenuUtils.java
+++ b/src/org/broad/igv/track/TrackMenuUtils.java
@@ -515,6 +515,30 @@ public class TrackMenuUtils {
     // stevenbusan
     public static void addBasePairItems(JPopupMenu menu, final Collection<Track> tracks) {
 
+        JCheckBoxMenuItem fitHeightBox = new JCheckBoxMenuItem("Fit arcs within track height");
+        for (Track track : tracks) {
+            if (track instanceof BasePairTrack) {
+                if (((BasePairTrack) track).getFitHeight()) {
+                    fitHeightBox.setSelected(true);
+                }
+            }
+        }
+        fitHeightBox.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent evt) {
+                AbstractButton b = (AbstractButton) evt.getSource();
+                boolean isSelected = b.getModel().isSelected();
+                for (Track track : tracks) {
+                    if (track instanceof BasePairTrack) {
+                        ((BasePairTrack) track).setFitHeight(isSelected);
+                    }
+                }
+                IGV.getInstance().repaint();
+            }
+        });
+        menu.add(fitHeightBox);
+
+        menu.addSeparator();
+
         JLabel arcDirectionHeading = new JLabel(LEADING_HEADING_SPACER + "Arc direction", JLabel.LEFT);
         arcDirectionHeading.setFont(UIConstants.boldFont);
 
@@ -691,6 +715,7 @@ public class TrackMenuUtils {
      */
     public static void addSharedItems(JPopupMenu menu, final Collection<Track> tracks, boolean hasFeatureTracks, boolean hasCoverageTracks) {
 
+        //JLabel trackSettingsHeading = new JLabel(LEADING_HEADING_SPACER + "Track Settings", JLabel.LEFT);
         //JLabel trackSettingsHeading = new JLabel(LEADING_HEADING_SPACER + "Track Settings", JLabel.LEFT);
         //trackSettingsHeading.setFont(boldFont);
         //menu.add(trackSettingsHeading);

--- a/src/org/broad/igv/track/TrackMenuUtils.java
+++ b/src/org/broad/igv/track/TrackMenuUtils.java
@@ -516,12 +516,9 @@ public class TrackMenuUtils {
     /**
      * Return popup menu with items applicable to BasePairTrack(s)
      *
-     * @return
+     * @author stevenbusan
      */
-    // stevenbusan
     public static void addBasePairItems(JPopupMenu menu, final Collection<Track> tracks) {
-
-        // WIP: color legend with interactive color selection dialog
 
         JLabel arcColorHeading = new JLabel(LEADING_HEADING_SPACER + "Arc color", JLabel.LEFT);
         arcColorHeading.setFont(UIConstants.boldFont);
@@ -564,16 +561,13 @@ public class TrackMenuUtils {
 
             JLabel colorBox = new JLabel(LEADING_HEADING_SPACER + "██"); //, JLabel.LEFT
             colorBox.setForeground(color);
-            
-            // FIXME: fix menu selection highlight, especially for blank label entries
+
             JPanel p = new JPanel();
             p.setLayout(new BoxLayout(p, BoxLayout.X_AXIS));
             p.add(colorBox);
             p.add(Box.createHorizontalStrut(1));
-            //p.add(Box.createGlue());
             p.add(new JLabel(" "+labelText));
-            //p.setBorder(BorderFactory.createEmptyBorder(2, 2, 2, 2));
-            //p.setMinimumSize(new Dimension(p.getWidth()+10 , p.getHeight()+20));
+            p.add(Box.createGlue());
             p.setAlignmentX(Component.LEFT_ALIGNMENT);
 
             JMenuItem item = new JMenuItem();
@@ -581,7 +575,7 @@ public class TrackMenuUtils {
             double w = p.getPreferredSize().getWidth();
             double h = p.getPreferredSize().getHeight();
             Dimension size = new Dimension();
-            size.setSize(w, h+10);
+            size.setSize(w, h+8);
             item.setPreferredSize(size);
 
             final ArrayList<Pair<BasePairTrack, Integer>> selected = legendMap.get(key).getSecond();

--- a/src/org/broad/igv/track/TrackMenuUtils.java
+++ b/src/org/broad/igv/track/TrackMenuUtils.java
@@ -528,7 +528,7 @@ public class TrackMenuUtils {
 
         menu.add(arcColorHeading);
 
-        // Attempt to aggregate arc color legends for multiple selected tracks
+        // Attempt to aggregate arc color selector/legends for multiple selected tracks
         // This is pretty ugly, sorry. should probably use a custom class for readability - stevenbusan
         LinkedHashMap<String,
                       Pair<String, ArrayList<Pair<BasePairTrack, Integer>>>>
@@ -537,12 +537,10 @@ public class TrackMenuUtils {
         // Make list of unique color+labels, linked to lists of all matching tracks and color indices,
         // key: color string + label
         // value: Pair<String label, List<Pair<BasePairTrack, int colorIndex>>>
-        Color tmpColor = new Color(255,255,255);
         for (Track track : tracks) {
             if (track instanceof BasePairTrack) {
                 List<String> colors = ((BasePairTrack) track).getRenderOptions().getColors();
                 List<String> colorLabels = ((BasePairTrack) track).getRenderOptions().getColorLabels();
-                tmpColor = ColorUtilities.stringToColor(colors.get(0));
                 // iterate in reverse order so colors appearing first in list are the ones rendered on top
                 for (int i=colors.size()-1; i>=0; --i) {
                     String key = colors.get(i) + ' ' + colorLabels.get(i);
@@ -566,8 +564,7 @@ public class TrackMenuUtils {
 
             JLabel colorBox = new JLabel(LEADING_HEADING_SPACER + "██"); //, JLabel.LEFT
             colorBox.setForeground(color);
-
-            // FIXME: fix padding so legend text is clearly visible
+            
             // FIXME: fix menu selection highlight, especially for blank label entries
             JPanel p = new JPanel();
             p.setLayout(new BoxLayout(p, BoxLayout.X_AXIS));
@@ -581,6 +578,11 @@ public class TrackMenuUtils {
 
             JMenuItem item = new JMenuItem();
             item.add(p);
+            double w = p.getPreferredSize().getWidth();
+            double h = p.getPreferredSize().getHeight();
+            Dimension size = new Dimension();
+            size.setSize(w, h+10);
+            item.setPreferredSize(size);
 
             final ArrayList<Pair<BasePairTrack, Integer>> selected = legendMap.get(key).getSecond();
 

--- a/src/org/broad/igv/track/TrackMenuUtils.java
+++ b/src/org/broad/igv/track/TrackMenuUtils.java
@@ -584,31 +584,6 @@ public class TrackMenuUtils {
 
         menu.addSeparator();
 
-        // preselect fit arcs option if all selected tracks have it enabled
-        int fitCount = 0;
-        int noFitCount = 0;
-        boolean fitHeight = false; // mixed fit/no fit height or all no fit
-        for (BasePairTrack track: bpTracks) {
-            if (track.getRenderOptions().getFitHeight()) ++fitCount; else ++noFitCount;
-        }
-        if (noFitCount==0) fitHeight = true;
-
-        JCheckBoxMenuItem fitHeightBox = new JCheckBoxMenuItem("Fit arcs within track height");
-        fitHeightBox.setSelected(fitHeight);
-        fitHeightBox.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent evt) {
-            AbstractButton b = (AbstractButton) evt.getSource();
-            boolean isSelected = b.getModel().isSelected();
-            for (BasePairTrack track : bpTracks) {
-                track.getRenderOptions().setFitHeight(isSelected);
-            }
-            IGV.getInstance().repaint();
-            }
-        });
-        menu.add(fitHeightBox);
-
-        menu.addSeparator();
-
         JLabel arcDirectionHeading = new JLabel(LEADING_HEADING_SPACER + "Arc direction", JLabel.LEFT);
         arcDirectionHeading.setFont(UIConstants.boldFont);
 
@@ -647,6 +622,31 @@ public class TrackMenuUtils {
             menu.add(mm);
         }
 
+        menu.addSeparator();
+
+        // preselect fit arcs option if all selected tracks have it enabled
+        int fitCount = 0;
+        int noFitCount = 0;
+        boolean fitHeight = false; // mixed fit/no fit height or all no fit
+        for (BasePairTrack track: bpTracks) {
+            if (track.getRenderOptions().getFitHeight()) ++fitCount; else ++noFitCount;
+        }
+        if (noFitCount==0) fitHeight = true;
+
+        JCheckBoxMenuItem fitHeightBox = new JCheckBoxMenuItem("Fit arcs within track height");
+        fitHeightBox.setSelected(fitHeight);
+        fitHeightBox.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent evt) {
+                AbstractButton b = (AbstractButton) evt.getSource();
+                boolean isSelected = b.getModel().isSelected();
+                for (BasePairTrack track : bpTracks) {
+                    track.getRenderOptions().setFitHeight(isSelected);
+                }
+                IGV.getInstance().repaint();
+            }
+        });
+        menu.add(fitHeightBox);
+        
     }
 
     private static JMenuItem getFeatureToGeneListItem(final Track t) {

--- a/src/org/broad/igv/track/TrackMenuUtils.java
+++ b/src/org/broad/igv/track/TrackMenuUtils.java
@@ -513,6 +513,7 @@ public class TrackMenuUtils {
      * @return
      */
     // stevenbusan
+    // FIXME: move to BasePairTrack like AlignmentTrack
     public static void addBasePairItems(JPopupMenu menu, final Collection<Track> tracks) {
 
         JCheckBoxMenuItem fitHeightBox = new JCheckBoxMenuItem("Fit arcs within track height");

--- a/src/org/broad/igv/track/TrackMenuUtils.java
+++ b/src/org/broad/igv/track/TrackMenuUtils.java
@@ -546,12 +546,13 @@ public class TrackMenuUtils {
 
         final String[] arcDirectionLabels = {"Up", "Down"};
 
+        // FIXME: make this a mutually exclusive combo box list
         for (int i = 0; i < arcDirectionLabels.length; i++) {
             JCheckBoxMenuItem item = new JCheckBoxMenuItem(arcDirectionLabels[i]);
-            final int n = (i == 0) ? 1 : -1;
+            final BasePairTrack.ArcDirection n = (i == 0) ? BasePairTrack.ArcDirection.UP : BasePairTrack.ArcDirection.DOWN;
             for (Track track : tracks) {
                 if (track instanceof BasePairTrack) {
-                    if (((BasePairTrack) track).getDirection() == n) {
+                    if (((BasePairTrack) track).getArcDirection() == n) {
                         item.setSelected(true);
                     }
                 }
@@ -560,7 +561,7 @@ public class TrackMenuUtils {
                 public void actionPerformed(ActionEvent evt) {
                     for (Track track : tracks) {
                         if (track instanceof BasePairTrack) {
-                            ((BasePairTrack) track).setDirection(n);
+                            ((BasePairTrack) track).setArcDirection(n);
                         }
                     }
                     IGV.getInstance().repaint();

--- a/src/org/broad/igv/track/TrackMenuUtils.java
+++ b/src/org/broad/igv/track/TrackMenuUtils.java
@@ -646,7 +646,7 @@ public class TrackMenuUtils {
             }
         });
         menu.add(fitHeightBox);
-        
+
     }
 
     private static JMenuItem getFeatureToGeneListItem(final Track t) {


### PR DESCRIPTION
Added option to fit arcs within track height.
Added editable arc colors legend to track menu, and hid unused track color menu entry for BasePairTracks.
Arc color, height fit, and direction options are all now saved to session files.
Adjusted default pairing probability arc colors.

[example_data.zip](https://github.com/igvteam/igv/files/832406/example_data.zip)

- Steve
