### PR TITLE
Fix inability to zoom out when tracks were initially loaded from port/batch

### DIFF
--- a/src/org/broad/igv/lists/Preloader.java
+++ b/src/org/broad/igv/lists/Preloader.java
@@ -69,6 +69,7 @@ public class Preloader {
         ReferenceFrame frame = dataPanel.getFrame();
         Collection<Track> trackList = dataPanel.visibleTracks();
         List<CompletableFuture> futures = new ArrayList(trackList.size());
+        boolean batchLoaded = false;
         for (Track track : trackList) {
             if (track.isReadyToPaint(frame) == false) {
                 final Runnable runnable = () -> {
@@ -80,13 +81,14 @@ public class Preloader {
 
                 if(Globals.isBatch()) {
                     runnable.run();
+                    batchLoaded = true;
                 } else {
                     futures.add(CompletableFuture.runAsync(runnable, threadExecutor));
                 }
             }
         }
 
-        if (futures.size() > 0) {
+        if (futures.size() > 0 || batchLoaded) {
             final CompletableFuture[] futureArray = futures.toArray(new CompletableFuture[futures.size()]);
             WaitCursorManager.CursorToken token = WaitCursorManager.showWaitCursor();
             CompletableFuture.allOf(futureArray).thenRun(() -> {


### PR DESCRIPTION
OK, #361 was driving me bonkers, so I dug into this with the debugger.

During batch loading of a VCF, `DataPanel.paintComponent()` is doing `loadInProgress = true` and then calling `Preloader.load()`. Inside that load method, `loadInProgress` is only set back to false when the features are loaded asynchronously, **not** for the case when `Globals.isBatch()` is true.

Even when loading from batch/port, we need to ensure that `loadInProgress`
is reset to false after loading is completed, otherwise subsequent interactive `DataPanel.paintComponent()` calls never call `Preloader.load()` to fetch the variants we need after e.g. zoom out operations.
