### PR TITLE
Fixes for Google requester-pays buckets (userProject) and derived index URL

### DIFF
--- a/src/main/java/org/broad/igv/sam/reader/BAMReader.java
+++ b/src/main/java/org/broad/igv/sam/reader/BAMReader.java
@@ -325,9 +325,13 @@ public class BAMReader implements AlignmentReader<PicardAlignment> {
         String indexPath = null;
         try {
             URL url = HttpUtils.createURL(urlString);
+            //note that url may be quite different than urlString due to substitutions
+            //made in createURL (e.g. Google cloud paths are converted), thus we should
+            //use url rather than urlString in subsequent transformations here.
+            urlString = url.toExternalForm();
             String queryString = url.getQuery();
             if (queryString == null) {
-                indexPath = urlString + extension;
+                indexPath = url + extension;
             } else {
                 Map<String, String> parameters = HttpUtils.parseQueryString(queryString);
                 if (parameters.containsKey("file")) {

--- a/src/main/java/org/broad/igv/util/HttpUtils.java
+++ b/src/main/java/org/broad/igv/util/HttpUtils.java
@@ -706,7 +706,10 @@ public class HttpUtils {
             String newPath = url.toExternalForm().replaceAll(" ", "%20");
             url = HttpUtils.createURL(newPath);
         }
-
+        
+        if(url.getHost().equals(GoogleUtils.GOOGLE_API_HOST) && GoogleUtils.getProjectID() != null && GoogleUtils.getProjectID().length() > 0) {
+            url = addQueryParameter(url, "userProject", GoogleUtils.getProjectID());
+        }
 
         Proxy sysProxy = null;
 
@@ -791,9 +794,6 @@ public class HttpUtils {
             if (token != null) conn.setRequestProperty("Authorization", "Bearer " + token);
         }
 
-        if(url.getHost().equals(GoogleUtils.GOOGLE_API_HOST) && GoogleUtils.getProjectID() != null && GoogleUtils.getProjectID().length() > 0) {
-            url = addQueryParameter(url, "userProject", GoogleUtils.getProjectID());
-        }
 
         if (method.equals("PUT")) {
             return conn;


### PR DESCRIPTION
Two small fixes to get Google bucket URLs and requester-pays buckets to work properly:

1. Moved code to add userProject to URL earlier in HttpUtils.openConnection , so the change takes effect in all code paths
2. Changed BAMReader.getIndexURL to derive the index URL from the URL returned by HttpsUtils.createURL and not the original "gs://" path.