### PR TITLE
Be robust to invalid SA entries

### DIFF
--- a/src/org/broad/igv/sam/SAMAlignment.java
+++ b/src/org/broad/igv/sam/SAMAlignment.java
@@ -651,8 +651,13 @@ public abstract class SAMAlignment implements Alignment {
         buf.append("SupplementaryAlignments");
         String[] records = Globals.semicolonPattern.split(sa);
         for (String rec : records) {
-            SupplementaryAlignment a = new SupplementaryAlignment(rec);
-            buf.append("<br>" + a.printString());
+            try {
+                SupplementaryAlignment a = new SupplementaryAlignment(rec);
+                buf.append("<br>" + a.printString());
+            }
+            catch (Exception e) {
+                buf.append("<br>* Invalid SA entry (not listed) *");
+            }
         }
         return buf.toString();
     }


### PR DESCRIPTION
The alignment details popover parses supplementary alignment (SA) entries.
Invalid entries that raise an exception during parsing suppress the popover.
This catches those exceptions and warns about invalid entries.

Closes #521