### PR TITLE
Fix crash when choosing files on Windows 10.

### DIFF
--- a/src/org/broad/igv/ui/Main.java
+++ b/src/org/broad/igv/ui/Main.java
@@ -91,6 +91,14 @@ public class Main {
 
         Runnable runnable = new Runnable() {
             public void run() {
+
+                // This is a workaround for an internal JVM crash that was happening on Windows 10 (Creators Update).
+                // TODO: remove when enough users have migrated to Java 8u141 or greater.
+                // http://bugs.java.com/bugdatabase/view_bug.do?bug_id=JDK-8179014
+                if (Globals.IS_WINDOWS && System.getProperty("os.name").contains("10")) {
+                    UIManager.put("FileChooser.useSystemExtensionHiding", false);
+                }
+
                 initApplication();
 
                 JFrame frame = new JFrame();


### PR DESCRIPTION
There's a nasty crash happening in the latest version of Windows 10 (Creators Update) and the latest JRE, where creating an instance of JFileChooser causes an internal access violation. The bug is documented [here](http://bugs.java.com/bugdatabase/view_bug.do?bug_id=JDK-8179014), and contains a workaround that I've provided in this patch.

The only consequence for the user is that the FileChooser will explicitly show file extensions, which may not correspond to the user's global preference, but at least it doesn't crash.