### PR TITLE
Always treat http://...query.cgi?file=... to be an alignment track

### DIFF
--- a/src/main/java/org/broad/igv/track/TrackLoader.java
+++ b/src/main/java/org/broad/igv/track/TrackLoader.java
@@ -172,7 +172,8 @@ public class TrackLoader {
                 loadRNAiHPScoreFile(locator);
             } else if (typeString.contains(".tabblastn") || typeString.endsWith(".orthologs")) {
                 loadSyntentyMapping(locator, newTracks);
-            } else if (isAlignmentTrack(typeString)) {
+            } else if (isAlignmentTrack(typeString) ||
+                       (path.startsWith("http") && path.contains("/query.cgi?"))) {
                 loadAlignmentsTrack(locator, newTracks, genome);
             } else if (typeString.endsWith(".shape") || typeString.endsWith(".map")) {
                 convertLoadShapeFile(locator, newTracks, genome);


### PR DESCRIPTION
The only handler for this form of URL is for SAM/BAM, so it doesn't cause any
regression.

This change will allow for a CGI-based viewer for non-bam/sam alignment
files. In particular, we want to use it for pam (https://github.com/grailbio/bio/tree/master/encoding/pam).