### PR TITLE
Add setLogScale command to CommandExecutor, test for same.

### DIFF
--- a/src/main/java/org/broad/igv/batch/CommandExecutor.java
+++ b/src/main/java/org/broad/igv/batch/CommandExecutor.java
@@ -43,6 +43,7 @@ import org.broad.igv.renderer.DataRange;
 import org.broad.igv.sam.AlignmentTrack;
 import org.broad.igv.track.RegionScoreType;
 import org.broad.igv.track.Track;
+import org.broad.igv.track.TrackProperties;
 import org.broad.igv.ui.IGV;
 import org.broad.igv.event.DataLoadedEvent;
 import org.broad.igv.event.IGVEventBus;
@@ -151,6 +152,8 @@ public class CommandExecutor {
                 igv.tweakPanelDivider();
             } else if (cmd.equalsIgnoreCase("setDataRange")) {
                 result = this.setDataRange(param1, param2);
+            } else if (cmd.equalsIgnoreCase("setLogScale")) {
+                result = this.setLogScale(param1, param2);
             } else if (cmd.equalsIgnoreCase("maxpanelheight") && param1 != null) {
                 return setMaxPanelHeight(param1);
             } else if (cmd.equalsIgnoreCase("tofront")) {
@@ -263,6 +266,30 @@ public class CommandExecutor {
                 track.setAutoScale(false);
             }
         }
+        return "OK";
+    }
+
+    private String setLogScale(String logScaleString, String trackName) {
+        List<Track> tracks = igv.getAllTracks();
+        boolean logScale;
+        try {
+            if(logScaleString.equalsIgnoreCase("true") || logScaleString.equalsIgnoreCase("false")){
+                logScale = Boolean.valueOf(logScaleString);
+            }else{
+                return "ERROR: logscale value (" + logScaleString + ")is not 'true' or 'false'.";
+            }
+        } catch (IllegalArgumentException e) {
+            return e.getMessage();
+        }
+        DataRange.Type scaleType = logScale==true ?
+                DataRange.Type.LOG :
+                DataRange.Type.LINEAR;
+        for (Track track : tracks) {
+            if (trackName == null || trackName.equalsIgnoreCase(track.getName())) {
+                    track.getDataRange().setType(scaleType);
+            }
+        }
+        IGV.getInstance().revalidateTrackPanels();
         return "OK";
     }
 

--- a/src/test/java/org/broad/igv/batch/CommandExecutorTest.java
+++ b/src/test/java/org/broad/igv/batch/CommandExecutorTest.java
@@ -432,6 +432,34 @@ public class CommandExecutorTest extends AbstractHeadedTest {
     }
 
     @Test
+    public void testSetLogScale() throws Exception {
+        String dataFile = TestUtils.DATA_DIR + "igv/recombRate.ens.igv.txt";
+        Map<String, String> params = null;
+        String name = null;
+        String format = null;
+        String index = null;
+        String coverage = null;
+        String locus = null;
+        boolean merge = true;
+        exec.loadFiles(dataFile, index, coverage, name, format, locus, merge, params);
+
+        String[] goodArgSet = new String[]{"true"};
+        for (String arg : goodArgSet) {
+            String resp = exec.execute("setLogScale " + arg);
+            assertEquals("OK", resp);
+        }
+
+        String[] badArgSet = new String[]{"bad"};
+        for (String arg : badArgSet) {
+            String resp = exec.execute("setLogScale " + arg);
+            assertTrue(resp.toLowerCase().startsWith("error"));
+        }
+
+
+    }
+
+
+    @Test
     public void testLoadGenomesById() throws Exception {
         String[] genomeIds = new String[]{"hg19", "mm10", "rn5", "canFam2", "bosTau7", "sacCer3", "WS220"};
         for (String genomeId : genomeIds) {


### PR DESCRIPTION
the goal of this modification is to enable to switch between linear and log scales for tracks using IGV batch commands. The syntax is "setLogScale ['true' or 'false'] [trackName]". If trackName is left blank, range is applied to all.