### PR TITLE
Fix #416: black images from batch snapshot

### DIFF
--- a/src/org/broad/igv/batch/CommandExecutor.java
+++ b/src/org/broad/igv/batch/CommandExecutor.java
@@ -874,7 +874,7 @@ public class CommandExecutor {
         }
 
         try {
-            return IGV.getInstance().createSnapshotNonInteractive(target, file, true);
+            return IGV.getInstance().createSnapshotNonInteractive(target, file, false);
         } catch (IOException e) {
             log.error(e);
             return e.getMessage();


### PR DESCRIPTION
Fix issue #416 where the batch "snapshot" command produces a fully black image.

This modification does correct the problem for me, but I am not certain that it is the right fix.  This adjusts a code change from Jan 2013 in 9cffc1026274a038aff8f0.