### PR TITLE
Fix to put the genomes dir in the location expected by the code

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -295,7 +295,7 @@ task createToolsDist(type: Copy, dependsOn: toolJar)  {
         into "lib"
     }
     
-    with copySpec { from ("genomes") { } into "genomes" }
+    with copySpec { from ("genomes/sizes") { } into "lib/genomes" }
 
     into "${buildDir}/IGVTools-dist"
 }

--- a/build_java9.gradle
+++ b/build_java9.gradle
@@ -252,7 +252,7 @@ task createToolsDist(type: Copy, dependsOn: tooljar)  {
         into "lib"
     }
 
-    with copySpec { from ("genomes") { } into "genomes" }
+    with copySpec { from ("genomes/sizes") { } into "lib/genomes" }
 
     into "${buildDir}/IGVTools-dist"
 }


### PR DESCRIPTION
This fixes #594.  This location apparently changed from v2.3 to v2.4.