### PR TITLE
Allow setting NAME_PANEL_WIDTH to 0

### DIFF
--- a/src/org/broad/igv/ui/IGVMenuBar.java
+++ b/src/org/broad/igv/ui/IGVMenuBar.java
@@ -745,11 +745,11 @@ public class IGVMenuBar extends JMenuBar implements IGVEventObserver {
                 if (newValue != null) {
                     try {
                         Integer w = Integer.parseInt(newValue);
-                        if (w <= 0 || w == 1000) throw new NumberFormatException();
+                        if (w < 0 || w == 1000) throw new NumberFormatException();
                         PreferencesManager.getPreferences().put(NAME_PANEL_WIDTH, newValue);
                         mainPanel.setNamePanelWidth(w);
                     } catch (NumberFormatException ex) {
-                        MessageUtils.showErrorMessage("Error: value must be a positive integer < 1000.", ex);
+                        MessageUtils.showErrorMessage("Error: value must be a non-negative integer < 1000.", ex);
                     }
                 }
             }


### PR DESCRIPTION
Setting NAME_PANEL_WIDTH to 0 was already how igv handles making the Name Panel non-visible, but it throws an exception if it is set to 0 by the user or the prefs.properties file. This change allows the user to make the Name Panel invisible by default.