### PR TITLE
Updated JNLPs to work with Java 9

### DIFF
--- a/web/jnlp/igv24.jnlp
+++ b/web/jnlp/igv24.jnlp
@@ -22,6 +22,7 @@
   <update check="always"/>
   <resources>
     <java version="1.8+"
+          java-vm-args="-XX:+IgnoreUnrecognizedVMOptions --illegal-access=permit --add-modules=java.xml.bind"
           initial-heap-size="256m"
           max-heap-size="750m" />
     <jar href="igv.jar" download="eager" main="true"/>

--- a/web/jnlp/igv24_hm.jnlp
+++ b/web/jnlp/igv24_hm.jnlp
@@ -22,6 +22,7 @@
   <update check="always"/>
   <resources>
     <java version="1.8+"
+          java-vm-args="-XX:+IgnoreUnrecognizedVMOptions --illegal-access=permit --add-modules=java.xml.bind"
           initial-heap-size="256m"
           max-heap-size="10000m"/>
     <jar href="igv.jar" download="eager" main="true"/>

--- a/web/jnlp/igv24_lm.jnlp
+++ b/web/jnlp/igv24_lm.jnlp
@@ -22,6 +22,7 @@
   <update check="always"/>
   <resources>
     <java version="1.8+"
+          java-vm-args="-XX:+IgnoreUnrecognizedVMOptions --illegal-access=permit --add-modules=java.xml.bind"
           initial-heap-size="256m"
           max-heap-size="1800m"/>
     <jar href="igv.jar" download="eager" main="true"/>

--- a/web/jnlp/igv24_mm.jnlp
+++ b/web/jnlp/igv24_mm.jnlp
@@ -22,6 +22,7 @@
   <update check="always"/>
   <resources>
     <java version="1.8+"
+          java-vm-args="-XX:+IgnoreUnrecognizedVMOptions --illegal-access=permit --add-modules=java.xml.bind"
           initial-heap-size="256m"
           max-heap-size="1100m"/>
     <jar href="igv.jar" download="eager" main="true"/>


### PR DESCRIPTION
Added some Java VM args to allow IGV to launch using Java 9.  It's
possible we'll find some more of these in further testing but this is
what we know so far.