### PR TITLE
Build updates for Java 9 tests

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -310,6 +310,8 @@
         <junit haltonfailure="no" showoutput="${show.test.out}" printsummary="on" failureproperty="tests.failed"
                maxmemory="2000m">
 
+            <jvmarg value="-XX:+IgnoreUnrecognizedVMOptions"/>
+            <jvmarg line="--add-modules=java.xml.bind"/>
             <jvmarg value="-javaagent:${testlib.dir}/JavaAgent.jar"/>
             <jvmarg value="-Dfile.encoding=${java.encoding}"/>
             <jvmarg value="-Dinclude.longrunning=${include.longrunning}"/>
@@ -317,6 +319,7 @@
             <sysproperty key="LARGE_DATA_DIR" value="${LARGE_DATA_DIR}"/>
             <sysproperty key="MONGO_EXEC_PATH" value="${MONGO_EXEC_PATH}"/>
             <sysproperty key="make.fail" value="${make.fail}"/>
+        	<sysproperty key="java.awt.headless" value="true" />
 
             <classpath refid="test.classpath"/>
             <formatter type="xml" usefile="true"/>

--- a/test/README.txt
+++ b/test/README.txt
@@ -32,3 +32,5 @@ ant -Dfilesetpattern=IgvToolsTest tests
 
 would run only those test classes named IgvToolsTest.
 
+The build assumes that Apache BCEL is available.  If you have failing tests, add the BCEL JAR file to your
+$ANT_HOME/lib directory.


### PR DESCRIPTION
Minor modifications to the build to allow the tests to run under Java 9.
This does *not* affect building the application.