### PR TITLE
Add "group" and "color" by PacBio movie and ZMW

### DIFF
--- a/src/main/java/org/broad/igv/sam/AlignmentPacker.java
+++ b/src/main/java/org/broad/igv/sam/AlignmentPacker.java
@@ -374,6 +374,7 @@ public class AlignmentPacker {
         AlignmentTrack.GroupOption groupBy = renderOptions.getGroupByOption();
         String tag = renderOptions.getGroupByTag();
         Range pos = renderOptions.getGroupByPos();
+        String readNameParts[], movieName, zmw;
 
         switch (groupBy) {
             case STRAND:
@@ -431,6 +432,21 @@ public class AlignmentPacker {
                 else { // does not overlap position
                     return "3:";
                 }
+            case MOVIE: // group PacBio reads by movie
+                readNameParts = al.getReadName().split("/");
+                if (readNameParts.length != 3) {
+                    return "";
+                }
+                movieName = readNameParts[0];
+                return movieName;
+            case ZMW: // group PacBio reads by ZMW
+                readNameParts = al.getReadName().split("/");
+                if (readNameParts.length != 3) {
+                    return "";
+                }
+                movieName = readNameParts[0];
+                zmw = readNameParts[1];
+                return movieName + "/" + zmw;
         }
         return null;
     }

--- a/src/main/java/org/broad/igv/sam/AlignmentRenderer.java
+++ b/src/main/java/org/broad/igv/sam/AlignmentRenderer.java
@@ -102,6 +102,8 @@ public class AlignmentRenderer {
 
     private static ColorTable readGroupColors;
     private static ColorTable sampleColors;
+    private static ColorTable movieColors;
+    private static ColorTable zmwColors;
     private static Map<String, ColorTable> tagValueColors;
     private static ColorTable defaultTagColors;
 
@@ -218,6 +220,8 @@ public class AlignmentRenderer {
         ColorPalette palette = ColorUtilities.getPalette("Pastel 1");  // TODO let user choose
         readGroupColors = new PaletteColorTable(palette);
         sampleColors = new PaletteColorTable(palette);
+        movieColors = new PaletteColorTable(palette);
+        zmwColors = new PaletteColorTable(palette);
         defaultTagColors = new PaletteColorTable(palette);
         tagValueColors = new HashMap();
 
@@ -1225,8 +1229,8 @@ public class AlignmentRenderer {
         // center line.  Also restorePersistentState row "score" if alignment intersects center line
 
         Color c = DEFAULT_ALIGNMENT_COLOR;
-
         ColorOption colorOption = renderOptions.getColorOption();
+        String readNameParts[];
 
         switch (colorOption) {
 
@@ -1323,6 +1327,18 @@ public class AlignmentRenderer {
                 String library = alignment.getLibrary();
                 if (library != null) {
                     c = sampleColors.get(library);
+                }
+                break;
+            case MOVIE:
+                readNameParts = alignment.getReadName().split("/");
+                if (readNameParts.length == 3) {
+                    c = movieColors.get(readNameParts[0]);
+                }
+                break;
+            case ZMW:
+                readNameParts = alignment.getReadName().split("/");
+                if (readNameParts.length == 3) {
+                    c = zmwColors.get(readNameParts[0] + "/" + readNameParts[1]);
                 }
                 break;
             case TAG:

--- a/src/main/java/org/broad/igv/sam/AlignmentTrack.java
+++ b/src/main/java/org/broad/igv/sam/AlignmentTrack.java
@@ -148,7 +148,7 @@ public class AlignmentTrack extends AbstractTrack implements IGVEventObserver {
     }
 
     enum ColorOption {
-        INSERT_SIZE, READ_STRAND, FIRST_OF_PAIR_STRAND, PAIR_ORIENTATION, SAMPLE, READ_GROUP, LIBRARY, BISULFITE, NOMESEQ,
+        INSERT_SIZE, READ_STRAND, FIRST_OF_PAIR_STRAND, PAIR_ORIENTATION, SAMPLE, READ_GROUP, LIBRARY, MOVIE, ZMW, BISULFITE, NOMESEQ,
         TAG, NONE, UNEXPECTED_PAIR, MAPPED_SIZE, LINK_STRAND, YC_TAG
     }
 
@@ -157,7 +157,7 @@ public class AlignmentTrack extends AbstractTrack implements IGVEventObserver {
     }
 
     public enum GroupOption {
-        STRAND, SAMPLE, READ_GROUP, LIBRARY, FIRST_OF_PAIR_STRAND, TAG, PAIR_ORIENTATION, MATE_CHROMOSOME, NONE, SUPPLEMENTARY, BASE_AT_POS
+        STRAND, SAMPLE, READ_GROUP, LIBRARY, FIRST_OF_PAIR_STRAND, TAG, PAIR_ORIENTATION, MATE_CHROMOSOME, NONE, SUPPLEMENTARY, BASE_AT_POS, MOVIE, ZMW
     }
 
     public enum BisulfiteContext {
@@ -1672,6 +1672,8 @@ public class AlignmentTrack extends AbstractTrack implements IGVEventObserver {
             mappings.put("chromosome of mate", GroupOption.MATE_CHROMOSOME);
             mappings.put("pair orientation", GroupOption.PAIR_ORIENTATION);
             mappings.put("supplementary flag", GroupOption.SUPPLEMENTARY);
+            mappings.put("movie", GroupOption.MOVIE);
+            mappings.put("ZMW", GroupOption.ZMW);
 
 
             for (Map.Entry<String, GroupOption> el : mappings.entrySet()) {
@@ -1824,6 +1826,8 @@ public class AlignmentTrack extends AbstractTrack implements IGVEventObserver {
             mappings.put("read group", ColorOption.READ_GROUP);
             mappings.put("sample", ColorOption.SAMPLE);
             mappings.put("library", ColorOption.LIBRARY);
+            mappings.put("movie", ColorOption.MOVIE);
+            mappings.put("ZMW", ColorOption.ZMW);
 
             for (Map.Entry<String, ColorOption> el : mappings.entrySet()) {
                 JRadioButtonMenuItem mi = getColorMenuItem(el.getKey(), el.getValue());


### PR DESCRIPTION
Add "group by" and "color by" PacBio movie and ZMW, which are similar to grouping or coloring by read group or library.

PacBio read names follow the convention "movie/zmw/qStart_qEnd" where a movie is a single run of PacBio machine with a single SMRT Cell, ZMW is a single hole/molecule on the SMRT Cell, and qStart/qEnd are coordinates for a single subread within a ZMW read.

Just as it is useful to group/color by library and read group, it is useful to group/color by PacBio movie and ZMW.  This PR adds those features with movie and ZMW parsed from the read names.