### PR TITLE
Replace all instances of Feature.getChr with getContig

### DIFF
--- a/src/main/java/org/broad/igv/batch/CommandExecutor.java
+++ b/src/main/java/org/broad/igv/batch/CommandExecutor.java
@@ -759,7 +759,7 @@ public class CommandExecutor {
             if (locus != null) {
                 int start = Math.max(0, locus.getStart() - 1);
                 String desc = param2 != null ? param2 : "";
-                roi = new RegionOfInterest(locus.getChr(), start, locus.getEnd(), desc);
+                roi = new RegionOfInterest(locus.getContig(), start, locus.getEnd(), desc);
 
             }
         }
@@ -779,7 +779,7 @@ public class CommandExecutor {
                 Locus locus = Locus.fromString(locusString);
                 if (locus != null) {
                     int start = Math.max(0, locus.getStart() - 1);
-                    roi = new RegionOfInterest(locus.getChr(), start, locus.getEnd(), "");
+                    roi = new RegionOfInterest(locus.getContig(), start, locus.getEnd(), "");
                 }
             }
             igv.sortByRegionScore(roi, regionSortOption, FrameManager.getDefaultFrame());

--- a/src/main/java/org/broad/igv/blast/BlastMapping.java
+++ b/src/main/java/org/broad/igv/blast/BlastMapping.java
@@ -70,7 +70,7 @@ public class BlastMapping extends BasicFeature {
     }
 
     @Override
