### PR TITLE
Reimplement BasePairTrack features lost around 2.4.0

### DIFF
--- a/src/main/java/org/broad/igv/feature/basepair/BasePairFeature.java
+++ b/src/main/java/org/broad/igv/feature/basepair/BasePairFeature.java
@@ -40,11 +40,11 @@ public class BasePairFeature implements Feature{
     int startRight;
     int endLeft;
     int endRight;
-    Color color;
+    int colorIndex;
 
-    public BasePairFeature(String chr,  int startLeft, int startRight, int endLeft, int endRight,  Color color) {
+    public BasePairFeature(String chr,  int startLeft, int startRight, int endLeft, int endRight,  int colorIndex) {
         this.chr = chr;
-        this.color = color;
+        this.colorIndex = colorIndex;
         this.endLeft = endLeft;
         this.endRight = endRight;
         this.startLeft = startLeft;
@@ -79,14 +79,9 @@ public class BasePairFeature implements Feature{
 
     public int getEndRight() { return endRight; }
 
-    public Color getColor() { return color; }
-
-
-    public String toStringNoColor() {
-        return getChr() + "\t" + startLeft + "\t" + startRight + "\t" + endLeft + "\t" + endRight;
-    }
+    public int getColorIndex() { return colorIndex; }
 
     public String toString() {
-        return toStringNoColor() + "\t" + color;
+        return getChr() + "\t" + startLeft + "\t" + startRight + "\t" + endLeft + "\t" + endRight;
     }
 }

--- a/src/main/java/org/broad/igv/feature/basepair/BasePairRenderer.java
+++ b/src/main/java/org/broad/igv/feature/basepair/BasePairRenderer.java
@@ -1,40 +1,25 @@
-// previously ArcRenderer
-
 package org.broad.igv.feature.basepair;
 
 //~--- non-JDK imports --------------------------------------------------------
 
 import org.apache.log4j.Logger;
+import org.broad.igv.feature.basepair.BasePairTrack.*;
 import org.broad.igv.track.RenderContext;
+import org.broad.igv.ui.color.ColorUtilities;
 
 import java.awt.*;
 import java.awt.geom.GeneralPath;
 
-// TODO: add vertical scaling option so arcs fit on track, or clip arcs outside of track rect?
-// TODO: add visualization for very zoomed-out views
+// TODO: add alternative visualization for very zoomed-out views
 
 public class BasePairRenderer {
 
     private static Logger log = Logger.getLogger(BasePairRenderer.class);
 
-    Color ARC_COLOR_A = new Color(50, 50, 150, 140); //transparent dull blue
-    Color ARC_COLOR_B = new Color(150, 50, 50, 140); //transparent dull red
-    Color ARC_COLOR_C = new Color(50, 0, 50, 250);
-
-    int dir = -1; // 1 for up, -1 for down
-
-    // central horizontal line color
-    Color COLOR_CENTERLINE = new Color(0, 0, 0, 100);
-
-    public int getDirection(){
-        return dir;
-    }
-
-    public void setDirection(int d){
-        dir = d;
-    }
-
-    public void draw(BasePairData data, RenderContext context, Rectangle trackRectangle){
+    public void draw(BasePairData data,
+                     RenderContext context,
+                     Rectangle trackRectangle,
+                     RenderOptions renderOptions){
 
         double nucsPerPixel = context.getScale();
         double origin = context.getOrigin();
@@ -44,55 +29,34 @@ public class BasePairRenderer {
         int end = (int) (origin + trackRectangle.width * nucsPerPixel) + 1;
         if (end <= start) return;
 
-        // TODO: make this a function
-
         java.util.List<BasePairFeature> featureList = data.getFeatures(context.getChr());
 
         if (featureList != null) {
 
-            for (BasePairFeature feature : featureList) {
+            // render in order of indexed colors
+            // FIXME: this is inefficient/slow (but not too bad in practice for most current use cases)
+            for (int colorIndex=0; colorIndex<renderOptions.getColors().size(); ++colorIndex) {
+                for (BasePairFeature feature : featureList) {
 
-                if(feature.startLeft > context.getEndLocation()) break;
-                else if(feature.endRight < context.getOrigin()) continue;
+                    if(feature.startLeft > context.getEndLocation()) break;
+                    else if(feature.endRight < context.getOrigin()) continue;
+                    else if (feature.colorIndex != colorIndex) continue;
 
-                //System.out.println("Color: "+data.colors[i]);
-                int arcCount = 0;
+                    double startLeftPix = (feature.startLeft - origin) / nucsPerPixel;
+                    double startRightPix = (feature.startRight + 1.0 - origin) / nucsPerPixel;
+                    double endLeftPix = (feature.endLeft - origin) / nucsPerPixel;
+                    double endRightPix = (feature.endRight + 1.0 - origin) / nucsPerPixel;
 
-                //System.out.println("In arcRenderer.draw(): ");
-                //System.out.println("    track.width = " + trackRectangle.width);
-                //System.out.println("    nucsPerPixel = " + nucsPerPixel);
-                //System.out.println("    origin = " + origin);
-                //System.out.println("    start = " + start);
-                //System.out.println("    end = " + end);
+                    Color color = ColorUtilities.stringToColor(renderOptions.getColors().get(feature.colorIndex));
 
-                double startLeftPix = (feature.startLeft - origin) / nucsPerPixel;
-                double startRightPix = (feature.startRight + 1.0 - origin) / nucsPerPixel;
-                double endLeftPix = (feature.endLeft - origin) / nucsPerPixel;
-                double endRightPix = (feature.endRight + 1.0 - origin) / nucsPerPixel;
+                    boolean drawOutline=false;
+                    drawArc(startLeftPix, startRightPix, endLeftPix, endRightPix,
+                            trackRectangle, context, color,
+                            renderOptions.getArcDirection(), drawOutline);
 
-                drawArc(startLeftPix, startRightPix, endLeftPix, endRightPix, trackRectangle, context, feature.color);
-                arcCount++;
-
-                //System.out.println("    leftStart = " + leftStartNucPix);
-                //System.out.println("    leftEnd = " + leftEndNucPix);
-                //System.out.println("    rightStart = " + rightStartNucPix);
-                //System.out.println("    rightEnd = " + rightEndNucPix);
-                //System.out.println("    arcWidth = " + arcWidthPix);
-
-                //drawArc(10, 210, 50, trackRectangle, context, ARC_COLOR_B);
-                //drawArc(300, 500, 50, trackRectangle, context, ARC_COLOR_A);
-
-
-                //System.out.println("Drew "+arcCount+" arcs");
+                }
             }
         }
-        //System.out.println("");
-
-        //draw a central horizontal line
-        //Graphics2D g2D = context.getGraphic2DForColor(COLOR_CENTERLINE);
-
-        //g2D.drawLine((int) trackRectangle.getX(), y,
-        //        (int) trackRectangle.getMaxX(), y);
     }
 
 
@@ -108,15 +72,18 @@ public class BasePairRenderer {
      * @param trackRectangle
      * @param context
      * @param featureColor       the color specified for this feature.  May be null.
+     * @param arcDirection up or down
+     * @param drawOutline render outline around arc shape so always visible even when zoomed out
      */
     protected void drawArc(double startLeft, double startRight, double endLeft, double endRight,
-                           Rectangle trackRectangle, RenderContext context, Color featureColor) {
+                           Rectangle trackRectangle, RenderContext context, Color featureColor,
+                           ArcDirection arcDirection, boolean drawOutline) {
 
         Color color;
         if (featureColor != null) {
             color = featureColor;
         } else {
-            color = ARC_COLOR_A;
+            color = new Color(50, 50, 150, 140);
         }
 
         Graphics2D g2D = context.getGraphic2DForColor(color);
@@ -131,6 +98,9 @@ public class BasePairRenderer {
         double innerRadius = (double) (endLeft-startRight)/2.0;
 
         double arcWidth = Math.max(1.0, startRight-startLeft);
+
+        int dir  = 1; // 1 for up, -1 for down
+        if (arcDirection == ArcDirection.DOWN) dir = -1;
 
         int y = 0;
         if (dir>0){
@@ -183,54 +153,29 @@ public class BasePairRenderer {
         int innerLX = (int) (trackRectangle.getX() + startLeft + arcWidth);
         int innerLY = outerLY;
 
-        if (false){
-            GeneralPath arcCage = new GeneralPath();
-            arcCage.moveTo(outerLX, outerLY); // outer left
-            arcCage.lineTo(outerLC1X, outerLC1Y);
-            arcCage.lineTo(outerLC2X, outerLC2Y);
-            arcCage.lineTo(outerCenterX, outerCenterY); // outer left control 1, outer left control 2, outer center
-            arcCage.lineTo(outerRC1X, outerRC1Y);
-            arcCage.lineTo(outerRC2X, outerRC2Y);
-            arcCage.lineTo(outerRX, outerRY);// outer right control 1, outer right control 2, outer right
-            arcCage.lineTo(innerRX, innerRY); // inner right
-            arcCage.lineTo(innerRC1X, innerRC1Y);
-            arcCage.lineTo(innerRC2X, innerRC2Y);
-            arcCage.lineTo(innerCenterX, innerCenterY); // inner right control 1, inner right control 2, inner center
-            arcCage.lineTo(innerLC1X, innerLC1Y);
-            arcCage.lineTo(innerLC2X, innerLC2Y);
-            arcCage.lineTo(innerLX, innerLY); // inner left control 1, inner left control 2, inner left
-            arcCage.lineTo(outerLX, outerLY); // outer left
-            arcCage.moveTo(outerLX, outerLY);
-            arcCage.closePath();
-            // Draw the shape
-            //g2D.draw(arcCage);
-            g2D.fill(arcCage);
-        }
+        GeneralPath arcPath = new GeneralPath();
+        arcPath.moveTo(outerLX, outerLY); // outer left
+        arcPath.curveTo(outerLC1X, outerLC1Y,
+                outerLC2X, outerLC2Y,
+                outerCenterX, outerCenterY); // outer left control 1, outer left control 2, outer center
+        arcPath.curveTo(outerRC1X, outerRC1Y,
+                outerRC2X, outerRC2Y,
+                outerRX, outerRY);// outer right control 1, outer right control 2, outer right
+        arcPath.lineTo(innerRX, innerRY); // inner right
+        arcPath.curveTo(innerRC1X, innerRC1Y,
+                innerRC2X, innerRC2Y,
+                innerCenterX, innerCenterY); // inner right control 1, inner right control 2, inner center
+        arcPath.curveTo(innerLC1X, innerLC1Y,
+                innerLC2X, innerLC2Y,
+                innerLX, innerLY); // inner left control 1, inner left control 2, inner left
+        arcPath.lineTo(outerLX, outerLY); // outer left
+        arcPath.moveTo(outerLX, outerLY);
+        arcPath.closePath();
 
-        // Create path
-        if (true){
-            GeneralPath arcPath = new GeneralPath();
-            arcPath.moveTo(outerLX, outerLY); // outer left
-            arcPath.curveTo(outerLC1X, outerLC1Y,
-                    outerLC2X, outerLC2Y,
-                    outerCenterX, outerCenterY); // outer left control 1, outer left control 2, outer center
-            arcPath.curveTo(outerRC1X, outerRC1Y,
-                    outerRC2X, outerRC2Y,
-                    outerRX, outerRY);// outer right control 1, outer right control 2, outer right
-            arcPath.lineTo(innerRX, innerRY); // inner right
-            arcPath.curveTo(innerRC1X, innerRC1Y,
-                    innerRC2X, innerRC2Y,
-                    innerCenterX, innerCenterY); // inner right control 1, inner right control 2, inner center
-            arcPath.curveTo(innerLC1X, innerLC1Y,
-                    innerLC2X, innerLC2Y,
-                    innerLX, innerLY); // inner left control 1, inner left control 2, inner left
-            arcPath.lineTo(outerLX, outerLY); // outer left
-            arcPath.moveTo(outerLX, outerLY);
-            arcPath.closePath();
-
-            // Draw the arc face
-            g2D.fill(arcPath);
-        }
+        // Draw outline so thin arcs don't vanish when zoomed out
+        if (drawOutline) g2D.draw(arcPath);
+        // Draw the arc face
+        g2D.fill(arcPath);
 
         g2D.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_DEFAULT);
         g2D.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_DEFAULT);

--- a/src/main/java/org/broad/igv/feature/basepair/BasePairTrack.java
+++ b/src/main/java/org/broad/igv/feature/basepair/BasePairTrack.java
@@ -3,30 +3,45 @@ package org.broad.igv.feature.basepair;
 import org.apache.log4j.Logger;
 import org.broad.igv.feature.genome.*;
 import org.broad.igv.renderer.*;
+import org.broad.igv.session.IGVSessionReader;
+import org.broad.igv.session.SubtlyImportant;
 import org.broad.igv.track.AbstractTrack;
 import org.broad.igv.track.RenderContext;
+import org.broad.igv.ui.color.ColorUtilities;
 import org.broad.igv.ui.panel.ReferenceFrame;
 import org.broad.igv.util.ResourceLocator;
 
+import javax.xml.bind.annotation.*;
 import java.awt.*;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Show base-pairing arcs
  *
  * @author sbusan
  */
+@XmlType(factoryMethod = "getNextTrack")
+@XmlSeeAlso(BasePairTrack.RenderOptions.class)
 public class BasePairTrack extends AbstractTrack {
 
     private static Logger log = Logger.getLogger(BasePairTrack.class);
 
     private BasePairRenderer basePairRenderer = new BasePairRenderer();
-    private BasePairData basePairData;
+    private BasePairData basePairData = new BasePairData();
     Genome genome;
+
+    public enum ArcDirection {
+        UP, DOWN
+    }
+
+    private RenderOptions renderOptions = new RenderOptions();
 
     public BasePairTrack(ResourceLocator locator, String id, String name, Genome genome) {
         super(locator, id, name);
+        BasePairFileParser.loadData(locator, genome,
+                basePairData, renderOptions);
         this.genome = genome;
-
     }
 
     @Override
@@ -36,7 +51,8 @@ public class BasePairTrack extends AbstractTrack {
 
     @Override
     public void load(ReferenceFrame frame) {
-        basePairData = BasePairFileParser.loadData(this.getResourceLocator(), genome);
+        BasePairFileParser.loadData(this.getResourceLocator(),
+                genome, basePairData, renderOptions);
     }
 
     public void render(RenderContext context, Rectangle rect) {
@@ -47,41 +63,105 @@ public class BasePairTrack extends AbstractTrack {
         context.clearGraphicsCache();
 
         try {
-            basePairRenderer.draw(basePairData, context, rect);
+            basePairRenderer.draw(basePairData, context, rect, renderOptions);
             context.clearGraphicsCache();
-        }
-        finally {
+        } finally {
             g2d.setClip(clip);
         }
     }
 
+    @XmlElement(name = RenderOptions.NAME)
+    private void setRenderOptions(BasePairTrack.RenderOptions renderOptions) {
+        this.renderOptions = renderOptions;
+    }
 
-    public void checkHeight(RenderContext context, Rectangle rect) {
+    @SubtlyImportant
+    public BasePairTrack.RenderOptions getRenderOptions() {
+        return this.renderOptions;
+    }
 
-        java.util.List<BasePairFeature> featureList = basePairData.getFeatures(context.getChr());
+    @XmlType(name = RenderOptions.NAME)
+    @XmlAccessorType(XmlAccessType.NONE)
+    public static class RenderOptions {
 
-        if (featureList != null) {
-            int maxL = 0;
-            for (BasePairFeature feature : featureList) {
-                //if(feature.startLeft > context.getEndLocation()) break;
-                //else if(feature.endRight < context.getOrigin()) continue;
-                maxL = Math.max(maxL, feature.getEndRight() - feature.getStartLeft());
-            }
-            int height = (int) (maxL / (2 * context.getScale()));
-            setHeight(height, true);
+        public static final String NAME = "BPRenderOptions";
 
+        @XmlAttribute
+        private ArcDirection arcDirection;
+        // FIXME: instead of strings use @XmlJavaTypeAdapter(SessionXmlAdapters.Color.class)
+        @XmlElement
+        private List<String> colors;
+        @XmlElement
+        private List<String> colorLabels; // menu legend labels for each color
+
+        public RenderOptions() {
+            // TODO: load some options from global PreferenceManager like AlignmentTrack does?
+            arcDirection = ArcDirection.DOWN;
+            colors = new ArrayList();
+            colorLabels = new ArrayList();
         }
+
+        public void changeColor(Color currentColor, String currentLabel, Color newColor) {
+            String currentColorString = ColorUtilities.colorToString(currentColor);
+            String newColorString = ColorUtilities.colorToString(newColor);
+            for (int i=0; i<getColors().size(); ++i) {
+                String colorString = getColors().get(i);
+                String label = getColorLabels().get(i);
+                if (!currentColorString.equals(colorString) || !currentLabel.equals(label)) {
+                    continue;
+                }
+                setColor(i, newColorString);
+            }
+        }
+
+        public ArcDirection getArcDirection() {
+            return arcDirection;
+        }
+
+        public void setArcDirection(ArcDirection d) {
+            this.arcDirection = d;
+        }
+
+        public List<String> getColors() {
+            return this.colors;
+        }
+
+        public void setColors(List<String> l) {
+            this.colors = l;
+        }
+
+        public List<String> getColorLabels() {
+            return this.colorLabels;
+        }
+
+        public void setColorLabels(List<String> l) {
+            this.colorLabels = l;
+        }
+
+        public String getColor(int i) {
+            return this.colors.get(i);
+        }
+
+        public void setColor(int i, String s) {
+            this.colors.set(i, s);
+        }
+
+        public String getColorLabel(int i) {
+            return this.colorLabels.get(i);
+        }
+
+        public void setColorLabel(int i, String s) {
+            this.colorLabels.set(i, s);
+        }
+
     }
 
     public Renderer getRenderer() {
         return null;
     }
 
-    public int getDirection() {
-        return basePairRenderer.getDirection();
-    }
-
-    public void setDirection(int d) {
-        basePairRenderer.setDirection(d);
+    @SubtlyImportant
+    private static BasePairTrack getNextTrack() {
+        return (BasePairTrack) IGVSessionReader.getNextTrack();
     }
 }

--- a/src/main/java/org/broad/igv/track/AbstractTrack.java
+++ b/src/main/java/org/broad/igv/track/AbstractTrack.java
@@ -32,6 +32,7 @@ import org.apache.log4j.Logger;
 import org.broad.igv.Globals;
 import org.broad.igv.event.IGVEventBus;
 import org.broad.igv.event.IGVEventObserver;
+import org.broad.igv.feature.basepair.BasePairTrack;
 import org.broad.igv.gwas.GWASTrack;
 import org.broad.igv.prefs.PreferencesManager;
 import org.broad.igv.renderer.*;
@@ -69,7 +70,7 @@ import static org.broad.igv.prefs.Constants.*;
  */
 @XmlType(factoryClass = IGVSessionReader.class, factoryMethod = "getNextTrack")
 @XmlAccessorType(XmlAccessType.NONE)
-@XmlSeeAlso({CNFreqTrack.class, CoverageTrack.class, AlignmentTrack.class, DataSourceTrack.class, GWASTrack.class, FeatureTrack.class, MergedTracks.class})
+@XmlSeeAlso({CNFreqTrack.class, CoverageTrack.class, AlignmentTrack.class, DataSourceTrack.class, GWASTrack.class, FeatureTrack.class, MergedTracks.class, BasePairTrack.class})
 public abstract class AbstractTrack implements Track {
 
     private static Logger log = Logger.getLogger(AbstractTrack.class);

--- a/src/main/java/org/broad/igv/track/TrackMenuUtils.java
+++ b/src/main/java/org/broad/igv/track/TrackMenuUtils.java
@@ -57,6 +57,7 @@ import org.broad.igv.ui.util.FileDialogUtils;
 import org.broad.igv.ui.util.MessageUtils;
 import org.broad.igv.ui.util.UIUtilities;
 import org.broad.igv.util.LongRunningTask;
+import org.broad.igv.util.Pair;
 import org.broad.igv.util.ResourceLocator;
 import org.broad.igv.util.StringUtils;
 import org.broad.igv.util.blat.BlatClient;
@@ -518,43 +519,112 @@ public class TrackMenuUtils {
     }
 
     /**
-     * Return popup menu with items applicable to arc tracks
+     * Return popup menu with items applicable to BasePairTrack(s)
      *
-     * @return
+     * @author stevenbusan
      */
-    // stevenbusan
     public static void addBasePairItems(JPopupMenu menu, final Collection<Track> tracks) {
+
+        final ArrayList<BasePairTrack> bpTracks = new ArrayList<BasePairTrack>();
+        for (Track track : tracks) {
+            if (track instanceof BasePairTrack) {
+                bpTracks.add((BasePairTrack) track);
+            }
+        }
+
+        JLabel arcColorHeading = new JLabel(LEADING_HEADING_SPACER + "Arc colors (click to change)", JLabel.LEFT);
+        arcColorHeading.setFont(UIConstants.boldFont);
+
+        menu.add(arcColorHeading);
+
+        // aggregate arc color selector/legends for multiple selected tracks
+        ArrayList<Pair<Color, String>> legendList = new ArrayList<Pair<Color, String>>();
+        HashSet<String> keys = new HashSet<String>();
+        for (BasePairTrack track : bpTracks) {
+            List<String> colors = track.getRenderOptions().getColors();
+            List<String> colorLabels = track.getRenderOptions().getColorLabels();
+            // iterate in reverse order so colors appearing first in list are the ones rendered on top
+            for (int i=colors.size()-1; i>=0; --i) {
+                String key = colors.get(i) + ' ' + colorLabels.get(i);
+                if (!keys.contains(key)) {
+                    keys.add(key);
+                    legendList.add(new Pair<Color, String>(ColorUtilities.stringToColor(colors.get(i)), colorLabels.get(i)));
+                }
+            }
+        }
+
+        for (Pair<Color, String> pair : legendList) {
+            final Color color = pair.getFirst();
+            final String label = pair.getSecond();
+
+            JLabel colorBox = new JLabel(LEADING_HEADING_SPACER + "██");
+            colorBox.setFont(UIConstants.boldFont);
+            colorBox.setForeground(color);
+
+            JPanel p = new JPanel();
+            p.setLayout(new BoxLayout(p, BoxLayout.X_AXIS));
+            p.add(colorBox);
+            p.add(Box.createHorizontalStrut(1));
+            p.add(new JLabel(" "+label));
+            p.add(Box.createGlue());
+            p.setAlignmentX(Component.LEFT_ALIGNMENT);
+
+            JMenuItem item = new JMenuItem();
+            item.add(p);
+            double w = p.getPreferredSize().getWidth();
+            double h = p.getPreferredSize().getHeight();
+            Dimension size = new Dimension();
+            size.setSize(w, h+8);
+            item.setPreferredSize(size);
+
+            item.addActionListener(new ActionListener() {
+                public void actionPerformed(ActionEvent evt) {
+                    changeBasePairTrackColor(bpTracks, color, label);
+                }
+            });
+
+            menu.add(item);
+        }
+
+        menu.addSeparator();
 
         JLabel arcDirectionHeading = new JLabel(LEADING_HEADING_SPACER + "Arc direction", JLabel.LEFT);
         arcDirectionHeading.setFont(UIConstants.boldFont);
 
         menu.add(arcDirectionHeading);
 
-        final String[] arcDirectionLabels = {"Up", "Down"};
+        // preselect up or down if all selected tracks have the same arc direction
+        int upCount = 0;
+        int downCount = 0;
+        BasePairTrack.ArcDirection currentArcDirection = null; // mixed up and down
+        for (BasePairTrack track: bpTracks) {
+            if (track.getRenderOptions().getArcDirection() == BasePairTrack.ArcDirection.UP) ++upCount;
+            if (track.getRenderOptions().getArcDirection() == BasePairTrack.ArcDirection.DOWN) ++downCount;
+        }
+        if (upCount==0) currentArcDirection = BasePairTrack.ArcDirection.DOWN;
+        if (downCount==0) currentArcDirection = BasePairTrack.ArcDirection.UP;
 
-        for (int i = 0; i < arcDirectionLabels.length; i++) {
-            JCheckBoxMenuItem item = new JCheckBoxMenuItem(arcDirectionLabels[i]);
-            final int n = (i == 0) ? 1 : -1;
-            for (Track track : tracks) {
-                if (track instanceof BasePairTrack) {
-                    if (((BasePairTrack) track).getDirection() == n) {
-                        item.setSelected(true);
-                    }
-                }
-            }
-            item.addActionListener(new ActionListener() {
+        ButtonGroup group = new ButtonGroup();
+        Map<String, BasePairTrack.ArcDirection> arcDirections = new LinkedHashMap<String, BasePairTrack.ArcDirection>(3);
+        arcDirections.put("Up", BasePairTrack.ArcDirection.UP);
+        arcDirections.put("Down", BasePairTrack.ArcDirection.DOWN);
+
+        for (final Map.Entry<String, BasePairTrack.ArcDirection> entry : arcDirections.entrySet()) {
+            JRadioButtonMenuItem mm = new JRadioButtonMenuItem(entry.getKey());
+            mm.setSelected(currentArcDirection == entry.getValue());
+            mm.addActionListener(new ActionListener() {
                 public void actionPerformed(ActionEvent evt) {
                     for (Track track : tracks) {
                         if (track instanceof BasePairTrack) {
-                            ((BasePairTrack) track).setDirection(n);
+                            ((BasePairTrack) track).getRenderOptions().setArcDirection(entry.getValue());
                         }
                     }
-                    IGV.getInstance().repaint();
+                    refresh();
                 }
             });
-            menu.add(item);
+            group.add(mm);
+            menu.add(mm);
         }
-
         menu.addSeparator();
     }
 
@@ -1264,6 +1334,33 @@ public class TrackMenuUtils {
 
         for (Track track : selectedTracks) {
             track.setAltColor(ColorUtilities.modifyAlpha(color, currentSelection.getAlpha()));
+        }
+        refresh();
+
+    }
+
+    /**
+     *
+     * @author stevenbusan
+     */
+    public static void changeBasePairTrackColor(final List<BasePairTrack> tracks,
+                                                final Color currentColor,
+                                                final String currentLabel) {
+
+        if (tracks.isEmpty()) {
+            return;
+        }
+
+        Color newColor = UIUtilities.showColorChooserDialog(
+                "Select Arc Color ("+currentLabel+")",
+                currentColor);
+
+        if (newColor == null) {
+            return;
+        }
+
+        for (BasePairTrack t : tracks) {
+            t.getRenderOptions().changeColor(currentColor, currentLabel, newColor);
         }
         refresh();
 


### PR DESCRIPTION
There were some BasePairTrack features that were functional ~2.3.92, but seem to have gotten lost somewhere around the transition to the 2.4.0 release. I've added these features back in, and confirmed that they work alongside the newer track clipping rectangle.

1) BasePairTrack color legend within track menu
![track_menu_legend](https://user-images.githubusercontent.com/15159734/39016400-4d8c1036-43ee-11e8-8d55-0087dd0b933a.png)

2) XML session saving for BasePairTracks

3) Render arcs in order by color. When there are multiple overlapping arcs with different "strengths" or significances, it's useful to render the most important arcs on top.

Screenshot from 2.4.10 (a bunch of low-confidence pairs obscure any useful information):
![2 4 10_igv_arc_problem](https://user-images.githubusercontent.com/15159734/39016403-50d8a27c-43ee-11e8-8d78-fcc8cecafd4c.png)

Screenshot from this PR:
![commit_changes](https://user-images.githubusercontent.com/15159734/39016782-791a5914-43ef-11e8-9d03-e30f4c95b644.png)



