### PR TITLE
More flexible parsing of ZMW and movie name

### DIFF
--- a/src/main/java/org/broad/igv/sam/AlignmentPacker.java
+++ b/src/main/java/org/broad/igv/sam/AlignmentPacker.java
@@ -459,14 +459,14 @@ public class AlignmentPacker {
                 }
             case MOVIE: // group PacBio reads by movie
                 readNameParts = al.getReadName().split("/");
-                if (readNameParts.length != 3) {
+                if (readNameParts.length < 3) {
                     return "";
                 }
                 movieName = readNameParts[0];
                 return movieName;
             case ZMW: // group PacBio reads by ZMW
                 readNameParts = al.getReadName().split("/");
-                if (readNameParts.length != 3) {
+                if (readNameParts.length < 3) {
                     return "";
                 }
                 movieName = readNameParts[0];

--- a/src/main/java/org/broad/igv/sam/AlignmentRenderer.java
+++ b/src/main/java/org/broad/igv/sam/AlignmentRenderer.java
@@ -1299,13 +1299,13 @@ public class AlignmentRenderer {
                 break;
             case MOVIE:
                 readNameParts = alignment.getReadName().split("/");
-                if (readNameParts.length == 3) {
+                if (readNameParts.length >= 3) {
                     c = movieColors.get(readNameParts[0]);
                 }
                 break;
             case ZMW:
                 readNameParts = alignment.getReadName().split("/");
-                if (readNameParts.length == 3) {
+                if (readNameParts.length >= 3) {
                     c = zmwColors.get(readNameParts[0] + "/" + readNameParts[1]);
                 }
                 break;


### PR DESCRIPTION
Be more flexible in parsing ZMW and movie name from PacBio read names.
Rather than requiring that a read name be "movie/zmw/coords" allow
"movie/zmw/coords/...".

More generic read name parsing for e5508667.