-    public String getChr() {
+    public String getContig(){
         return queryBlock.getContig();
     }
 

--- a/src/main/java/org/broad/igv/cli_plugin/BEDGraphEncoder.java
+++ b/src/main/java/org/broad/igv/cli_plugin/BEDGraphEncoder.java
@@ -57,7 +57,7 @@ public class BEDGraphEncoder implements LineFeatureEncoder {
 
     public String encode(LocusScore score) {
         String[] tokens = new String[4];
-        tokens[0] = score.getChr();
+        tokens[0] = score.getContig();
         tokens[1] = "" + score.getStart();
         tokens[2] = "" + score.getEnd();
         tokens[3] = "" + score.getScore();

--- a/src/main/java/org/broad/igv/cli_plugin/PluginDataSource.java
+++ b/src/main/java/org/broad/igv/cli_plugin/PluginDataSource.java
@@ -110,7 +110,7 @@ public class PluginDataSource extends AbstractDataSource {
                 startLocations[idx] = locusScore.getStart();
                 endLocations[idx] = locusScore.getEnd();
                 scores[idx] = locusScore.getScore();
-                names[idx] = Locus.getFormattedLocusString(locusScore.getChr(), locusScore.getStart(), locusScore.getEnd());
+                names[idx] = Locus.getFormattedLocusString(locusScore.getContig(), locusScore.getStart(), locusScore.getEnd());
                 idx++;
             }
             return new DataTile(startLocations, endLocations, scores, names);

--- a/src/main/java/org/broad/igv/das/DASFeatureSource.java
+++ b/src/main/java/org/broad/igv/das/DASFeatureSource.java
@@ -395,7 +395,7 @@ public class DASFeatureSource implements FeatureSource {
 
                 feature = groupFeatureCache.get(group);
                 if (feature == null) {
-                    feature = new BasicFeature(exon.getChr(), exon.getStart(), exon.getEnd(), exon.getStrand());
+                    feature = new BasicFeature(exon.getContig(), exon.getStart(), exon.getEnd(), exon.getStrand());
                     feature.addExon(exon);
                     if (groupLink != null) {
                         feature.setURL(groupLink);

--- a/src/main/java/org/broad/igv/data/BasicScore.java
+++ b/src/main/java/org/broad/igv/data/BasicScore.java
@@ -60,12 +60,8 @@ public class BasicScore implements LocusScore {
 
     /**
      * This method is required by the Tribble interface but not used.  To save space the chromosome is not stored, return null
-     * @return
+     * @return null
      */
-    public String getChr() {
-        return null;
-    }
-
     @Override
     public String getContig() {
         return null;

--- a/src/main/java/org/broad/igv/data/CompositeScore.java
+++ b/src/main/java/org/broad/igv/data/CompositeScore.java
@@ -106,10 +106,6 @@ public class CompositeScore implements LocusScore {
         return buf.toString();
     }
 
-    public String getChr() {
-        return null;  //To change body of implemented methods use File | Settings | File Templates.
-    }
-
     @Override
     public String getContig() {
         return null;

--- a/src/main/java/org/broad/igv/data/cufflinks/CufflinksDataSource.java
+++ b/src/main/java/org/broad/igv/data/cufflinks/CufflinksDataSource.java
@@ -131,7 +131,7 @@ public class CufflinksDataSource implements DataSource {
     private DownsampledDoubleArrayList sampleValues(List<? extends LocusScore> valueList, Genome genome){
         DownsampledDoubleArrayList sampledData = new DownsampledDoubleArrayList(5000, 10000);
         for (LocusScore val : valueList) {
-            String chr = val.getChr();
+            String chr = val.getContig();
 
             List<LocusScore> chrValues = values.get(chr);
             if (chrValues == null) {

--- a/src/main/java/org/broad/igv/data/cufflinks/ExpDiffCodec.java
+++ b/src/main/java/org/broad/igv/data/cufflinks/ExpDiffCodec.java
@@ -74,7 +74,7 @@ public class ExpDiffCodec extends CufflinksCodec<ExpDiffValue>{
             if (locusString == null) return null;
 
             Locus locus = Locus.fromString(locusString);
-            if (locus == null || locus.getChr() == null) return null;
+            if (locus == null || locus.getContig() == null) return null;
 
             String logRatioStr = tokens[logRatioColumn];
             float logRatio = Float.parseFloat(logRatioStr);
@@ -88,7 +88,7 @@ public class ExpDiffCodec extends CufflinksCodec<ExpDiffValue>{
             float fpkmY = Float.parseFloat(tokens[yColumn]);
             String gene = tokens[geneColumn];
             String significant = tokens[sigColumn];
-            return new ExpDiffValue(locus.getChr(), locus.getStart() - 1, locus.getEnd(), gene,
+            return new ExpDiffValue(locus.getContig(), locus.getStart() - 1, locus.getEnd(), gene,
                     logRatio, fpkmX, fpkmY, significant);
         } else {
             log.info("Unexpected # of columns.  Expected at least 12,  found " + tokens.length);

--- a/src/main/java/org/broad/igv/data/cufflinks/ExpDiffValue.java
+++ b/src/main/java/org/broad/igv/data/cufflinks/ExpDiffValue.java
@@ -58,7 +58,7 @@ public class ExpDiffValue extends CufflinksValue implements LocusScore {
     public String getValueString(double position, int mouseX, WindowFunction windowFunction) {
 
         StringBuilder sb = new StringBuilder();
-        sb.append(getChr() + ":" + (getStart() + 1) + "-" + getEnd());
+        sb.append(getContig() + ":" + (getStart() + 1) + "-" + getEnd());
         sb.append("<br>gene = " + gene);
         sb.append("<br>log2(y/x) = " + log2Ratio);
         sb.append("<br>FPKM X = " + fpkmX);

--- a/src/main/java/org/broad/igv/data/cufflinks/FPKMSampleValue.java
+++ b/src/main/java/org/broad/igv/data/cufflinks/FPKMSampleValue.java
@@ -54,7 +54,7 @@ public class FPKMSampleValue extends CufflinksValue{
     public String getValueString(double position, int mouseX, WindowFunction windowFunction) {
 
         StringBuilder sb = new StringBuilder();
-        sb.append(getChr() + ":" + (getStart() + 1) + "-" + getEnd());
+        sb.append(getContig() + ":" + (getStart() + 1) + "-" + getEnd());
         sb.append("<br>Gene = " + gene);
         sb.append("<br>FPKM = " + fpkm);
         sb.append("<br>FPKM_LO = " + fpkmLo);

--- a/src/main/java/org/broad/igv/data/cufflinks/FPKMTrackingCodec.java
+++ b/src/main/java/org/broad/igv/data/cufflinks/FPKMTrackingCodec.java
@@ -78,7 +78,7 @@ public class FPKMTrackingCodec extends CufflinksCodec<FPKMValue>{
             if (locusString == null) return null;
 
             Locus locus = Locus.fromString(locusString);
-            if(locus == null || locus.getChr() == null) return null;
+            if(locus == null || locus.getContig() == null) return null;
 
             String gene = tokens[geneColumn];
             float[] fpkm = new float[numSamples];
@@ -92,7 +92,7 @@ public class FPKMTrackingCodec extends CufflinksCodec<FPKMValue>{
                 confHi[sampNum] = Float.parseFloat(tokens[startCol+2]);
             }
 
-            return new FPKMValue(locus.getChr(), locus.getStart() - 1, locus.getEnd(), gene,
+            return new FPKMValue(locus.getContig(), locus.getStart() - 1, locus.getEnd(), gene,
                     fpkm, confLo, confHi);
         } else {
             log.info("Unexpected # of columns.  Expected at least 12,  found " + tokens.length);

--- a/src/main/java/org/broad/igv/data/expression/ExpressionFileParser.java
+++ b/src/main/java/org/broad/igv/data/expression/ExpressionFileParser.java
@@ -324,7 +324,7 @@ public class ExpressionFileParser {
             for (Locus locus : loci) {
                 if ((locus != null) && locus.isValid()) {
 
-                    String chr = genome == null ? locus.getChr() : genome.getCanonicalChrName(locus.getChr());
+                    String chr = genome == null ? locus.getContig() : genome.getCanonicalChrName(locus.getContig());
 
                     List<Row> rows = rowMap.get(chr);
                     if (rows == null) {

--- a/src/main/java/org/broad/igv/data/expression/GeneToLocusHelper.java
+++ b/src/main/java/org/broad/igv/data/expression/GeneToLocusHelper.java
@@ -188,7 +188,7 @@ public class GeneToLocusHelper {
             // Maybe its a gene or feature
             Feature gene = FeatureDB.getFeature(geneOrLocusString);
             if (gene != null) {
-                return new Locus(gene.getChr(), gene.getStart(), gene.getEnd());
+                return new Locus(gene.getContig(), gene.getStart(), gene.getEnd());
             }
         }
         return null;

--- a/src/main/java/org/broad/igv/data/seg/FreqData.java
+++ b/src/main/java/org/broad/igv/data/seg/FreqData.java
@@ -189,7 +189,7 @@ public class FreqData {
         for (Map.Entry<String, List<LocusScore>> entry : amp.entrySet()) {
             if (!entry.getKey().equals(Globals.CHR_ALL)) {
                 for (LocusScore bin : entry.getValue()) {
-                    System.out.println(bin.getChr() + "\t" + bin.getStart() + "\t" + bin.getEnd() + "\t" + bin.getScore());
+                    System.out.println(bin.getContig() + "\t" + bin.getStart() + "\t" + bin.getEnd() + "\t" + bin.getScore());
                 }
             }
         }
@@ -239,11 +239,6 @@ public class FreqData {
 
         float getAvgCN() {
             return count == 0 ? 0 : getTotalCN() / count;
-        }
-
-
-        public String getChr() {
-            return chr;
         }
 
         @Override

--- a/src/main/java/org/broad/igv/feature/AbstractFeature.java
+++ b/src/main/java/org/broad/igv/feature/AbstractFeature.java
@@ -101,10 +101,6 @@ abstract public class AbstractFeature implements IGVFeature, htsjdk.tribble.Feat
         return Float.NaN;
     }
 
-    public String getChr() {
-        return chromosome;
-    }
-
     public String getContig() {
         return chromosome;
     }
@@ -138,7 +134,7 @@ abstract public class AbstractFeature implements IGVFeature, htsjdk.tribble.Feat
         if (feature == null) {
             return false;
         }
-        if (!this.getChr().equals(feature.getChr()) ||
+        if (!this.getContig().equals(feature.getContig()) ||
                 this.getStrand() != feature.getStrand()) {
             return false;
         }
@@ -225,7 +221,7 @@ abstract public class AbstractFeature implements IGVFeature, htsjdk.tribble.Feat
     public boolean overlaps(Feature anotherFeature) {
 
         return end >= anotherFeature.getStart() && start <= anotherFeature.getEnd() &&
-                chromosome.equals(anotherFeature.getChr());
+                chromosome.equals(anotherFeature.getContig());
 
     }
 
@@ -253,7 +249,7 @@ abstract public class AbstractFeature implements IGVFeature, htsjdk.tribble.Feat
      * @return
      */
     public String getLocusString() {
-        return getChr() + ":" + (getStart() + 1) + "-" + getEnd();
+        return getContig() + ":" + (getStart() + 1) + "-" + getEnd();
     }
 
 

--- a/src/main/java/org/broad/igv/feature/AbstractFeatureParser.java
+++ b/src/main/java/org/broad/igv/feature/AbstractFeatureParser.java
@@ -202,7 +202,7 @@ public abstract class AbstractFeatureParser implements FeatureParser {
             for (IGVFeature gene : features) {
                 pw.print(gene.getName() + "\t");
                 pw.print(gene.getIdentifier() + "\t");
-                pw.print(gene.getChr() + "\t");
+                pw.print(gene.getContig() + "\t");
                 if (gene.getStrand() == Strand.POSITIVE) {
                     pw.print("+\t");
                 } else if (gene.getStrand() == Strand.NEGATIVE) {

--- a/src/main/java/org/broad/igv/feature/BasePairFileUtils.java
+++ b/src/main/java/org/broad/igv/feature/BasePairFileUtils.java
@@ -86,7 +86,7 @@ public class BasePairFileUtils {
                                                      String strand) {
         LinkedList<BasePairFeature> transArcs = new LinkedList<BasePairFeature>();
         for (BasePairFeature arc : arcs) {
-            String chr = arc.getChr();
+            String chr = arc.getContig();
             int colorIndex = arc.getColorIndex();
             int startLeft, startRight, endLeft, endRight;
             if (strand == "+") {

--- a/src/main/java/org/broad/igv/feature/BasicFeature.java
+++ b/src/main/java/org/broad/igv/feature/BasicFeature.java
@@ -76,7 +76,7 @@ public class BasicFeature extends AbstractFeature {
     }
 
     public BasicFeature(BasicFeature feature) {
-        super(feature.getChr(), feature.getStart(), feature.getEnd(), feature.getStrand());
+        super(feature.getContig(), feature.getStart(), feature.getEnd(), feature.getStrand());
         super.setName(feature.getName());
         this.confidence = feature.confidence;
         this.color = feature.color;
@@ -312,7 +312,7 @@ public class BasicFeature extends AbstractFeature {
         int[] featurePositions = new int[]{startTranscriptPosition, startTranscriptPosition + 1,
                 startTranscriptPosition + 2};
         int[] genomePositions = featureToGenomePosition(featurePositions);
-        Codon codonInfo = new Codon(getChr(), proteinPosition, getStrand());
+        Codon codonInfo = new Codon(getContig(), proteinPosition, getStrand());
         for (int gp : genomePositions) {
             codonInfo.setNextGenomePosition(gp);
         }

--- a/src/main/java/org/broad/igv/feature/Cytoband.java
+++ b/src/main/java/org/broad/igv/feature/Cytoband.java
@@ -52,10 +52,6 @@ public class Cytoband implements NamedFeature {
         return chromosome;
     }
 
-    public String getChr() {
-        return chromosome;
-    }
-
     public void setName(String name) {
         this.name = name;
     }

--- a/src/main/java/org/broad/igv/feature/EmblFeatureTableParser.java
+++ b/src/main/java/org/broad/igv/feature/EmblFeatureTableParser.java
@@ -203,7 +203,7 @@ public class EmblFeatureTableParser implements FeatureParser {
                     newFeatureList.add(gene);
                     genes.put(geneId, gene);
                 }
-                Exon exon = new Exon(feature.getChr(), feature.getStart(), feature.getEnd(),
+                Exon exon = new Exon(feature.getContig(), feature.getStart(), feature.getEnd(),
                         feature.getStrand());
                 gene.addExon(exon);
             }
@@ -218,7 +218,7 @@ public class EmblFeatureTableParser implements FeatureParser {
             } else if (type.equals("3'UTR") || type.equals("5'UTR")) {
                 BasicFeature gene = genes.get(feature.getIdentifier());
                 if (gene != null) {
-                    Exon exon = new Exon(feature.getChr(), feature.getStart(),
+                    Exon exon = new Exon(feature.getContig(), feature.getStart(),
                             feature.getEnd(), feature.getStrand());
                     exon.setNonCoding(true);
                     boolean plus = (type.equals("5'UTR") && feature.getStrand() == Strand.POSITIVE) ||

--- a/src/main/java/org/broad/igv/feature/Exon.java
+++ b/src/main/java/org/broad/igv/feature/Exon.java
@@ -117,7 +117,7 @@ public class Exon extends AbstractFeature implements IExon {
         this.strand = bf.getStrand();
         this.codingStart = bf.getCdStart();
         this.codingEnd = bf.getCdEnd();
-        this.chromosome = bf.getChr();
+        this.chromosome = bf.getContig();
         this.type = bf.getType();
         this.color = bf.getColor();
         this.description = bf.getDescription();
@@ -135,7 +135,7 @@ public class Exon extends AbstractFeature implements IExon {
         this.strand = bf.getStrand();
         this.codingStart = bf.getThickStart();
         this.codingEnd = bf.getThickEnd();
-        this.chromosome = bf.getChr();
+        this.chromosome = bf.getContig();
         this.type = bf.getType();
         this.color = bf.getColor();
         this.description = bf.getDescription();
@@ -204,7 +204,7 @@ public class Exon extends AbstractFeature implements IExon {
         }
         int start = getStart();
         int end = getEnd();
-        String chr = getChr();
+        String chr = getContig();
 
         if (readingFrame >= 0) {
             int readStart = (codingStart > start) ? codingStart : start;
@@ -271,7 +271,7 @@ public class Exon extends AbstractFeature implements IExon {
     }
 
     public Exon copy() {
-        Exon copy = new Exon(getChr(), getStart(), getEnd(), getStrand());
+        Exon copy = new Exon(getContig(), getStart(), getEnd(), getStrand());
         copy.seqBytes = this.seqBytes;
         copy.aminoAcidSequence = this.aminoAcidSequence;
         copy.codingEnd = this.codingEnd;
@@ -330,7 +330,7 @@ public class Exon extends AbstractFeature implements IExon {
                 return false;
             }
             IExon other = (IExon) inother;
-            boolean eq = parent.getChr().equals(other.getChr());
+            boolean eq = parent.getContig().equals(other.getContig());
             eq &= parent.getStart() == other.getStart();
             eq &= parent.getEnd() == other.getEnd();
             eq &= parent.getCdStart() == other.getCdStart();
@@ -344,7 +344,7 @@ public class Exon extends AbstractFeature implements IExon {
                 return hashCode;
             }
 
-            String conc = parent.getChr() + parent.getStrand().toString() + parent.getStart();
+            String conc = parent.getContig() + parent.getStrand().toString() + parent.getStart();
             conc += parent.getEnd();
             conc += parent.getCdStart();
             conc += parent.getCdEnd();

--- a/src/main/java/org/broad/igv/feature/FeatureDB.java
+++ b/src/main/java/org/broad/igv/feature/FeatureDB.java
@@ -137,7 +137,7 @@ public class FeatureDB {
         String key = name.toUpperCase();
         if (!Globals.isHeadless()) {
             Genome currentGenome = genome != null ? genome : GenomeManager.getInstance().getCurrentGenome();
-            if (currentGenome != null && currentGenome.getChromosome(feature.getChr()) == null) {
+            if (currentGenome != null && currentGenome.getChromosome(feature.getContig()) == null) {
                 return false;
             }
         }
@@ -393,7 +393,7 @@ public class FeatureDB {
                     if (genomePosition < 0) {
                         continue;
                     }
-                    final byte[] nuclSequence = currentGenome.getSequence(bf.getChr(), genomePosition, genomePosition + 1);
+                    final byte[] nuclSequence = currentGenome.getSequence(bf.getContig(), genomePosition, genomePosition + 1);
                     if (nuclSequence == null) {
                         continue;
                     }
@@ -446,8 +446,8 @@ public class FeatureDB {
 
             // Prefer the shortest chromosome name.  Longer names are most likely "weird"
             // e.g.  chr1_gl000191_random
-            int nameLen1 = feat1.getChr().length();
-            int nameLen2 = feat2.getChr().length();
+            int nameLen1 = feat1.getContig().length();
+            int nameLen2 = feat2.getContig().length();
             if (nameLen1 != nameLen2) {
                 return nameLen1 - nameLen2;
             }

--- a/src/main/java/org/broad/igv/feature/FeatureFileUtils.java
+++ b/src/main/java/org/broad/igv/feature/FeatureFileUtils.java
@@ -405,7 +405,7 @@ public class FeatureFileUtils {
                 int tss = transcript.getStrand() == Strand.POSITIVE ? f.getStart() : f.getEnd();
                 if (tss != lastTSS) {
                     int tssEnd = transcript.getStrand() == Strand.POSITIVE ? tss + 20 : tss - 20;
-                    pw.println(transcript.getChr() + "\t" + Math.min(tss, tssEnd) + "\t" + Math.max(tss, tssEnd));
+                    pw.println(transcript.getContig() + "\t" + Math.min(tss, tssEnd) + "\t" + Math.max(tss, tssEnd));
                     lastTSS = tss;
                 }
 
@@ -521,7 +521,7 @@ public class FeatureFileUtils {
             String[] tokens = nextLine.split("\t");
             Locus locus = Locus.fromString(tokens[1].trim());
             pw.println(
-                    locus.getChr() + "\t" + locus.getStart() + "\t" + locus.getEnd() + "\t" + tokens[0].trim());
+                    locus.getContig() + "\t" + locus.getStart() + "\t" + locus.getEnd() + "\t" + tokens[0].trim());
         }
 
         br.close();

--- a/src/main/java/org/broad/igv/feature/FeatureUtils.java
+++ b/src/main/java/org/broad/igv/feature/FeatureUtils.java
@@ -47,7 +47,7 @@ public class FeatureUtils {
         Predicate<Feature> overlapPredicate = new Predicate<Feature>() {
             @Override
             public boolean apply(Feature object) {
-                return chr.equals(object.getChr()) && object.getStart() <= end && object.getEnd() > start;
+                return chr.equals(object.getContig()) && object.getStart() <= end && object.getEnd() > start;
             }
         };
         return overlapPredicate;
@@ -56,10 +56,10 @@ public class FeatureUtils {
     public static Map<String, List<IGVFeature>> divideByChromosome(List<IGVFeature> features) {
         Map<String, List<IGVFeature>> featureMap = new LinkedHashMap();
         for (IGVFeature f : features) {
-            List<IGVFeature> flist = featureMap.get(f.getChr());
+            List<IGVFeature> flist = featureMap.get(f.getContig());
             if (flist == null) {
                 flist = new ArrayList();
-                featureMap.put(f.getChr(), flist);
+                featureMap.put(f.getContig(), flist);
             }
             flist.add(f);
         }
@@ -425,7 +425,7 @@ public class FeatureUtils {
         System.out.println(feature.getName());
         System.out.print(genome.getId() + "\t");
         String str = feature.getStrand() == Strand.POSITIVE ? "+" : "-";
-        System.out.print(feature.getChr() + "\t" + str + "\t" + feature.getStart() + "\t" + feature.getEnd() + "\t");
+        System.out.print(feature.getContig() + "\t" + str + "\t" + feature.getStart() + "\t" + feature.getEnd() + "\t");
 
         List<Exon> exons = feature.getExons();
 
@@ -467,7 +467,7 @@ public class FeatureUtils {
             buffer = Math.min(50, (nextExonStart - ex.getEnd()) / 2);
             int seqEnd = ex.getEnd() + buffer;
 
-            byte [] sequence = genome.getSequence(feature.getChr(), seqStart, seqEnd);
+            byte [] sequence = genome.getSequence(feature.getContig(), seqStart, seqEnd);
             String seqString = new String(sequence);
             System.out.println(seqStart + "\t" + seqEnd + "\t" + seqString);
         }

--- a/src/main/java/org/broad/igv/feature/GisticScore.java
+++ b/src/main/java/org/broad/igv/feature/GisticScore.java
@@ -129,10 +129,6 @@ public class GisticScore implements LocusScore {
         this.gisticType = type;
     }
 
-    public String getChr() {
-        return null;  //To change body of implemented methods use File | Settings | File Templates.
-    }
-
     @Override
     public String getContig() {
         return null;

--- a/src/main/java/org/broad/igv/feature/Locus.java
+++ b/src/main/java/org/broad/igv/feature/Locus.java
@@ -63,7 +63,7 @@ public class Locus extends Range implements NamedFeature {
     }
 
     public boolean isValid() {
-        return getChr() != null && getStart() >= 0 && getEnd() >= getStart();
+        return getContig() != null && getStart() >= 0 && getEnd() >= getStart();
     }
 
     // Only accept full locus strings,  i.e. must contain : and -

--- a/src/main/java/org/broad/igv/feature/Mutation.java
+++ b/src/main/java/org/broad/igv/feature/Mutation.java
@@ -204,10 +204,6 @@ public class Mutation implements IGVFeature {
         return false;
     }
 
-    public String getChr() {
-        return chr;
-    }
-
     @Override
     public String getContig() {
         return chr;
@@ -253,7 +249,7 @@ public class Mutation implements IGVFeature {
      */
     public boolean contains(IGVFeature feature) {
 
-        if (feature == null || !this.getChr().equals(feature.getChr())) {
+        if (feature == null || !this.getContig().equals(feature.getContig())) {
             return false;
         }
         if ((feature.getStart() >= this.getStart()) && (feature.getEnd() <= this.getEnd())) {

--- a/src/main/java/org/broad/igv/feature/Range.java
+++ b/src/main/java/org/broad/igv/feature/Range.java
@@ -50,11 +50,6 @@ public class Range implements Feature {
         this.end = end;
     }
 
-
-    public String getChr() {
-        return chr;
-    }
-
     @Override
     public String getContig() {
         return chr;
@@ -104,7 +99,7 @@ public class Range implements Feature {
     }
 
     public boolean overlaps(Range range) {
-        return this.overlaps(range.getChr(), range.getStart(), range.getEnd());
+        return this.overlaps(range.getContig(), range.getStart(), range.getEnd());
     }
 
     public boolean contains(Range range) {

--- a/src/main/java/org/broad/igv/feature/SpliceJunctionFeature.java
+++ b/src/main/java/org/broad/igv/feature/SpliceJunctionFeature.java
@@ -137,8 +137,8 @@ public class SpliceJunctionFeature extends BasicFeature {
     public List<Exon> getExons() {
         if(exons == null) {
             exons = new ArrayList<Exon>(2);
-            exons.add(new Exon(getChr(), start, junctionStart, getStrand()));
-            exons.add(new Exon(getChr(), junctionEnd, end, getStrand()));
+            exons.add(new Exon(getContig(), start, junctionStart, getStrand()));
+            exons.add(new Exon(getContig(), junctionEnd, end, getStrand()));
         }
         return exons;
     }

--- a/src/main/java/org/broad/igv/feature/UCSCSnpFeature.java
+++ b/src/main/java/org/broad/igv/feature/UCSCSnpFeature.java
@@ -71,11 +71,6 @@ public class UCSCSnpFeature implements IGVFeature, htsjdk.tribble.Feature {
     }
 
     @Override
-    public String getChr() {
-        return chr;
-    }
-
-    @Override
     public int getStart() {
         return start;
     }
@@ -172,7 +167,7 @@ public class UCSCSnpFeature implements IGVFeature, htsjdk.tribble.Feature {
         if (feature == null) {
             return false;
         }
-        if (!this.getChr().equals(feature.getChr()) ||
+        if (!this.getContig().equals(feature.getContig()) ||
                 this.getStrand() != feature.getStrand()) {
             return false;
         }

--- a/src/main/java/org/broad/igv/feature/basepair/BasePairData.java
+++ b/src/main/java/org/broad/igv/feature/basepair/BasePairData.java
@@ -21,7 +21,7 @@ public class BasePairData{
 
     public void addFeature(BasePairFeature feature) {
 
-        String chr = feature.getChr();
+        String chr = feature.getContig();
         List<BasePairFeature> featureList = featureMap.get(chr);
         if(featureList == null) {
             featureList = new ArrayList<BasePairFeature>();

--- a/src/main/java/org/broad/igv/feature/basepair/BasePairFeature.java
+++ b/src/main/java/org/broad/igv/feature/basepair/BasePairFeature.java
@@ -52,11 +52,6 @@ public class BasePairFeature implements Feature{
     }
 
     @Override
-    public String getChr() {
-        return chr;
-    }
-
-    @Override
     public String getContig() {
         return chr;
     }
@@ -82,6 +77,6 @@ public class BasePairFeature implements Feature{
     public int getColorIndex() { return colorIndex; }
 
     public String toString() {
-        return getChr() + "\t" + startLeft + "\t" + startRight + "\t" + endLeft + "\t" + endRight;
+        return getContig() + "\t" + startLeft + "\t" + startRight + "\t" + endLeft + "\t" + endRight;
     }
 }

--- a/src/main/java/org/broad/igv/feature/bionano/SMAPPairedFeature.java
+++ b/src/main/java/org/broad/igv/feature/bionano/SMAPPairedFeature.java
@@ -46,13 +46,13 @@ public class SMAPPairedFeature extends AbstractFeature {
     public SMAPPairedFeature(SMAPFeature feature1, SMAPFeature feature2) {
 
 
-        if (!feature1.getChr().equals(feature2.getChr())) {
+        if (!feature1.getContig().equals(feature2.getContig())) {
             // TODO - throw error?
             log.error("Inter-chromosomal linked features not supported");
             return;
         }
 
-        setChr(feature1.getChr());
+        setChr(feature1.getContig());
         if (feature1.getStart() < feature2.getStart()) {
             this.feature1 = feature1;
             this.feature2  = feature2;

--- a/src/main/java/org/broad/igv/feature/dranger/DRangerFeature.java
+++ b/src/main/java/org/broad/igv/feature/dranger/DRangerFeature.java
@@ -98,7 +98,7 @@ public class DRangerFeature extends AbstractFeature {
 
     public LocusScore copy() {
         DRangerFeature newFeat = new DRangerFeature();
-        newFeat.setChr(getChr());
+        newFeat.setChr(getContig());
         newFeat.setStart(getStart());
         newFeat.setEnd(getEnd());
         newFeat.chr2 = chr2;

--- a/src/main/java/org/broad/igv/feature/dsi/DSIFeature.java
+++ b/src/main/java/org/broad/igv/feature/dsi/DSIFeature.java
@@ -32,11 +32,6 @@ public class DSIFeature implements Feature {
     int u;
 
     @Override
-    public String getChr() {
-        return chr;
-    }
-
-    @Override
     public String getContig() {
         return chr;
     }

--- a/src/main/java/org/broad/igv/feature/tribble/BCF2WrapperCodec.java
+++ b/src/main/java/org/broad/igv/feature/tribble/BCF2WrapperCodec.java
@@ -62,7 +62,7 @@ public class BCF2WrapperCodec implements FeatureCodec<VCFVariant, PositionalBuff
         if (vc == null) {
             return null;
         }
-        String chr = genome == null ? vc.getChr() : genome.getCanonicalChrName(vc.getChr());
+        String chr = genome == null ? vc.getContig() : genome.getCanonicalChrName(vc.getContig());
         return new VCFVariant(vc, chr);
 
     }

--- a/src/main/java/org/broad/igv/feature/tribble/DGVCodec.java
+++ b/src/main/java/org/broad/igv/feature/tribble/DGVCodec.java
@@ -189,7 +189,7 @@ samples	IS30771,IS39243,IS41043	longblob	 	Sample IDs if available
 
         StringBuffer buffer = new StringBuffer();
 
-        buffer.append(feature.getChr());
+        buffer.append(feature.getContig());
         buffer.append("\t");
         final int featureStart = feature.getStart();
         buffer.append(String.valueOf(featureStart));

--- a/src/main/java/org/broad/igv/feature/tribble/IGVBEDCodec.java
+++ b/src/main/java/org/broad/igv/feature/tribble/IGVBEDCodec.java
@@ -343,7 +343,7 @@ public class IGVBEDCodec extends UCSCCodec<BasicFeature> implements LineFeatureE
 
         StringBuffer buffer = new StringBuffer();
 
-        buffer.append(feature.getChr());
+        buffer.append(feature.getContig());
         buffer.append("\t");
         final int featureStart = feature.getStart();
         buffer.append(String.valueOf(featureStart));

--- a/src/main/java/org/broad/igv/feature/tribble/Locus.java
+++ b/src/main/java/org/broad/igv/feature/tribble/Locus.java
@@ -48,10 +48,6 @@ public class Locus implements Feature {
         this.end = end;
     }
 
-    public String getChr() {
-        return chr;
-    }
-
     @Override
     public String getContig() {
         return chr;

--- a/src/main/java/org/broad/igv/feature/tribble/PAFFeature.java
+++ b/src/main/java/org/broad/igv/feature/tribble/PAFFeature.java
@@ -79,7 +79,7 @@ public class PAFFeature implements IGVFeature {
         if (feature == null) {
             return false;
         }
-        if (!this.getChr().equals(feature.getChr()) ||
+        if (!this.getContig().equals(feature.getContig()) ||
                 this.getStrand() != feature.getStrand()) {
             return false;
         }

--- a/src/main/java/org/broad/igv/feature/tribble/VCFFeature.java
+++ b/src/main/java/org/broad/igv/feature/tribble/VCFFeature.java
@@ -164,10 +164,6 @@ public class VCFFeature implements IGVFeature, htsjdk.tribble.Feature {
         return "VCF";  //To change body of implemented methods use File | Settings | File Templates.
     }
 
-    public String getChr() {
-        return chr;
-    }
-
     @Override
     public String getContig() {
         return chr;
@@ -193,7 +189,7 @@ public class VCFFeature implements IGVFeature, htsjdk.tribble.Feature {
 
     // TODO -- move this up
     public String getLocusString() {
-        return getChr() + ":" + getStart() + ":" + getEnd();
+        return getContig() + ":" + getStart() + ":" + getEnd();
     }
 
 }

--- a/src/main/java/org/broad/igv/feature/tribble/VCFWrapperCodec.java
+++ b/src/main/java/org/broad/igv/feature/tribble/VCFWrapperCodec.java
@@ -82,7 +82,7 @@ public class VCFWrapperCodec extends AsciiFeatureCodec<VCFVariant> {
         if (vc == null) {
             return null;
         }
-        String chr = genome == null ? vc.getChr() : genome.getCanonicalChrName(vc.getChr());
+        String chr = genome == null ? vc.getContig() : genome.getCanonicalChrName(vc.getContig());
         return new VCFVariant(vc, chr);
 
     }

--- a/src/main/java/org/broad/igv/goby/GobyAlignment.java
+++ b/src/main/java/org/broad/igv/goby/GobyAlignment.java
@@ -424,13 +424,9 @@ public class GobyAlignment implements Alignment {
     /**
      * Get the reference id from the iterator, prepend "chr".
      */
-    public String getChr() {
-        return getChromosome(entry.getTargetIndex());
-    }
-
     @Override
     public String getContig() {
-        return getChr();
+        return getChromosome(entry.getTargetIndex());
     }
 
     /**
@@ -768,7 +764,7 @@ public class GobyAlignment implements Alignment {
             buffer.append("Mate start = " + getMate().positionString() + "<br>");
             buffer.append("Mate is mapped = " + (getMate().isMapped() ? "yes" : "no") + "<br>");
             //buf.append("Pair is proper = " + (getProperPairFlag() ? "yes" : "no") + "<br>");
-            if (getChr().equals(getMate().getChr())) {
+            if (getContig().equals(getMate().getChr())) {
                 buffer.append("Insert size = " + getInferredInsertSize() + "<br>");
             }
             if (getPairOrientation().length() > 0) {

--- a/src/main/java/org/broad/igv/gwas/EQTLFeature.java
+++ b/src/main/java/org/broad/igv/gwas/EQTLFeature.java
@@ -80,7 +80,7 @@ public class EQTLFeature extends AbstractFeature {
     }
 
     @Override
-    public String getChr() {
+    public String getContig(){
         return chr;
     }
 

--- a/src/main/java/org/broad/igv/gwas/EqtlPreprocessor.java
+++ b/src/main/java/org/broad/igv/gwas/EqtlPreprocessor.java
@@ -103,7 +103,7 @@ public class EqtlPreprocessor {
             while ((nextLine = br.readLine()) != null) {
 
                 EQTLFeature feature = codec.decode(nextLine);
-                String chr = feature.getChr();
+                String chr = feature.getContig();
                 if (!chr.equals(currentChr)) {
                     if (currentChrBuffer != null) {
                         System.out.println(currentChr);

--- a/src/main/java/org/broad/igv/methyl/MethylScore.java
+++ b/src/main/java/org/broad/igv/methyl/MethylScore.java
@@ -51,10 +51,6 @@ public class MethylScore implements LocusScore {
         this.totalCount = totalCount;
     }
 
-    public String getChr() {
-        return chr;
-    }
-
     @Override
     public String getContig() {
         return chr;

--- a/src/main/java/org/broad/igv/peaks/Peak.java
+++ b/src/main/java/org/broad/igv/peaks/Peak.java
@@ -77,10 +77,6 @@ public class Peak implements LocusScore, htsjdk.tribble.Feature {
         }
     }
 
-    public String getChr() {
-        return chr;
-    }
-
     @Override
     public String getContig() {
         return chr;

--- a/src/main/java/org/broad/igv/renderer/IGVFeatureRenderer.java
+++ b/src/main/java/org/broad/igv/renderer/IGVFeatureRenderer.java
@@ -426,8 +426,8 @@ public class IGVFeatureRenderer extends FeatureRenderer {
             int curYOffset = yOffset;
             boolean drawConnectingLine = true;
 
-            int pStart = getPixelFromChromosomeLocation(exon.getChr(), exon.getStart(), theOrigin, locationScale);
-            int pEnd = getPixelFromChromosomeLocation(exon.getChr(), exon.getEnd(), theOrigin, locationScale);
+            int pStart = getPixelFromChromosomeLocation(exon.getContig(), exon.getStart(), theOrigin, locationScale);
+            int pEnd = getPixelFromChromosomeLocation(exon.getContig(), exon.getEnd(), theOrigin, locationScale);
 
 
             Graphics2D arrowGraphics = context.getGraphic2DForColor(Color.blue);
@@ -446,10 +446,10 @@ public class IGVFeatureRenderer extends FeatureRenderer {
             if ((pEnd >= trackRectangle.getX()) && (pStart <= trackRectangle.getMaxX())) {
                 int pCdStart =
                         Math.min(pEnd, Math.max(pStart,
-                                getPixelFromChromosomeLocation(exon.getChr(),
+                                getPixelFromChromosomeLocation(exon.getContig(),
                                         exon.getCdStart(), theOrigin, locationScale)));
                 int pCdEnd = Math.max(pStart, Math.min(pEnd,
-                        getPixelFromChromosomeLocation(exon.getChr(),
+                        getPixelFromChromosomeLocation(exon.getContig(),
                                 exon.getCdEnd(), theOrigin, locationScale)));
 
                 // Entire exon is UTR
@@ -638,8 +638,8 @@ public class IGVFeatureRenderer extends FeatureRenderer {
 
                     int start = Math.max(exon.getStart(), aaSeqStartPosition);
                     int end = Math.min(exon.getEnd(), aaSeqStartPosition + 3);
-                    int px = getPixelFromChromosomeLocation(exon.getChr(), start, theOrigin, locationScale);
-                    int px2 = getPixelFromChromosomeLocation(exon.getChr(), end, theOrigin, locationScale);
+                    int px = getPixelFromChromosomeLocation(exon.getContig(), start, theOrigin, locationScale);
+                    int px2 = getPixelFromChromosomeLocation(exon.getContig(), end, theOrigin, locationScale);
 
                     if ((px <= trackRectangle.getMaxX()) && (px2 >= trackRectangle.getX())) {
 
@@ -672,8 +672,8 @@ public class IGVFeatureRenderer extends FeatureRenderer {
                 // The last codon is not complete (continues on next exon).
                 // TODO -- get base from previous exon and compute aaSequence
                 int cdEnd = Math.min(exon.getCdEnd(), exon.getEnd());
-                aaRect.x = getPixelFromChromosomeLocation(exon.getChr(), aaSeqStartPosition, theOrigin, locationScale);
-                aaRect.width = getPixelFromChromosomeLocation(exon.getChr(), cdEnd, theOrigin, locationScale) - aaRect.x;
+                aaRect.x = getPixelFromChromosomeLocation(exon.getContig(), aaSeqStartPosition, theOrigin, locationScale);
+                aaRect.width = getPixelFromChromosomeLocation(exon.getContig(), cdEnd, theOrigin, locationScale) - aaRect.x;
                 Graphics2D bgGraphics = context.getGraphic2DForColor(odd ? AA_COLOR_1 : AA_COLOR_2);
                 odd = !odd;
                 bgGraphics.fill(aaRect);

--- a/src/main/java/org/broad/igv/sam/Alignment.java
+++ b/src/main/java/org/broad/igv/sam/Alignment.java
@@ -43,8 +43,6 @@ public interface Alignment extends LocusScore {
 
     String getReadSequence();
 
-    String getChr();
-
     int getAlignmentStart();
 
     int getAlignmentEnd();

--- a/src/main/java/org/broad/igv/sam/AlignmentDataManager.java
+++ b/src/main/java/org/broad/igv/sam/AlignmentDataManager.java
@@ -625,7 +625,7 @@ public class AlignmentDataManager implements IGVEventObserver {
                         if (tmp.size() == maxSize) break;
                         for (ReferenceFrame frame : frames) {
                             Range range = frame.getCurrentRange();
-                            if (interval.contains(range.getChr(), range.getStart(), range.getEnd())) {
+                            if (interval.contains(range.getContig(), range.getStart(), range.getEnd())) {
                                 tmp.add(interval);
                                 break;
                             }
@@ -649,7 +649,7 @@ public class AlignmentDataManager implements IGVEventObserver {
         public AlignmentInterval getIntervalForRange(Range range) {
 
             for (AlignmentInterval interval : intervals) {
-                if (interval.contains(range.getChr(), range.getStart(), range.getEnd())) {
+                if (interval.contains(range.getContig(), range.getStart(), range.getEnd())) {
                     return interval;
                 }
             }

--- a/src/main/java/org/broad/igv/sam/AlignmentInterval.java
+++ b/src/main/java/org/broad/igv/sam/AlignmentInterval.java
@@ -102,7 +102,7 @@ public class AlignmentInterval extends Locus {
         if (genome == null) {
             return 0;
         }
-        return genome.getReference(getChr(), pos);
+        return genome.getReference(getContig(), pos);
     }
 
     public AlignmentCounts getCounts() {
@@ -161,7 +161,7 @@ public class AlignmentInterval extends Locus {
     }
 
     public Range getRange() {
-        return new Range(getChr(), getStart(), getEnd());
+        return new Range(getContig(), getStart(), getEnd());
     }
 
     public void packAlignments(AlignmentTrack.RenderOptions renderOptions) {

--- a/src/main/java/org/broad/igv/sam/AlignmentPacker.java
+++ b/src/main/java/org/broad/igv/sam/AlignmentPacker.java
@@ -256,7 +256,7 @@ public class AlignmentPacker {
         return al.isPrimary() &&
                 al.isPaired() &&
                 al.getMate().isMapped() &&
-                al.getMate().getChr().equals(al.getChr());
+                al.getMate().getChr().equals(al.getContig());
     }
 
     private List<Alignment> linkByTag(List<Alignment> alList, String tag) {
@@ -333,7 +333,7 @@ public class AlignmentPacker {
         for (Alignment alignment : alignmentsList) {
             maxEnd = Math.max(maxEnd, alignment.getEnd());
         }
-        return new Range(firstAlignment.getChr(), minStart,
+        return new Range(firstAlignment.getContig(), minStart,
                 maxEnd);
     }
 
@@ -442,7 +442,7 @@ public class AlignmentPacker {
                 //    2: alignments with a gap at the position
                 //    3: alignment that do not overlap the position (or are on a different chromosome)
 
-                if (al.getChr().equals(pos.getChr()) &&
+                if (al.getContig().equals(pos.getContig()) &&
                     al.getAlignmentStart() <= pos.getStart() &&
                     al.getAlignmentEnd() > pos.getStart()) {
 

--- a/src/main/java/org/broad/igv/sam/AlignmentRenderer.java
+++ b/src/main/java/org/broad/igv/sam/AlignmentRenderer.java
@@ -560,7 +560,7 @@ public class AlignmentRenderer {
         Color alignmentColor1 = getAlignmentColor(pair.firstAlignment, renderOptions);
         Color alignmentColor2 = null;
 
-        boolean overlapped = pair.secondAlignment != null && (pair.firstAlignment.getChr().equals(pair.secondAlignment.getChr())) &&
+        boolean overlapped = pair.secondAlignment != null && (pair.firstAlignment.getContig().equals(pair.secondAlignment.getContig())) &&
                 pair.firstAlignment.getAlignmentEnd() > pair.secondAlignment.getAlignmentStart();
 
         Graphics2D g = context.getGraphics2D("ALIGNMENT");
@@ -1259,7 +1259,7 @@ public class AlignmentRenderer {
             case INSERT_SIZE:
                 boolean isPairedAlignment = alignment instanceof PairedAlignment;
                 if ((alignment.isPaired() && alignment.getMate().isMapped()) || isPairedAlignment) {
-                    boolean sameChr = isPairedAlignment || alignment.getMate().getChr().equals(alignment.getChr());
+                    boolean sameChr = isPairedAlignment || alignment.getMate().getChr().equals(alignment.getContig());
                     if (sameChr) {
                         int readDistance = Math.abs(alignment.getInferredInsertSize());
                         if (readDistance != 0) {

--- a/src/main/java/org/broad/igv/sam/AlignmentTrack.java
+++ b/src/main/java/org/broad/igv/sam/AlignmentTrack.java
@@ -839,7 +839,7 @@ public class AlignmentTrack extends AbstractTrack implements IGVEventObserver {
             StringBuffer buf = new StringBuffer();
             buf.append(alignment.getValueString(location, mouseX, null).replace("<br>", "\n"));
             buf.append("\n");
-            buf.append("Alignment start position = " + alignment.getChr() + ":" + (alignment.getAlignmentStart() + 1));
+            buf.append("Alignment start position = " + alignment.getContig() + ":" + (alignment.getAlignmentStart() + 1));
             buf.append("\n");
             buf.append(alignment.getReadSequence());
             StringSelection stringSelection = new StringSelection(buf.toString());
@@ -1708,7 +1708,7 @@ public class AlignmentTrack extends AbstractTrack implements IGVEventObserver {
                 frame = FrameManager.getDefaultFrame();  // Clicked over name panel, not a specific frame
             }
             final Range range = frame.getCurrentRange();
-            final String chrom = range.getChr();
+            final String chrom = range.getContig();
             final int chromStart = (int) frame.getChromosomePosition(me.getX());
             // Change track height by attribute
             JMenu groupMenu = new JMenu("Group alignments by");
@@ -1749,14 +1749,14 @@ public class AlignmentTrack extends AbstractTrack implements IGVEventObserver {
 
             Range oldGroupByPos = renderOptions.getGroupByPos();
             if (renderOptions.getGroupByOption() == GroupOption.BASE_AT_POS) { // already sorted by the base at a position
-                JCheckBoxMenuItem oldGroupByPosOption = new JCheckBoxMenuItem("base at " + oldGroupByPos.getChr() +
+                JCheckBoxMenuItem oldGroupByPosOption = new JCheckBoxMenuItem("base at " + oldGroupByPos.getContig() +
                         ":" + Globals.DECIMAL_FORMAT.format(1 + oldGroupByPos.getStart()));
                 groupMenu.add(oldGroupByPosOption);
                 oldGroupByPosOption.setSelected(true);
             }
 
             if (renderOptions.getGroupByOption() != GroupOption.BASE_AT_POS || oldGroupByPos == null ||
-                    !oldGroupByPos.getChr().equals(chrom) || oldGroupByPos.getStart() != chromStart) { // not already sorted by this position
+                    !oldGroupByPos.getContig().equals(chrom) || oldGroupByPos.getStart() != chromStart) { // not already sorted by this position
                 JCheckBoxMenuItem newGroupByPosOption = new JCheckBoxMenuItem("base at " + chrom +
                         ":" + Globals.DECIMAL_FORMAT.format(1 + chromStart));
                 newGroupByPosOption.addActionListener(new ActionListener() {

--- a/src/main/java/org/broad/igv/sam/BaseAlignmentCounts.java
+++ b/src/main/java/org/broad/igv/sam/BaseAlignmentCounts.java
@@ -85,10 +85,6 @@ abstract public class BaseAlignmentCounts implements AlignmentCounts {
         return end;
     }
 
-    public String getChr() {
-        return null;
-    }
-
     @Override
     public String getContig() {
         return null;

--- a/src/main/java/org/broad/igv/sam/BisulfiteCounts.java
+++ b/src/main/java/org/broad/igv/sam/BisulfiteCounts.java
@@ -55,7 +55,7 @@ public class BisulfiteCounts {
         // Only works with block formats
         if(baseAlignment.getAlignmentBlocks() == null) return;
 
-        String chrname = genome.getCanonicalChrName(baseAlignment.getChr());
+        String chrname = genome.getCanonicalChrName(baseAlignment.getContig());
 
         boolean flipRead;
         // We will only need reverse complement if the strand and paired end status don't match (2nd ends are G->A)

--- a/src/main/java/org/broad/igv/sam/DotAlignedAlignment.java
+++ b/src/main/java/org/broad/igv/sam/DotAlignedAlignment.java
@@ -104,10 +104,6 @@ public class DotAlignedAlignment implements Alignment {
         return chromosome;
     }
 
-    public String getChr() {
-        return chromosome;
-    }
-
     @Override
     public String getContig() {
         return chromosome;

--- a/src/main/java/org/broad/igv/sam/DownsampledInterval.java
+++ b/src/main/java/org/broad/igv/sam/DownsampledInterval.java
@@ -60,10 +60,6 @@ public class DownsampledInterval implements Feature {
         return start;
     }
 
-    public String getChr() {
-        return null;
-    }
-
     @Override
     public String getContig() {
         return null;

--- a/src/main/java/org/broad/igv/sam/FeatureWrappedAlignment.java
+++ b/src/main/java/org/broad/igv/sam/FeatureWrappedAlignment.java
@@ -53,7 +53,7 @@ public class FeatureWrappedAlignment implements Alignment {
     public FeatureWrappedAlignment(BasicFeature f) {
 
         this.readName = f.getName();
-        this.chr = f.getChr();
+        this.chr = f.getContig();
         this.start = f.getStart();
         this.end = f.getEnd();
         strand = f.getStrand();
@@ -79,10 +79,6 @@ public class FeatureWrappedAlignment implements Alignment {
     }
 
     public String getChromosome() {
-        return chr;
-    }
-
-    public String getChr() {
         return chr;
     }
 

--- a/src/main/java/org/broad/igv/sam/LinkedAlignment.java
+++ b/src/main/java/org/broad/igv/sam/LinkedAlignment.java
@@ -48,7 +48,7 @@ public class LinkedAlignment implements Alignment {
         String library = alignment.getLibrary();
 
         if (alignments.isEmpty()) {
-            this.chr = alignment.getChr();
+            this.chr = alignment.getContig();
             alignmentStart = alignment.getAlignmentStart();
             alignmentEnd = alignment.getAlignmentEnd();
 
@@ -62,7 +62,7 @@ public class LinkedAlignment implements Alignment {
 
         } else {
 
-            if (!this.chr.equals(alignment.getChr())) {
+            if (!this.chr.equals(alignment.getContig())) {
                 throw new RuntimeException("Mixed chromosome linked alignments not supported");
             }
 
@@ -111,11 +111,6 @@ public class LinkedAlignment implements Alignment {
             }
         }
         return strand;
-    }
-
-    @Override
-    public String getChr() {
-        return chr;
     }
 
     @Override
@@ -414,7 +409,7 @@ public class LinkedAlignment implements Alignment {
 
     @Override
     public String getContig() {
-        return null;
+        return chr;
     }
 
     static final Comparator<Alignment> ALIGNMENT_START_COMPARATOR = new Comparator<Alignment>() {

--- a/src/main/java/org/broad/igv/sam/PairedAlignment.java
+++ b/src/main/java/org/broad/igv/sam/PairedAlignment.java
@@ -51,7 +51,7 @@ public class PairedAlignment implements Alignment {
         this.firstAlignment = firstAlignment;
         this.start = firstAlignment.getStart();
         this.end = firstAlignment.getEnd();
-        this.chr = firstAlignment.getChr();
+        this.chr = firstAlignment.getContig();
     }
 
     public void setSecondAlignment(Alignment alignment) {
@@ -67,10 +67,6 @@ public class PairedAlignment implements Alignment {
     }
 
     public String getChromosome() {
-        return chr;  //To change body of implemented methods use File | Settings | File Templates.
-    }
-
-    public String getChr() {
         return chr;  //To change body of implemented methods use File | Settings | File Templates.
     }
 

--- a/src/main/java/org/broad/igv/sam/PositionCache.java
+++ b/src/main/java/org/broad/igv/sam/PositionCache.java
@@ -71,7 +71,7 @@ class PositionCache<V> {
     }
 
     private Range getKeyForRange(Range range) {
-        String chr = range.getChr();
+        String chr = range.getContig();
         for (Range cachedRange : intervals.keySet()) {
             if (cachedRange.contains(chr, range.getStart(), range.getEnd())) {
                 return cachedRange;

--- a/src/main/java/org/broad/igv/sam/ReducedMemoryAlignment.java
+++ b/src/main/java/org/broad/igv/sam/ReducedMemoryAlignment.java
@@ -62,7 +62,7 @@ public class ReducedMemoryAlignment implements Alignment {
 
         this.negativeStrand = al.isNegativeStrand();
         this.readName = al.getReadName();
-        this.chromosome = al.getChr();
+        this.chromosome = al.getContig();
         this.start = al.getStart();
         this.end = al.getEnd();
         this.cigarString = al.getCigarString();
@@ -156,10 +156,6 @@ public class ReducedMemoryAlignment implements Alignment {
 
 
     public String getChromosome() {
-        return chromosome;
-    }
-
-    public String getChr() {
         return chromosome;
     }
 
@@ -547,11 +543,6 @@ public class ReducedMemoryAlignment implements Alignment {
         }
 
         // Rest is needed for the interface, but NA for reduced memory alignments
-        @Override
-        public String getChr() {
-            return null;
-        }
-
         @Override
         public String getContig() {
             return null;

--- a/src/main/java/org/broad/igv/sam/Row.java
+++ b/src/main/java/org/broad/igv/sam/Row.java
@@ -145,7 +145,7 @@ public class Row implements Comparable<Row> {
                     if (mate == null) {
                         return Integer.MAX_VALUE;
                     } else {
-                        if (mate.getChr().equals(centerAlignment.getChr())) {
+                        if (mate.getChr().equals(centerAlignment.getContig())) {
                             return Integer.MAX_VALUE - 1;
                         } else {
                             return mate.getChr().hashCode();

--- a/src/main/java/org/broad/igv/sam/SAMAlignment.java
+++ b/src/main/java/org/broad/igv/sam/SAMAlignment.java
@@ -112,11 +112,6 @@ public abstract class SAMAlignment implements Alignment {
     public SAMAlignment() {
     }
 
-
-    public String getChr() {
-        return chr;
-    }
-
     @Override
     public String getContig() {
         return chr;
@@ -532,7 +527,7 @@ public abstract class SAMAlignment implements Alignment {
         buf.append("Mapping = " + (isPrimary() ? (isSupplementary() ? "Supplementary" : "Primary") : "Secondary") +
                 (isDuplicate() ? " Duplicate" : "") + (isVendorFailedRead() ? " Failed QC" : "") +
                 " @ MAPQ " + Globals.DECIMAL_FORMAT.format(getMappingQuality()) + "<br>");
-        buf.append("Reference span = " + getChr() + ":" + Globals.DECIMAL_FORMAT.format(getAlignmentStart() + 1) + "-" +
+        buf.append("Reference span = " + getContig() + ":" + Globals.DECIMAL_FORMAT.format(getAlignmentStart() + 1) + "-" +
                 Globals.DECIMAL_FORMAT.format(getAlignmentEnd()) + " (" + (isNegativeStrand() ? "-" : "+") + ")" +
                 " = " + Globals.DECIMAL_FORMAT.format(getAlignmentEnd() - getAlignmentStart()) + "bp<br>");
         buf.append("Cigar = " + cigarString + "<br>");
@@ -584,7 +579,7 @@ public abstract class SAMAlignment implements Alignment {
             if (getMate().isMapped()) {
                 buf.append("Mate start = " + getMate().positionString() + "<br>");
                 //buf.append("Pair is proper = " + (getProperPairFlag() ? "yes" : "no") + "<br>");
-                if (getChr().equals(getMate().getChr())) {
+                if (getContig().equals(getMate().getChr())) {
                     buf.append("Insert size = " + getInferredInsertSize() + "<br>");
                 }
             }
@@ -635,7 +630,7 @@ public abstract class SAMAlignment implements Alignment {
                 }
 
                 byte quality = block.getQuality(offset);
-                buf.append("Location = " + getChr() + ":" + Globals.DECIMAL_FORMAT.format(1 + (long) position) + "<br>");
+                buf.append("Location = " + getContig() + ":" + Globals.DECIMAL_FORMAT.format(1 + (long) position) + "<br>");
                 buf.append("Base = " + (char) base + " @ QV " + Globals.DECIMAL_FORMAT.format(quality) + "<br>");
 
                 break;
@@ -802,7 +797,7 @@ public abstract class SAMAlignment implements Alignment {
 
          */
 
-        if (isPaired() && isMapped() && mate != null && mate.isMapped() && getChr().equals(mate.getChr())) {   // && name === mate.name
+        if (isPaired() && isMapped() && mate != null && mate.isMapped() && getContig().equals(mate.getChr())) {   // && name === mate.name
 
             char s1 = isNegativeStrand() ? 'R' : 'F';
             char s2 = mate.isNegativeStrand() ? 'R' : 'F';

--- a/src/main/java/org/broad/igv/sam/SAMWriter.java
+++ b/src/main/java/org/broad/igv/sam/SAMWriter.java
@@ -116,7 +116,7 @@ public class SAMWriter {
      */
     public static String getSAMString(Alignment alignment) {
 
-        String refName = alignment.getChr();
+        String refName = alignment.getContig();
         List<String> tokens = new ArrayList<String>(11);
 
         tokens.add(alignment.getReadName());
@@ -220,7 +220,7 @@ public class SAMWriter {
         }
 
         private boolean passLocFilter(Alignment al) {
-            return this.chr != null && this.overlaps(al.getChr(), al.getStart(), al.getEnd());
+            return this.chr != null && this.overlaps(al.getContig(), al.getStart(), al.getEnd());
         }
 
         /**

--- a/src/main/java/org/broad/igv/sam/SpliceJunctionHelper.java
+++ b/src/main/java/org/broad/igv/sam/SpliceJunctionHelper.java
@@ -135,7 +135,7 @@ public class SpliceJunctionHelper {
                         SpliceJunctionFeature junction = startEndJunctionsTableThisStrand.get(junctionStart, junctionEnd);
 
                         if (junction == null) {
-                            junction = new SpliceJunctionFeature(alignment.getChr(), junctionStart, junctionEnd,
+                            junction = new SpliceJunctionFeature(alignment.getContig(), junctionStart, junctionEnd,
                                     isNegativeStrand ? Strand.NEGATIVE : Strand.POSITIVE);
                             startEndJunctionsTableThisStrand.put(junctionStart, junctionEnd, junction);
                             allSpliceJunctionFeatures.add(junction);
@@ -177,7 +177,7 @@ public class SpliceJunctionHelper {
             final int junctionStart = posFeature.getJunctionStart();
             final int junctionEnd = posFeature.getJunctionEnd();
 
-            SpliceJunctionFeature combinedFeature = new SpliceJunctionFeature(posFeature.getChr(), junctionStart, junctionEnd);
+            SpliceJunctionFeature combinedFeature = new SpliceJunctionFeature(posFeature.getContig(), junctionStart, junctionEnd);
             combinedFeature.setJunctionDepth(posFeature.getJunctionDepth());
             combinedMap.put(junctionStart, junctionEnd, combinedFeature);
         }
@@ -193,7 +193,7 @@ public class SpliceJunctionHelper {
 
             if (junction == null) {
                 // No existing (+) junction here, just add the (-) one\
-                SpliceJunctionFeature combinedFeature = new SpliceJunctionFeature(negFeature.getChr(), junctionStart, junctionEnd);
+                SpliceJunctionFeature combinedFeature = new SpliceJunctionFeature(negFeature.getContig(), junctionStart, junctionEnd);
                 combinedFeature.setJunctionDepth(negFeature.getJunctionDepth());
                 combinedMap.put(junctionStart, junctionEnd, negFeature);
             } else {

--- a/src/main/java/org/broad/igv/sam/cram/IGVReferenceSource.java
+++ b/src/main/java/org/broad/igv/sam/cram/IGVReferenceSource.java
@@ -55,7 +55,7 @@ public class IGVReferenceSource implements CRAMReferenceSource {
 
     private static Logger log = Logger.getLogger(IGVReferenceSource.class);
 
-    static ObjectCache<String, byte[]> cachedSequences = new ObjectCache<String, byte[]>(2);
+    static ObjectCache<String, byte[]> cachedSequences = new ObjectCache<>(2);
 
     static GenomeChangeListener genomeChangeListener;
 

--- a/src/main/java/org/broad/igv/sam/reader/DotAlignedCodec.java
+++ b/src/main/java/org/broad/igv/sam/reader/DotAlignedCodec.java
@@ -60,7 +60,7 @@ public class DotAlignedCodec implements SortingCollection.Codec<DotAlignedAlignm
 
     public void encode(DotAlignedAlignment alignment) {
         try {
-            outputStream.writeUTF(alignment.getChr());
+            outputStream.writeUTF(alignment.getContig());
             outputStream.writeInt(alignment.getStart());
             outputStream.writeInt(alignment.getEnd());
             outputStream.writeBoolean(alignment.isNegativeStrand());

--- a/src/main/java/org/broad/igv/sam/reader/GeraldReader.java
+++ b/src/main/java/org/broad/igv/sam/reader/GeraldReader.java
@@ -229,7 +229,7 @@ public class GeraldReader implements AlignmentReader {
         private void advanceToFirstRecord() {
             nextRecord = parseNextRecord();
             while (nextRecord != null) {
-                if (!nextRecord.getChr().equals(chr)) {
+                if (!nextRecord.getContig().equals(chr)) {
                     break;
                 } else if (withinBounds(nextRecord)) {
                     break;
@@ -266,7 +266,7 @@ public class GeraldReader implements AlignmentReader {
         @Override
         public boolean hasNext() {
             if (nextRecord == null ||
-                    !chr.equals(nextRecord.getChr())) {
+                    !chr.equals(nextRecord.getContig())) {
                 return false;
             } else {
                 return contained ? nextRecord.getEnd() <= end

--- a/src/main/java/org/broad/igv/sam/reader/MergedAlignmentReader.java
+++ b/src/main/java/org/broad/igv/sam/reader/MergedAlignmentReader.java
@@ -232,8 +232,8 @@ public class MergedAlignmentReader implements AlignmentReader {
                 Alignment a1 = wrapper1.nextRecord;
                 Alignment a2 = wrapper2.nextRecord;
 
-                Integer idx1 = chrNameIndex.get(a1.getChr());
-                Integer idx2 = chrNameIndex.get(a2.getChr());
+                Integer idx1 = chrNameIndex.get(a1.getContig());
+                Integer idx2 = chrNameIndex.get(a2.getContig());
                 if(idx1==null) idx1 = Integer.MAX_VALUE;
                 if(idx2== null) idx2 = Integer.MAX_VALUE;  // Put these records at the end.
                 if (idx1 > idx2) {

--- a/src/main/java/org/broad/igv/sashimi/SashimiJunctionRenderer.java
+++ b/src/main/java/org/broad/igv/sashimi/SashimiJunctionRenderer.java
@@ -319,7 +319,7 @@ public class SashimiJunctionRenderer extends IGVFeatureRenderer {
         int buffer = 4;
         int coverage = 0;
         for(AlignmentInterval interval: intervals){
-            if(interval.contains(interval.getChr(), genomePos - buffer, genomePos + buffer)){
+            if(interval.contains(interval.getContig(), genomePos - buffer, genomePos + buffer)){
                 for(int loc= genomePos - buffer; loc < genomePos + buffer; loc++){
                     coverage = Math.max(coverage, interval.getTotalCount(loc));
                 }

--- a/src/main/java/org/broad/igv/session/Session.java
+++ b/src/main/java/org/broad/igv/session/Session.java
@@ -274,7 +274,7 @@ public class Session implements IGVEventObserver {
         Range range = getReferenceFrame().getCurrentRange();
         String startStr = String.valueOf(range.getStart());
         String endStr = String.valueOf(range.getEnd());
-        String position = range.getChr() + ":" + startStr + "-" + endStr;
+        String position = range.getContig() + ":" + startStr + "-" + endStr;
         return position;
     }
 

--- a/src/main/java/org/broad/igv/tools/CoverageCounter.java
+++ b/src/main/java/org/broad/igv/tools/CoverageCounter.java
@@ -301,7 +301,7 @@ public class CoverageCounter {
                 iter = reader.iterator();
             } else {
                 reader = AlignmentReaderFactory.getReader(alignmentFile, true);
-                iter = reader.query(queryInterval.getChr(), queryInterval.getStart() - 1, queryInterval.getEnd(), false);
+                iter = reader.query(queryInterval.getContig(), queryInterval.getStart() - 1, queryInterval.getEnd(), false);
             }
 
             while (iter != null && iter.hasNext()) {
@@ -326,7 +326,7 @@ public class CoverageCounter {
 
                     totalCount++;
 
-                    String alignmentChr = alignment.getChr();
+                    String alignmentChr = alignment.getContig();
 
                     // Close all counters with position < alignment.getStart()
                     if (alignmentChr.equals(lastChr)) {

--- a/src/main/java/org/broad/igv/tools/FeatureSearcher.java
+++ b/src/main/java/org/broad/igv/tools/FeatureSearcher.java
@@ -231,7 +231,7 @@ public class FeatureSearcher implements Runnable {
             ReferenceFrame frame = FrameManager.getDefaultFrame();
             Feature f = searchResult.next();
 
-            String chr = GenomeManager.getInstance().getCurrentGenome().getCanonicalChrName(f.getChr());
+            String chr = GenomeManager.getInstance().getCurrentGenome().getCanonicalChrName(f.getContig());
             double newCenter = f.getStart();
             if (!chr.equals(frame.getChrName())) {
                 // Switch chromosomes.  We have to do some tricks to maintain the same resolution scale.

--- a/src/main/java/org/broad/igv/tools/PairedEndStats.java
+++ b/src/main/java/org/broad/igv/tools/PairedEndStats.java
@@ -167,7 +167,7 @@ public class PairedEndStats {
                 alignment.getInferredInsertSize() != 0) {
             ReadMate mate = alignment.getMate();
             boolean mateMapped = mate != null && mate.isMapped();
-            boolean sameChromosome = mateMapped && mate.getChr().equals(alignment.getChr());
+            boolean sameChromosome = mateMapped && mate.getChr().equals(alignment.getContig());
             return mateMapped && sameChromosome;
         }
         return false;

--- a/src/main/java/org/broad/igv/tools/PairedUtils.java
+++ b/src/main/java/org/broad/igv/tools/PairedUtils.java
@@ -73,7 +73,7 @@ public class PairedUtils {
                         alignment.getMappingQuality() > 0 &&
                         interactionFilter(alignment)) {
 
-                    String chr1 = alignment.getChr();
+                    String chr1 = alignment.getContig();
                     int bin1 = alignment.getAlignmentStart() / binSize;
                     String chr2 = alignment.getMate().getChr();
                     int bin2 = alignment.getMate().getStart() / binSize;
@@ -225,7 +225,7 @@ public class PairedUtils {
     }
 
     private static Orientation getOrientation(Alignment alignment) {
-        if (!alignment.getChr().equals(alignment.getMate().getChr())) {
+        if (!alignment.getContig().equals(alignment.getMate().getChr())) {
             return Orientation.INTER;
         } else {
             String pairOrientation = alignment.getPairOrientation();
@@ -261,7 +261,7 @@ public class PairedUtils {
 
     private static boolean interactionFilter(Alignment alignment) {
         return alignment.isPaired() && alignment.getMate().isMapped() &&
-                (Math.abs(alignment.getInferredInsertSize()) > 100000 || !alignment.getChr().equals(alignment.getMate().getChr()));
+                (Math.abs(alignment.getInferredInsertSize()) > 100000 || !alignment.getContig().equals(alignment.getMate().getChr()));
     }
 
     private static boolean funnyPairFilter(Alignment alignment) {
@@ -276,7 +276,7 @@ public class PairedUtils {
         if (Math.abs(alignment.getInferredInsertSize()) > 1000) return true;
 
         // Mate chromosome
-        if (alignment.getMate().isMapped() && !alignment.getChr().equals(alignment.getMate().getChr())) return true;
+        if (alignment.getMate().isMapped() && !alignment.getContig().equals(alignment.getMate().getChr())) return true;
 
         // Mate unmapped
         // if (!alignment.getMate().isMapped()) return true;

--- a/src/main/java/org/broad/igv/tools/converters/BamToBed.java
+++ b/src/main/java/org/broad/igv/tools/converters/BamToBed.java
@@ -65,7 +65,7 @@ public class BamToBed {
                     int end = properPairs ? (start + insertSize) : a.getAlignmentEnd();
                     String name = a.getReadName();
                     String strand = properPairs ? "." : (a.isNegativeStrand() ? "-" : "+");
-                    bedWriter.print(a.getChr() + "\t" + start + "\t" + end + "\t" + name + "\t" + strand);
+                    bedWriter.print(a.getContig() + "\t" + start + "\t" + end + "\t" + name + "\t" + strand);
                     if(properPairs) {
                         bedWriter.println("\t" + insertSize);
                     }

--- a/src/main/java/org/broad/igv/tools/converters/GCTtoIGVConverter.java
+++ b/src/main/java/org/broad/igv/tools/converters/GCTtoIGVConverter.java
@@ -101,9 +101,9 @@ public class GCTtoIGVConverter {
                     log.warn("No locus found for: " + probe + "  " + row.getDescription());
                 } else {
                     for (Locus locus : loci) {
-                        String igvLine = locus.getChr() + "\t" + locus.getStart() + "\t" + locus.getEnd() + "\t" + probe +
+                        String igvLine = locus.getContig() + "\t" + locus.getStart() + "\t" + locus.getEnd() + "\t" + probe +
                                 "\t" + row.getData();
-                        cltn.add(new SortableRecord(locus.getChr(), locus.getStart(), igvLine));
+                        cltn.add(new SortableRecord(locus.getContig(), locus.getStart(), igvLine));
                     }
                 }
             }

--- a/src/main/java/org/broad/igv/tools/converters/IlluminaToCN.java
+++ b/src/main/java/org/broad/igv/tools/converters/IlluminaToCN.java
@@ -101,7 +101,7 @@ public class IlluminaToCN {
                     int cnv = (int) Float.parseFloat(tokens[col + cnvOffset]);
 
                     Segment segment = currentSegments.get(sample);
-                    if (segment == null || !chr.equals(segment.getChr()) || cnv == (int) segment.getScore()) {
+                    if (segment == null || !chr.equals(segment.getContig()) || cnv == (int) segment.getScore()) {
                         if (segment != null) {
                             List<Segment> segs = cnvSegments.get(sample);
                             if (segs == null) {
@@ -135,7 +135,7 @@ public class IlluminaToCN {
             for (Map.Entry<String, List<Segment>> entry : cnvSegments.entrySet()) {
                 String sample = entry.getKey();
                 for (Segment segment : entry.getValue()) {
-                    cnvWriter.println(sample + "\t" + segment.getChr() + "\t" + segment.getStart() + "\t"
+                    cnvWriter.println(sample + "\t" + segment.getContig() + "\t" + segment.getStart() + "\t"
                             + segment.getEnd() + "\t" + "" + "\t" + (int) segment.getScore());
                 }
             }

--- a/src/main/java/org/broad/igv/tools/converters/MageTabToIGVConverter.java
+++ b/src/main/java/org/broad/igv/tools/converters/MageTabToIGVConverter.java
@@ -94,9 +94,9 @@ public class MageTabToIGVConverter {
                     System.out.println("No locus found for: " + probe + "  " + row.getDescription());
                 } else {
                     for (Locus locus : loci) {
-                        String igvLine = locus.getChr() + "\t" + locus.getStart() + "\t" + locus.getEnd() + "\t" + probe +
+                        String igvLine = locus.getContig() + "\t" + locus.getStart() + "\t" + locus.getEnd() + "\t" + probe +
                                 row.getData();
-                        cltn.add(new SortableRecord(locus.getChr(), locus.getStart(), igvLine));
+                        cltn.add(new SortableRecord(locus.getContig(), locus.getStart(), igvLine));
                     }
                 }
             }

--- a/src/main/java/org/broad/igv/track/FeatureCollectionSource.java
+++ b/src/main/java/org/broad/igv/track/FeatureCollectionSource.java
@@ -123,10 +123,10 @@ public class FeatureCollectionSource implements FeatureSource {
 
             featureMap = new HashMap();
             for (Feature f : allFeatures) {
-                List<Feature> fList = featureMap.get(f.getChr());
+                List<Feature> fList = featureMap.get(f.getContig());
                 if (fList == null) {
                     fList = new ArrayList();
-                    featureMap.put(f.getChr(), fList);
+                    featureMap.put(f.getContig(), fList);
                 }
                 fList.add(f);
             }

--- a/src/main/java/org/broad/igv/track/GFFFeatureSource.java
+++ b/src/main/java/org/broad/igv/track/GFFFeatureSource.java
@@ -282,14 +282,14 @@ public class GFFFeatureSource implements org.broad.igv.track.FeatureSource {
 
         private GFFFeature createParent(BasicFeature gffExon) {
 
-            return new GFFFeature(gffExon.getChr(), gffExon.getStart(), gffExon.getEnd(), gffExon.getStrand());
+            return new GFFFeature(gffExon.getContig(), gffExon.getStart(), gffExon.getEnd(), gffExon.getStrand());
 
         }
 
 
         private static BasicFeature copyForCDS(BasicFeature bf) {
 
-            BasicFeature copy = new BasicFeature(bf.getChr(), bf.getStart(), bf.getEnd(), bf.getStrand());
+            BasicFeature copy = new BasicFeature(bf.getContig(), bf.getStart(), bf.getEnd(), bf.getStrand());
             copy.setName(bf.getName());
             copy.setColor(bf.getColor());
             copy.setIdentifier(bf.getIdentifier());
@@ -323,7 +323,7 @@ public class GFFFeatureSource implements org.broad.igv.track.FeatureSource {
 
             public void addPart(BasicFeature bf) {
                 cdsParts.add(bf);
-                this.chr = bf.getChr();
+                this.chr = bf.getContig();
                 this.start = Math.min(this.start, bf.getStart());
                 this.end = Math.max(this.end, bf.getEnd());
                 this.strand = bf.getStrand();

--- a/src/main/java/org/broad/igv/track/TrackMenuUtils.java
+++ b/src/main/java/org/broad/igv/track/TrackMenuUtils.java
@@ -713,7 +713,7 @@ public class TrackMenuUtils {
             //return SAMWriter.writeAlignmentFilePicard(inlocator, outPath, range.getChr(), range.getStart(), range.getEnd());
 
             //Export those in memory, overlapping current view
-            return SAMWriter.writeAlignmentFilePicard(dataManager, outFile, frame, range.getChr(), range.getStart(), range.getEnd());
+            return SAMWriter.writeAlignmentFilePicard(dataManager, outFile, frame, range.getContig(), range.getStart(), range.getEnd());
         } catch (IOException e) {
             log.error(e.getMessage(), e);
             throw new RuntimeException(e);
@@ -750,7 +750,7 @@ public class TrackMenuUtils {
                 //Can't trust FeatureTrack.getFeatures to limit itself, so we filter
                 List<Feature> features = fTrack.getVisibleFeatures(frame);
                 Range range = frame.getCurrentRange();
-                Predicate<Feature> pred = FeatureUtils.getOverlapPredicate(range.getChr(), range.getStart(), range.getEnd());
+                Predicate<Feature> pred = FeatureUtils.getOverlapPredicate(range.getContig(), range.getStart(), range.getEnd());
                 features = CollUtils.filter(features, pred);
                 IGVBEDCodec codec = new IGVBEDCodec();
                 for (Feature feat : features) {
@@ -1418,7 +1418,7 @@ public class TrackMenuUtils {
 
                 double location = frame.getChromosomePosition(mouseX);
                 if (f instanceof IGVFeature) {
-                    String details = f.getChr() + ":" + (f.getStart() + 1) + "-" + f.getEnd() +
+                    String details = f.getContig() + ":" + (f.getStart() + 1) + "-" + f.getEnd() +
                             System.getProperty("line.separator") + System.getProperty("line.separator");
                     String valueString = ((IGVFeature) f).getValueString(location, mouseX, null);
                     if (details != null) {
@@ -1451,7 +1451,7 @@ public class TrackMenuUtils {
         item.addActionListener(new ActionListener() {
             public void actionPerformed(ActionEvent evt) {
                 Genome genome = GenomeManager.getInstance().getCurrentGenome();
-                IGV.copySequenceToClipboard(genome, f.getChr(), f.getStart(), f.getEnd(), strand);
+                IGV.copySequenceToClipboard(genome, f.getContig(), f.getStart(), f.getEnd(), strand);
             }
         });
         return item;
@@ -1462,7 +1462,7 @@ public class TrackMenuUtils {
         item.addActionListener(new ActionListener() {
 
             public void actionPerformed(ActionEvent evt) {
-                ExtendViewClient.postExtendView(featureName, f.getStart(), f.getEnd(), r.getChr(), r.getStart(), r.getEnd());
+                ExtendViewClient.postExtendView(featureName, f.getStart(), f.getEnd(), r.getContig(), r.getStart(), r.getEnd());
             }
         });
         return item;
@@ -1481,7 +1481,7 @@ public class TrackMenuUtils {
                     strand = Strand.NONE;
                 }
 
-                BlatClient.doBlatQuery(f.getChr(), f.getStart(), f.getEnd(), strand);
+                BlatClient.doBlatQuery(f.getContig(), f.getStart(), f.getEnd(), strand);
             }
         });
         return item;

--- a/src/main/java/org/broad/igv/track/TribbleFeatureSource.java
+++ b/src/main/java/org/broad/igv/track/TribbleFeatureSource.java
@@ -238,20 +238,20 @@ abstract public class TribbleFeatureSource implements org.broad.igv.track.Featur
                     int nSamples = 1000;
                     htsjdk.tribble.Feature firstFeature = iter.next();
                     htsjdk.tribble.Feature lastFeature = firstFeature;
-                    String chr = firstFeature.getChr();
+                    String chr = firstFeature.getContig();
                     int n = 1;
                     long len = 0;
                     while (iter.hasNext() && n < nSamples) {
                         htsjdk.tribble.Feature f = iter.next();
                         if (f != null) {
                             n++;
-                            if (f.getChr().equals(chr)) {
+                            if (f.getContig().equals(chr)) {
                                 lastFeature = f;
                             } else {
                                 len += lastFeature.getEnd() - firstFeature.getStart() + 1;
                                 firstFeature = f;
                                 lastFeature = f;
-                                chr = f.getChr();
+                                chr = f.getContig();
                             }
                         }
                     }
@@ -300,7 +300,7 @@ abstract public class TribbleFeatureSource implements org.broad.igv.track.Featur
                     Feature f = iter.next();
                     if (f == null) continue;
 
-                    String seqName = f.getChr();
+                    String seqName = f.getContig();
                     String igvChr = genome == null ? seqName : genome.getCanonicalChrName(seqName);
 
                     List<Feature> featureList = featureMap.get(igvChr);

--- a/src/main/java/org/broad/igv/ui/GlobalKeyDispatcher.java
+++ b/src/main/java/org/broad/igv/ui/GlobalKeyDispatcher.java
@@ -186,7 +186,7 @@ public class GlobalKeyDispatcher implements KeyEventDispatcher {
                 Range currentRange = FrameManager.getDefaultFrame().getCurrentRange();
                 RegionOfInterest regionOfInterest =
                         new RegionOfInterest(
-                                currentRange.getChr(),
+                                currentRange.getContig(),
                                 currentRange.getStart(),
                                 currentRange.getEnd(),
                                 null);
@@ -404,7 +404,7 @@ public class GlobalKeyDispatcher implements KeyEventDispatcher {
                 }
 
                 if (f != null) {
-                    String chr = GenomeManager.getInstance().getCurrentGenome().getCanonicalChrName(f.getChr());
+                    String chr = GenomeManager.getInstance().getCurrentGenome().getCanonicalChrName(f.getContig());
                     double newCenter = f.getStart();
                     if (!chr.equals(frame.getChrName())) {
                         // Switch chromosomes.  We have to do some tricks to maintain the same resolution scale.

--- a/src/main/java/org/broad/igv/ui/IGV.java
+++ b/src/main/java/org/broad/igv/ui/IGV.java
@@ -1630,7 +1630,7 @@ public class IGV implements IGVEventObserver {
             prefMgr.put(SAM_GROUP_BY_TAG, tag);
         }
         if (option == AlignmentTrack.GroupOption.BASE_AT_POS && pos != null) {
-            prefMgr.put(SAM_GROUP_BY_POS, pos.getChr() + " " + String.valueOf(pos.getStart()));
+            prefMgr.put(SAM_GROUP_BY_POS, pos.getContig() + " " + String.valueOf(pos.getStart()));
         }
         for (Track t : getAllTracks()) {
             if (t instanceof AlignmentTrack) {

--- a/src/main/java/org/broad/igv/ui/action/SearchCommand.java
+++ b/src/main/java/org/broad/igv/ui/action/SearchCommand.java
@@ -407,7 +407,7 @@ public class SearchCommand {
                 //The +2 accounts for centering on the center of the amino acid, not beginning
                 //and converting from 0-based to 1-based (which getStartEnd expects)
                 int[] locs = getStartEnd("" + (genomePos + 2));
-                result = new SearchResult(ResultType.LOCUS, feat.getChr(), locs[0], locs[1]);
+                result = new SearchResult(ResultType.LOCUS, feat.getContig(), locs[0], locs[1]);
                 results.add(result);
 
             }
@@ -597,7 +597,7 @@ public class SearchCommand {
         }
 
         public SearchResult(NamedFeature feature) {
-            this(ResultType.FEATURE, feature.getChr(), feature.getStart(), feature.getEnd());
+            this(ResultType.FEATURE, feature.getContig(), feature.getStart(), feature.getEnd());
             this.feature = feature;
             this.locus = this.feature.getName();
         }

--- a/src/main/java/org/broad/igv/ui/panel/FrameManager.java
+++ b/src/main/java/org/broad/igv/ui/panel/FrameManager.java
@@ -128,7 +128,7 @@ public class FrameManager implements IGVEventObserver {
                     lociNotFound.add(loci.get(0));
                 } else {
                     IGV.getInstance().getSession().setCurrentGeneList(null);
-                    getDefaultFrame().jumpTo(locus.getChr(), locus.getStart(), locus.getEnd());
+                    getDefaultFrame().jumpTo(locus.getContig(), locus.getStart(), locus.getEnd());
                     frames.add(getDefaultFrame());
                 }
             } else {

--- a/src/main/java/org/broad/igv/ui/panel/ReferenceFrame.java
+++ b/src/main/java/org/broad/igv/ui/panel/ReferenceFrame.java
@@ -411,7 +411,7 @@ public class ReferenceFrame {
     }
 
     public void jumpTo(Locus locus) {
-        String chr = locus.getChr();
+        String chr = locus.getContig();
         int start = locus.getStart();
         int end = locus.getEnd();
 
@@ -625,7 +625,7 @@ public class ReferenceFrame {
         } else {
 
             Range range = getCurrentRange();
-            return Locus.getFormattedLocusString(range.getChr(), range.getStart(), range.getEnd());
+            return Locus.getFormattedLocusString(range.getContig(), range.getStart(), range.getEnd());
         }
     }
 

--- a/src/main/java/org/broad/igv/ui/panel/RegionNavigatorDialog.java
+++ b/src/main/java/org/broad/igv/ui/panel/RegionNavigatorDialog.java
@@ -699,7 +699,7 @@ public class RegionNavigatorDialog extends JDialog implements Observer, IGVEvent
                         "Error", JOptionPane.INFORMATION_MESSAGE);
             } else {
                 Range r = FrameManager.getDefaultFrame().getCurrentRange();
-                RegionOfInterest newRegion = new RegionOfInterest(r.getChr(), r.getStart(), r.getEnd(), "");
+                RegionOfInterest newRegion = new RegionOfInterest(r.getContig(), r.getStart(), r.getEnd(), "");
                 IGV.getInstance().getSession().addRegionOfInterestWithNoListeners(newRegion);
             }
             updateButtonsEnabled();

--- a/src/main/java/org/broad/igv/util/blat/BlatTableModel.java
+++ b/src/main/java/org/broad/igv/util/blat/BlatTableModel.java
@@ -76,7 +76,7 @@ public class BlatTableModel extends AbstractTableModel {
 
         switch (columnIndex) {
             case 0:
-                return record.getChr();
+                return record.getContig();
             case 1:
                 return record.getStart();
             case 2:
@@ -109,7 +109,7 @@ public class BlatTableModel extends AbstractTableModel {
 
     public String getChr(int rowIndex) {
         PSLRecord record = records.get(rowIndex);
-        return record.getChr();
+        return record.getContig();
     }
 
     public int getStart(int rowIndex) {

--- a/src/main/java/org/broad/igv/util/extview/ExtendViewClient.java
+++ b/src/main/java/org/broad/igv/util/extview/ExtendViewClient.java
@@ -77,7 +77,7 @@ public class ExtendViewClient {
 
     public static void postExtendView(Alignment aln) {
         
-        String chr = aln.getChr();
+        String chr = aln.getContig();
         int start = aln.getAlignmentStart();
         int end = aln.getAlignmentEnd();
 

--- a/src/main/java/org/broad/igv/variant/New/Variant.java
+++ b/src/main/java/org/broad/igv/variant/New/Variant.java
@@ -50,11 +50,6 @@ public class Variant implements Feature {
 
 
     @Override
-    public String getChr() {
-        return chr;
-    }
-
-    @Override
     public String getContig() {
         return chr;
     }

--- a/src/main/java/org/broad/igv/variant/VariantTrack.java
+++ b/src/main/java/org/broad/igv/variant/VariantTrack.java
@@ -1004,7 +1004,7 @@ public class VariantTrack extends FeatureTrack implements IGVEventObserver {
         String id = variant.getID();
 
         StringBuffer toolTip = new StringBuffer();
-        toolTip.append("Chr: " + variant.getChr());
+        toolTip.append("Chr: " + variant.getContig());
         toolTip.append("<br>Position: " + variant.getPositionString());
         toolTip.append("<br>ID: " + id);
         toolTip.append("<br>Reference: " + variant.getReference());
@@ -1192,7 +1192,7 @@ public class VariantTrack extends FeatureTrack implements IGVEventObserver {
         }
         String id = variant.getID();
         StringBuffer toolTip = new StringBuffer();
-        toolTip = toolTip.append("Chr: " + variant.getChr());
+        toolTip = toolTip.append("Chr: " + variant.getContig());
         toolTip = toolTip.append("<br>Position: " + variant.getPositionString());
         toolTip = toolTip.append("<br>ID: " + id + "<br>");
         toolTip = toolTip.append("<br><b>Genotype Information</b>");

--- a/src/main/java/org/broad/igv/variant/util/VCFtoBed.java
+++ b/src/main/java/org/broad/igv/variant/util/VCFtoBed.java
@@ -67,7 +67,7 @@ public class VCFtoBed {
             while (iter.hasNext()) {
 
                 VariantContext vc = iter.next();
-                String chr = vc.getChr();
+                String chr = vc.getContig();
                 if (!chr.startsWith("chr")) {
                     chr = "chr" + chr;
                 }

--- a/src/main/java/org/broad/igv/variant/vcf/VCFVariant.java
+++ b/src/main/java/org/broad/igv/variant/vcf/VCFVariant.java
@@ -284,11 +284,6 @@ public class VCFVariant implements Variant {
     }
 
     @Override
-    public String getChr() {
-        return chr;
-    }
-
-    @Override
     public String getContig() {
         return chr;
     }
@@ -308,7 +303,7 @@ public class VCFVariant implements Variant {
 
     @Override
     public String toString() {
-        return String.format("VCFVariant[%s:%d-%d]", getChr(), getStart(), getEnd());
+        return String.format("VCFVariant[%s:%d-%d]", getContig(), getStart(), getEnd());
     }
 
     @Override
@@ -339,7 +334,7 @@ public class VCFVariant implements Variant {
             for (Allele all : variant.getAlternateAlleles()) {
                 alleleList.add(htsjdk.variant.variantcontext.Allele.create(all.getBases(), false));
             }
-            VariantContextBuilder vcb = new VariantContextBuilder(variant.getID(), variant.getChr(), variant.getStart(), variant.getEnd(), alleleList);
+            VariantContextBuilder vcb = new VariantContextBuilder(variant.getID(), variant.getContig(), variant.getStart(), variant.getEnd(), alleleList);
             return vcb.make();
         }
     }

--- a/src/test/java/org/broad/igv/cli_plugin/BEDToolsPluginSourceTest.java
+++ b/src/test/java/org/broad/igv/cli_plugin/BEDToolsPluginSourceTest.java
@@ -200,7 +200,7 @@ public class BEDToolsPluginSourceTest extends AbstractPluginTest {
             }
 
             Feature actFeature = actFeatures.get(ind);
-            assertEquals(expChr, actFeature.getChr());
+            assertEquals(expChr, actFeature.getContig());
             assertEquals(expStart, actFeature.getStart());
             assertEquals(expEnd, actFeature.getEnd());
 

--- a/src/test/java/org/broad/igv/data/GenomeSummaryDataTest.java
+++ b/src/test/java/org/broad/igv/data/GenomeSummaryDataTest.java
@@ -81,7 +81,7 @@ public class GenomeSummaryDataTest extends AbstractHeadlessTest {
         String lastChr = null;
 
         for(BasicFeature feature: features){
-            String chr = feature.getChr();
+            String chr = feature.getContig();
             //Finish off last chromosome
             if(lastChr != null && !chr.equals(lastChr)){
                 Map<String, float[]> dMap = new HashMap<String, float[]>();

--- a/src/test/java/org/broad/igv/data/cufflinks/FpkmTrackingCodecTest.java
+++ b/src/test/java/org/broad/igv/data/cufflinks/FpkmTrackingCodecTest.java
@@ -68,7 +68,7 @@ public class FpkmTrackingCodecTest {
         assertEquals(0.0001f, sampleVal1.fpkmLo);
         assertEquals(1.0f, sampleVal1.fpkmHi);
 
-        assertEquals(sampleVal0.getChr(), sampleVal1.getChr());
+        assertEquals(sampleVal0.getContig(), sampleVal1.getContig());
         assertEquals(sampleVal0.getStart(), sampleVal1.getStart());
         assertEquals(sampleVal0.getEnd(), sampleVal1.getEnd());
     }

--- a/src/test/java/org/broad/igv/feature/FeatureUtilsTest.java
+++ b/src/test/java/org/broad/igv/feature/FeatureUtilsTest.java
@@ -176,10 +176,6 @@ public class FeatureUtilsTest {
             throw new UnsupportedOperationException("Not supported yet.");
         }
 
-        public String getChr() {
-            return null;  //To change body of implemented methods use File | Settings | File Templates.
-        }
-
         @Override
         public String getContig() {
             return null;

--- a/src/test/java/org/broad/igv/feature/LocusTest.java
+++ b/src/test/java/org/broad/igv/feature/LocusTest.java
@@ -61,7 +61,7 @@ public class LocusTest {
         Locus locus = Locus.fromString(locusString);
         assertNotNull(locus);
         assertTrue(locus.isValid());
-        assertEquals("chr1", locus.getChr());
+        assertEquals("chr1", locus.getContig());
         assertEquals(15000000, locus.getStart());
         assertEquals(20000000, locus.getEnd());
     }

--- a/src/test/java/org/broad/igv/feature/MutationTrackLoaderTest.java
+++ b/src/test/java/org/broad/igv/feature/MutationTrackLoaderTest.java
@@ -73,7 +73,7 @@ public class MutationTrackLoaderTest extends AbstractHeadlessTest {
                 Mutation mut = (Mutation) features.get(0);
 
                 assertEquals(testSampleId, mut.getSampleId());
-                assertEquals(testChr, mut.getChr());
+                assertEquals(testChr, mut.getContig());
                 assertEquals(testStart, mut.getStart());
                 assertEquals(testEnd, mut.getEnd());
                 assertEquals("Missense_Mutation", mut.getMutationType());

--- a/src/test/java/org/broad/igv/feature/tribble/CachingFeatureReaderTest.java
+++ b/src/test/java/org/broad/igv/feature/tribble/CachingFeatureReaderTest.java
@@ -91,7 +91,7 @@ public class CachingFeatureReaderTest {
 
         while (iter.hasNext()) {
             VCFVariant var = iter.next();
-            assertEquals(chr, var.getChr());
+            assertEquals(chr, var.getContig());
             assertTrue(var.getEnd() >= start && var.getStart() <= end);
             baseReaderLoci.add(getLocusString(var));
         }
@@ -102,7 +102,7 @@ public class CachingFeatureReaderTest {
         iter = cacheReader.query(chr, start, end);
         while (iter.hasNext()) {
             VCFVariant var = iter.next();
-            assertEquals(chr, var.getChr());
+            assertEquals(chr, var.getContig());
             assertTrue(var.getEnd() >= start && var.getStart() <= end);
             cacheReaderLoci.add(getLocusString(var));
         }
@@ -114,6 +114,6 @@ public class CachingFeatureReaderTest {
     }
 
     String getLocusString(VCFVariant variant) {
-        return variant.getChr() + ":" + variant.getStart() + "-" + variant.getEnd();
+        return variant.getContig() + ":" + variant.getStart() + "-" + variant.getEnd();
     }
 }

--- a/src/test/java/org/broad/igv/feature/tribble/EncodePeakCodecTest.java
+++ b/src/test/java/org/broad/igv/feature/tribble/EncodePeakCodecTest.java
@@ -55,7 +55,7 @@ public class EncodePeakCodecTest {
         Feature feature =  codec.decode(line);
         Feature feature2 = codec2.decode(line);
 
-        assertEquals("chr22", feature.getChr());
+        assertEquals("chr22", feature.getContig());
 
 
     }

--- a/src/test/java/org/broad/igv/feature/tribble/TribbleIndexTest.java
+++ b/src/test/java/org/broad/igv/feature/tribble/TribbleIndexTest.java
@@ -137,7 +137,7 @@ public class TribbleIndexTest extends AbstractHeadlessTest {
         int count = 0;
         while (iter.hasNext()) {
             htsjdk.variant.variantcontext.VariantContext feat = iter.next();
-            assertEquals("chr9", feat.getChr());
+            assertEquals("chr9", feat.getContig());
             assertEquals(feat.getStart(), 5073767);
             assertTrue(feat.hasAttribute("MapQs"));
             count++;
@@ -149,7 +149,7 @@ public class TribbleIndexTest extends AbstractHeadlessTest {
         count = 0;
         while (iter.hasNext()) {
             htsjdk.variant.variantcontext.VariantContext feat = iter.next();
-            assertEquals("chr9", feat.getChr());
+            assertEquals("chr9", feat.getContig());
             assertEquals(feat.getStart(), 5073767);
             assertTrue(feat.hasAttribute("MapQs"));
             count++;
@@ -167,7 +167,7 @@ public class TribbleIndexTest extends AbstractHeadlessTest {
         count = 0;
         while (iter.hasNext()) {
             htsjdk.variant.variantcontext.VariantContext feat = iter.next();
-            assertEquals(chr, feat.getChr());
+            assertEquals(chr, feat.getContig());
             if (count == 0) {
                 assertEquals(984163, feat.getStart());
             }

--- a/src/test/java/org/broad/igv/goby/GobyAlignmentQueryReaderTest.java
+++ b/src/test/java/org/broad/igv/goby/GobyAlignmentQueryReaderTest.java
@@ -181,7 +181,7 @@ public class GobyAlignmentQueryReaderTest extends AbstractHeadlessTest{
         int countVisit = 0;
         while (iter.hasNext()) {
             Alignment a = iter.next();
-            final String entryChr = a.getChr();
+            final String entryChr = a.getContig();
             //   System.out.println("chr:" + entryChr);
 
             if (entryChr.equals(previousChr)) {
@@ -189,9 +189,9 @@ public class GobyAlignmentQueryReaderTest extends AbstractHeadlessTest{
             } else {
                 assertFalse("Chromosomes should occur in blocks." +
                         " A chromosome that was used in a previous block of entry cannot occur again.",
-                        chromosomeSeen.contains(a.getChr()));
-                previousChr = a.getChr();
-                chromosomeSeen.add(a.getChr());
+                        chromosomeSeen.contains(a.getContig()));
+                previousChr = a.getContig();
+                chromosomeSeen.add(a.getContig());
             }
             countVisit++;
             if (countVisit > maxEntries) break;
@@ -440,7 +440,7 @@ public class GobyAlignmentQueryReaderTest extends AbstractHeadlessTest{
     private static class MockGobyAlignment extends GobyAlignment{
 
         @Override
-        public String getChr() {
+        public String getContig() {
             return "chrMock";
         }
 

--- a/src/test/java/org/broad/igv/gwas/EQTLCodecTest.java
+++ b/src/test/java/org/broad/igv/gwas/EQTLCodecTest.java
@@ -50,7 +50,7 @@ public class EQTLCodecTest {
         assertEquals("rs4700772", f.getSnp());
         assertEquals("ENSG00000168903.7", f.getGeneId());
         assertEquals("BTNL3", f.getGeneName());
-        assertEquals("5", f.getChr());
+        assertEquals("5", f.getContig());
         assertEquals(180341844, f.getStart());
         assertEquals(180341845, f.getEnd());
 

--- a/src/test/java/org/broad/igv/methyl/BBMethylDataSourceTest.java
+++ b/src/test/java/org/broad/igv/methyl/BBMethylDataSourceTest.java
@@ -77,7 +77,7 @@ public class BBMethylDataSourceTest {
         int i = 0;
         while (iter.hasNext()) {
             MethylScore ms = iter.next();
-            assertEquals(chr, ms.getChr());
+            assertEquals(chr, ms.getContig());
             assertEquals(expectedStarts[i], ms.getStart());
             assertEquals(expectedEnds[i], ms.getEnd());
             assertEquals(expectedPercents[i], ms.getScore(), .000001);
@@ -146,7 +146,7 @@ public class BBMethylDataSourceTest {
             MethylScore cScore = cachedScores.get(i);
             MethylScore score = nonCachedScores.get(i);
             Assert.assertEquals(cScore.getStart(), score.getStart());
-            Assert.assertEquals(cScore.getChr(), score.getChr());
+            Assert.assertEquals(cScore.getContig(), score.getContig());
         }
     }
 }

--- a/src/test/java/org/broad/igv/sam/AlignmentDataManagerTest.java
+++ b/src/test/java/org/broad/igv/sam/AlignmentDataManagerTest.java
@@ -165,7 +165,7 @@ public class AlignmentDataManagerTest extends AbstractHeadlessTest {
                 overlap |= (rec.getEnd() >= start) && (rec.getStart() < start);
                 Assert.assertTrue(overlap);
             }
-            Assert.assertEquals(sequence, rec.getChr());
+            Assert.assertEquals(sequence, rec.getContig());
         }
         reader.close();
         AlignmentDataManager manager = new AlignmentDataManager(loc, genome);
@@ -206,7 +206,7 @@ public class AlignmentDataManagerTest extends AbstractHeadlessTest {
                 overlap |= start >= rec.getStart() && start < rec.getEnd();
                 Assert.assertTrue(overlap);
             }
-            Assert.assertEquals(sequence, rec.getChr());
+            Assert.assertEquals(sequence, rec.getContig());
 
             Alignment exp = expectedResult.get(i);
             Assert.assertEquals("Start mismatch at position " + i + " read name " + exp.getReadName(), exp.getStart(), rec.getStart());

--- a/src/test/java/org/broad/igv/sam/AlignmentTileLoaderTest.java
+++ b/src/test/java/org/broad/igv/sam/AlignmentTileLoaderTest.java
@@ -124,7 +124,7 @@ public class AlignmentTileLoaderTest extends AbstractHeadlessTest {
                     int mateStart = al.getMate().getStart();
                     //All we require is some overlap
                     boolean overlap = (mateStart + al.getReadSequence().length()) >= start && mateStart < end;
-                    overlap &= al.getMate().getChr().equals(al.getChr());
+                    overlap &= al.getMate().getChr().equals(al.getContig());
                     if (overlap) {
                         Integer rdCnt = pairedReads.get(al.getReadName());
                         rdCnt = rdCnt != null ? rdCnt + 1 : 1;

--- a/src/test/java/org/broad/igv/sam/SamIndexerTest.java
+++ b/src/test/java/org/broad/igv/sam/SamIndexerTest.java
@@ -81,7 +81,7 @@ public class SamIndexerTest extends AbstractHeadlessTest{
 
         while (iter.hasNext()) {
             Alignment rec = iter.next();
-            assertEquals(chr, rec.getChr());
+            assertEquals(chr, rec.getContig());
             assertTrue(rec.getStart() >= start);
             assertTrue(rec.getStart() < end);
             count++;

--- a/src/test/java/org/broad/igv/sam/SamQueryTextReaderTest.java
+++ b/src/test/java/org/broad/igv/sam/SamQueryTextReaderTest.java
@@ -87,7 +87,7 @@ public class SamQueryTextReaderTest {
         while (iter.hasNext()) {
             Alignment record = iter.next();
             if (record.isMapped()) {
-                assertEquals(chr, record.getChr());
+                assertEquals(chr, record.getContig());
                 assertTrue(record.getEnd() >= start);
                 assertTrue(record.getStart() <= end);
             }
@@ -121,7 +121,7 @@ public class SamQueryTextReaderTest {
         int count = 0;
         while (iter.hasNext()) {
             Alignment record = iter.next();
-            assertEquals(chr, record.getChr());
+            assertEquals(chr, record.getContig());
             assertTrue(record.getEnd() >= start);
             assertTrue(record.getStart() <= end);
             count++;
@@ -155,7 +155,7 @@ public class SamQueryTextReaderTest {
         int count = 0;
         while (iter.hasNext()) {
             Alignment record = iter.next();
-            assertEquals(chr, record.getChr());
+            assertEquals(chr, record.getContig());
             assertTrue(record.getEnd() >= start);
             assertTrue(record.getStart() <= end);
             count++;
@@ -181,7 +181,7 @@ public class SamQueryTextReaderTest {
         int count = 0;
         while (iter.hasNext()) {
             Alignment record = iter.next();
-            assertEquals(chr, record.getChr());
+            assertEquals(chr, record.getContig());
             assertTrue(record.getEnd() >= start);
             assertTrue(record.getStart() <= end);
             count++;

--- a/src/test/java/org/broad/igv/tools/FeatureSearcherTest.java
+++ b/src/test/java/org/broad/igv/tools/FeatureSearcherTest.java
@@ -101,7 +101,7 @@ public class FeatureSearcherTest extends AbstractHeadlessTest {
 
         Feature feat = searcher.getResult().next();
 
-        assertEquals("chr1", feat.getChr());
+        assertEquals("chr1", feat.getContig());
         assertEquals(100, feat.getStart());
         assertEquals(101, feat.getEnd());
     }
@@ -115,7 +115,7 @@ public class FeatureSearcherTest extends AbstractHeadlessTest {
 
         Feature feat = searcher.getResult().next();
 
-        assertEquals("chr1", feat.getChr());
+        assertEquals("chr1", feat.getContig());
         assertEquals(100000, feat.getStart());
         assertEquals(100010, feat.getEnd());
     }
@@ -129,7 +129,7 @@ public class FeatureSearcherTest extends AbstractHeadlessTest {
 
         Feature feat = searcher.getResult().next();
 
-        assertEquals("chr1", feat.getChr());
+        assertEquals("chr1", feat.getContig());
         assertEquals(100000, feat.getStart());
         assertEquals(100010, feat.getEnd());
     }
@@ -143,7 +143,7 @@ public class FeatureSearcherTest extends AbstractHeadlessTest {
 
         Feature feat = searcher.getResult().next();
 
-        assertEquals("chr2", feat.getChr());
+        assertEquals("chr2", feat.getContig());
         assertEquals(1, feat.getStart());
         assertEquals(10, feat.getEnd());
     }

--- a/src/test/java/org/broad/igv/tools/IGVToolsCountTest.java
+++ b/src/test/java/org/broad/igv/tools/IGVToolsCountTest.java
@@ -504,7 +504,7 @@ public class IGVToolsCountTest extends AbstractHeadlessTest {
         Iterator<Feature> features = reader.query(chr, 5085, 5091);
         int count = 0;
         while (features.hasNext() && count < 100) {
-            assertEquals(chr, features.next().getChr());
+            assertEquals(chr, features.next().getContig());
             count++;
         }
         assertEquals(3, count);

--- a/src/test/java/org/broad/igv/tools/IGVToolsTest.java
+++ b/src/test/java/org/broad/igv/tools/IGVToolsTest.java
@@ -324,11 +324,11 @@ public class IGVToolsTest extends AbstractHeadlessTest {
             Alignment a1 = iter.next();
             Alignment a2 = iter.next();
             assertEquals(a1.getReadName(), a2.getReadName());
-            assertEquals(a1.getChr(), a2.getChr());
+            assertEquals(a1.getContig(), a2.getContig());
             assertEquals(a1.getStart(), a2.getStart());
             assertEquals(a2.getEnd(), a2.getEnd());
 
-            String chr = a1.getChr();
+            String chr = a1.getContig();
             int start = a1.getAlignmentStart();
             if (lastChr != null && chr.equals(lastChr)) {
                 assertTrue(a1.getReadName(), start >= lastStart);

--- a/src/test/java/org/broad/igv/tools/converters/GFFtoBedTest.java
+++ b/src/test/java/org/broad/igv/tools/converters/GFFtoBedTest.java
@@ -92,7 +92,7 @@ public class GFFtoBedTest {
 
     private void compare(BasicFeature gffFeature, BasicFeature bedFeature) {
 
-        assertEquals(gffFeature.getChr(), bedFeature.getChr());
+        assertEquals(gffFeature.getContig(), bedFeature.getContig());
         assertEquals(gffFeature.getStart(), bedFeature.getStart());
         assertEquals(gffFeature.getEnd(), bedFeature.getEnd());
         assertEquals(gffFeature.getStrand(), bedFeature.getStrand());

--- a/src/test/java/org/broad/igv/tools/motiffinder/MotifFinderSourceTest.java
+++ b/src/test/java/org/broad/igv/tools/motiffinder/MotifFinderSourceTest.java
@@ -275,7 +275,7 @@ public class MotifFinderSourceTest extends AbstractHeadlessTest{
     }
 
     private void checkPatternMatches(String pattern, Feature feature){
-        byte[] sequence = genome.getSequence(feature.getChr(), feature.getStart(), feature.getEnd());
+        byte[] sequence = genome.getSequence(feature.getContig(), feature.getStart(), feature.getEnd());
         checkPatternMatches(pattern, feature, sequence);
     }
 

--- a/src/test/java/org/broad/igv/tools/parsers/TestBEDCodecs.java
+++ b/src/test/java/org/broad/igv/tools/parsers/TestBEDCodecs.java
@@ -211,7 +211,7 @@ public class TestBEDCodecs {
      * @param end
      */
     private void check_feat_unigene(Feature feat, String chr, int start, int end) {
-        assertEquals(chr, feat.getChr());
+        assertEquals(chr, feat.getContig());
         assertTrue(feat.getEnd() > feat.getStart());
         assertTrue("Start out of range", feat.getStart() >= start);
         assertTrue("end out of range", feat.getStart() <= end);

--- a/src/test/java/org/broad/igv/track/GFFFeatureSourceTest.java
+++ b/src/test/java/org/broad/igv/track/GFFFeatureSourceTest.java
@@ -74,7 +74,7 @@ public class GFFFeatureSourceTest extends AbstractHeadlessTest {
 
         while (feats.hasNext()) {
             Feature feat = feats.next();
-            assertEquals(chr, feat.getChr());
+            assertEquals(chr, feat.getContig());
             sourceFeats.add(feat);
         }
         return sourceFeats;
@@ -130,7 +130,7 @@ public class GFFFeatureSourceTest extends AbstractHeadlessTest {
 
 
             //Feature feat = features.next();
-            assertEquals(chr, feat.getChr());
+            assertEquals(chr, feat.getContig());
 
             BasicFeature bf = (BasicFeature) feat;
 

--- a/src/test/java/org/broad/igv/track/MutationDataManagerTest.java
+++ b/src/test/java/org/broad/igv/track/MutationDataManagerTest.java
@@ -57,7 +57,7 @@ public class MutationDataManagerTest extends AbstractHeadlessTest {
         int mutationCount = 0;
         while(mutations.hasNext()) {
             Mutation m = mutations.next();
-            assertEquals(chr, m.getChr());
+            assertEquals(chr, m.getContig());
 
             if(m.getStart() >= start && m.getEnd() <= end) {
                 mutationCount++;

--- a/src/test/java/org/broad/igv/track/PackedFeaturesTest.java
+++ b/src/test/java/org/broad/igv/track/PackedFeaturesTest.java
@@ -85,10 +85,6 @@ public class PackedFeaturesTest extends AbstractHeadlessTest {
             this.end = end;
         }
 
-        public String getChr() {
-            return chr;
-        }
-
         @Override
         public String getContig() {
             return chr;

--- a/src/test/java/org/broad/igv/ui/panel/ReferenceFrameTest.java
+++ b/src/test/java/org/broad/igv/ui/panel/ReferenceFrameTest.java
@@ -86,7 +86,7 @@ public class ReferenceFrameTest extends AbstractHeadlessTest{
         Locus locus = new Locus("chr1", 1000, 2000);
         frame.jumpTo(locus);
 
-        assertEquals(locus.getChr(), frame.getChrName());
+        assertEquals(locus.getContig(), frame.getChrName());
         assertEquals(locus.getStart(), frame.getOrigin(), 1.0);
         assertEquals(locus.getEnd(), frame.getEnd(), 1.0);
         assertConsistent();
@@ -102,7 +102,7 @@ public class ReferenceFrameTest extends AbstractHeadlessTest{
         double oldCenter = frame.getCenter();
 
         int delta = 12344;
-        frame.jumpTo(locus.getChr(), locus.getStart() + delta, locus.getEnd() + delta);
+        frame.jumpTo(locus.getContig(), locus.getStart() + delta, locus.getEnd() + delta);
 
         assertEquals(oldLocScale, frame.getScale());
         assertEquals(oldZoom, frame.getZoom());
@@ -171,7 +171,7 @@ public class ReferenceFrameTest extends AbstractHeadlessTest{
 
             Locus locus = Locus.fromString(loci.get(ii));
 
-            assertEquals(locus.getChr(), frame.getChrName());
+            assertEquals(locus.getContig(), frame.getChrName());
             assertEquals(locus.getStart() - 1, frame.getOrigin(), 0.5);
             assertEquals(locus.getEnd(), frame.getEnd(), 0.5);
         }

--- a/src/test/java/org/broad/igv/util/TestUtils.java
+++ b/src/test/java/org/broad/igv/util/TestUtils.java
@@ -210,7 +210,7 @@ public class TestUtils {
 
 
     public static void assertFeaturesEqual(Feature exp, Feature act) {
-        assertEquals(exp.getChr(), act.getChr());
+        assertEquals(exp.getContig(), act.getContig());
         assertEquals(exp.getStart(), act.getStart());
         assertEquals(exp.getEnd(), act.getEnd());
     }


### PR DESCRIPTION
@jrobinso It sounds like this is causing problems so I've updated all the deprecated calls to getChr.

* Replacing all instances of `Feature.getChr()` with the equivalent `Feature.getContig()`.
* Fixing some place where `getChr` and `getContig` were implemented differently.
  If they differed I resolved the differences by using the `getChr` implementation.
* Removing redundant implementations of `getChr` and allowing the default
implementation to be used.