### PR TITLE
Fix track names and renaming

### DIFF
--- a/src/main/java/org/broad/igv/track/AbstractTrack.java
+++ b/src/main/java/org/broad/igv/track/AbstractTrack.java
@@ -418,7 +418,7 @@ public abstract class AbstractTrack implements Track {
             }
         }
         else {
-            value = attributes.get(key);
+            value = attributes.get(attributeName);
             if(value == null) {
                 value = getFromAttributeManager(key);
             }


### PR DESCRIPTION
I noticed that in recent versions of IGV I am unable to rename tracks.

After some digging around I found that the track name always falls back
to the (basename of) the path. It looks like the keys of the track
attribute table `attributes` are not always uppercase, so looking up the
attribute value using the `attributeName` seems to work fine in this
instance. I am not 100% sure this is the correct fix, but if it is not I
hope that this can be helpful in tracking down the issue.