### PR TITLE
Genome position output in ruler mode

### DIFF
--- a/src/org/broad/igv/ui/IGV.java
+++ b/src/org/broad/igv/ui/IGV.java
@@ -2073,9 +2073,6 @@ public class IGV implements IGVEventObserver {
     }
 
     public void setRulerEnabled(boolean rulerEnabled) {
-        if (!rulerEnabled){
-            setStatusBarMessage3("");
-        }
         this.rulerEnabled = rulerEnabled;
     }
 

--- a/src/org/broad/igv/ui/IGV.java
+++ b/src/org/broad/igv/ui/IGV.java
@@ -2073,6 +2073,9 @@ public class IGV implements IGVEventObserver {
     }
 
     public void setRulerEnabled(boolean rulerEnabled) {
+        if (!rulerEnabled){
+            setStatusBarMessage3("");
+        }
         this.rulerEnabled = rulerEnabled;
     }
 

--- a/src/org/broad/igv/ui/panel/DataPanelContainer.java
+++ b/src/org/broad/igv/ui/panel/DataPanelContainer.java
@@ -148,6 +148,12 @@ public class DataPanelContainer extends TrackPanelComponent implements Paintable
             int start = MouseInfo.getPointerInfo().getLocation().x - getLocationOnScreen().x;
             g.setColor(Color.BLACK);
             g.drawLine(start, 0, start, getHeight());
+
+            if (!FrameManager.isGeneListMode()) {
+                ReferenceFrame frame = FrameManager.getDefaultFrame();
+                int pos = (int) frame.getChromosomePosition(start) + 1;
+                IGV.getInstance().setStatusBarMessage3(" " + Integer.toString(pos));
+            }
         }
     }
 

--- a/src/org/broad/igv/ui/panel/DataPanelContainer.java
+++ b/src/org/broad/igv/ui/panel/DataPanelContainer.java
@@ -36,6 +36,7 @@ import org.broad.igv.ui.MessageCollection;
 import org.broad.igv.ui.util.MessageUtils;
 import org.broad.igv.util.HttpUtils;
 import org.broad.igv.util.ResourceLocator;
+import org.broad.igv.Globals;
 
 import java.awt.*;
 import java.awt.datatransfer.DataFlavor;
@@ -151,8 +152,10 @@ public class DataPanelContainer extends TrackPanelComponent implements Paintable
             g.setColor(Color.BLACK);
             g.drawLine(start, 0, start, getHeight());
 
-            if (!FrameManager.isGeneListMode()) {
-                ReferenceFrame frame = FrameManager.getDefaultFrame();
+            ReferenceFrame frame = FrameManager.getDefaultFrame();
+            boolean all_chr_mode = frame.getChrName().equals(Globals.CHR_ALL);
+
+            if (!FrameManager.isGeneListMode() && !all_chr_mode) {
                 int pos = (int) frame.getChromosomePosition(start) + 1;
                 int y = MouseInfo.getPointerInfo().getLocation().y - getLocationOnScreen().y;
                 g.setFont(FontManager.getDefaultFont());

--- a/src/org/broad/igv/ui/panel/DataPanelContainer.java
+++ b/src/org/broad/igv/ui/panel/DataPanelContainer.java
@@ -25,8 +25,6 @@
 
 package org.broad.igv.ui.panel;
 
-import org.broad.igv.ui.FontManager;
-
 import org.apache.log4j.Logger;
 import org.broad.igv.exceptions.DataLoadException;
 import org.broad.igv.renderer.DataRange;
@@ -36,7 +34,9 @@ import org.broad.igv.ui.MessageCollection;
 import org.broad.igv.ui.util.MessageUtils;
 import org.broad.igv.util.HttpUtils;
 import org.broad.igv.util.ResourceLocator;
+import org.broad.igv.ui.FontManager;
 import org.broad.igv.Globals;
+import java.text.DecimalFormat;
 
 import java.awt.*;
 import java.awt.datatransfer.DataFlavor;
@@ -153,13 +153,14 @@ public class DataPanelContainer extends TrackPanelComponent implements Paintable
             g.drawLine(start, 0, start, getHeight());
 
             ReferenceFrame frame = FrameManager.getDefaultFrame();
-            boolean all_chr_mode = frame.getChrName().equals(Globals.CHR_ALL);
+            boolean allChrMode = frame.getChrName().equals(Globals.CHR_ALL);
 
-            if (!FrameManager.isGeneListMode() && !all_chr_mode) {
-                int pos = (int) frame.getChromosomePosition(start) + 1;
+            if (!FrameManager.isGeneListMode() && !allChrMode) {
                 int y = MouseInfo.getPointerInfo().getLocation().y - getLocationOnScreen().y;
+                int pos = (int) frame.getChromosomePosition(start) + 1;
+
                 g.setFont(FontManager.getDefaultFont());
-                g.drawString(Integer.toString(pos), start+10, y+30);
+                g.drawString(Globals.DECIMAL_FORMAT.format((double) pos), start + 10, y + 30);
             }
         }
     }

--- a/src/org/broad/igv/ui/panel/DataPanelContainer.java
+++ b/src/org/broad/igv/ui/panel/DataPanelContainer.java
@@ -25,6 +25,8 @@
 
 package org.broad.igv.ui.panel;
 
+import org.broad.igv.ui.FontManager;
+
 import org.apache.log4j.Logger;
 import org.broad.igv.exceptions.DataLoadException;
 import org.broad.igv.renderer.DataRange;
@@ -152,7 +154,9 @@ public class DataPanelContainer extends TrackPanelComponent implements Paintable
             if (!FrameManager.isGeneListMode()) {
                 ReferenceFrame frame = FrameManager.getDefaultFrame();
                 int pos = (int) frame.getChromosomePosition(start) + 1;
-                IGV.getInstance().setStatusBarMessage3(" " + Integer.toString(pos));
+                int y = MouseInfo.getPointerInfo().getLocation().y - getLocationOnScreen().y;
+                g.setFont(FontManager.getDefaultFont());
+                g.drawString(Integer.toString(pos), start+10, y+30);
             }
         }
     }


### PR DESCRIPTION
Hello. I really suffered without this feature. 

![screenshot from 2017-11-17 15-41-16](https://user-images.githubusercontent.com/1766152/32952764-87e16c1c-cbae-11e7-8ea5-8d9f71fb55a9.png)

I also can add enabling this tooltip in the preferences. 
In the first commit, I wanted to move the output to the status bar, but there were strange window blinkings when you move through the genome when the sequence track is shown.
