### PR TITLE
Remove duplicate SAM_RELOAD_KEYS list

### DIFF
--- a/src/org/broad/igv/prefs/IGVPreferences.java
+++ b/src/org/broad/igv/prefs/IGVPreferences.java
@@ -889,26 +889,4 @@ public class IGVPreferences {
     }
 
 
-    /**
-     * List of keys that affect the alignments loaded.  This list is used to trigger a reload, if required.
-     * Not all alignment preferences need trigger a reload, this is a subset.
-     */
-    static java.util.List<String> SAM_RELOAD_KEYS = Arrays.asList(
-            SAM_QUALITY_THRESHOLD,
-            SAM_FILTER_ALIGNMENTS,
-            SAM_FILTER_URL,
-            SAM_MAX_VISIBLE_RANGE,
-            SAM_SHOW_DUPLICATES,
-            SAM_SHOW_SOFT_CLIPPED,
-            SAM_SAMPLING_COUNT,
-            SAM_SAMPLING_WINDOW,
-            SAM_FILTER_FAILED_READS,
-            SAM_DOWNSAMPLE_READS,
-            SAM_FILTER_SECONDARY_ALIGNMENTS,
-            SAM_FILTER_SUPPLEMENTARY_ALIGNMENTS,
-            SAM_JUNCTION_MIN_FLANKING_WIDTH,
-            SAM_JUNCTION_MIN_COVERAGE
-    );
-
-
 }


### PR DESCRIPTION
The list of preferences that trigger a reload is duplicated in `prefs/IGVPreferences.java` and `prefs/Constants.java`, which itself is imported in `IGVPreferences.java`.  I think the list in `Constants.java` should be the single, authoritative version.

I noticed this when adding a new preference in my local branch.  I added the preference to SAM_RELOAD_KEYS list in `Constants.java`, but it had no effect since it was being overridden by the duplicate list in `IGVPreferences.java`.  This PR should not impact current behavior and simply removes duplicate logic that currently has to be synchronized.