### PR TITLE
Change CGIAlignmentReader.hasIndex to return true.

### DIFF
--- a/src/org/broad/igv/sam/reader/CGIAlignmentReader.java
+++ b/src/org/broad/igv/sam/reader/CGIAlignmentReader.java
@@ -201,7 +201,7 @@ public class CGIAlignmentReader implements AlignmentReader {
             BufferedInputStream stream = new BufferedInputStream(is, 500000);
             SamInputResource resource = SamInputResource.of(stream);
             SamReader reader = factory.open(resource);
-            
+
             CloseableIterator<SAMRecord> iter = reader.iterator();
             return new SAMQueryIterator(sequence, start, end, contained, iter);
 
@@ -212,7 +212,7 @@ public class CGIAlignmentReader implements AlignmentReader {
     }
 
     public boolean hasIndex() {
-        return false;  //To change body of implemented methods use File | Settings | File Templates.
+        return true;
     }
 
     public static void main(String[] args) throws IOException {


### PR DESCRIPTION
If hasIndex()=false, loading alignment records via "Open URL" menu fails always.
It doesn't hurt to change hasIndex() to be true, since the remote server can
still return an error if it can't handle queries.

Background: I'm trying to load reads from a remote BAM-like (but not quite BAM)
file.  I found CGIAlignmentReader to be the easiest hook to achieve that.