### PR TITLE
Improve insertion markers / expanded insertions logic

### DIFF
--- a/src/main/java/org/broad/igv/prefs/Constants.java
+++ b/src/main/java/org/broad/igv/prefs/Constants.java
@@ -284,7 +284,8 @@ final public class Constants {
             SAM_QUICK_CONSENSUS_MODE,
             SAM_ALLELE_THRESHOLD,
             SAM_FLAG_LARGE_INDELS,
-            SAM_LARGE_INDELS_THRESHOLD
+            SAM_LARGE_INDELS_THRESHOLD,
+            SAM_SHOW_INSERTION_MARKERS
     );
 
 }

--- a/src/main/java/org/broad/igv/sam/AlignmentRenderer.java
+++ b/src/main/java/org/broad/igv/sam/AlignmentRenderer.java
@@ -987,7 +987,7 @@ public class AlignmentRenderer {
     private void drawBase(Graphics2D g, Color color, char c, int pX, int pY, int dX, int dY, boolean bisulfiteMode,
                           DisplayStatus bisstatus) {
 
-        int fontSize = Math.min(dX, 12);
+        int fontSize = Math.min(Math.min(dX,dY), 12);
         if (fontSize >= 8 && (!bisulfiteMode || (bisulfiteMode && bisstatus.equals(DisplayStatus.CHARACTER)))) {
             Font f = FontManager.getFont(Font.BOLD, fontSize);
             g.setFont(f);

--- a/src/main/java/org/broad/igv/sam/AlignmentTrack.java
+++ b/src/main/java/org/broad/igv/sam/AlignmentTrack.java
@@ -683,12 +683,14 @@ public class AlignmentTrack extends AbstractTrack implements IGVEventObserver {
         maximumHeight = Integer.MAX_VALUE;
 
         // Divide rectangle into equal height levels
-        double y = inputRect.getY();
+        double y = inputRect.getY() - 3;
         double h;
         if (getDisplayMode() == DisplayMode.EXPANDED) {
             h = expandedHeight;
-        } else {
-
+        } else if (getDisplayMode() == DisplayMode.COLLAPSED) {
+            h = collapsedHeight;
+        }
+        else {
             int visHeight = visibleRect.height;
             int depth = dataManager.getNLevels();
             if (depth == 0) {

--- a/src/main/java/org/broad/igv/sam/AlignmentTrack.java
+++ b/src/main/java/org/broad/igv/sam/AlignmentTrack.java
@@ -445,7 +445,7 @@ public class AlignmentTrack extends AbstractTrack implements IGVEventObserver {
         downsampleRect.height = DOWNAMPLED_ROW_HEIGHT;
         renderDownsampledIntervals(context, downsampleRect);
 
-        if (renderOptions.drawInsertionIntervals) {
+        if (renderOptions.isDrawInsertionIntervals()) {
             insertionRect = new Rectangle(rect);
             insertionRect.y += DOWNAMPLED_ROW_HEIGHT + DS_MARGIN_0;
             insertionRect.height = INSERTION_ROW_HEIGHT;
@@ -514,7 +514,6 @@ public class AlignmentTrack extends AbstractTrack implements IGVEventObserver {
         List<InsertionInterval> insertionIntervals = getInsertionIntervals(context.getReferenceFrame());
         insertionIntervals.clear();
         for (InsertionMarker insertionMarker : intervals) {
-
             if (hideSmallIndex && insertionMarker.size < smallIndelThreshold) continue;
 
             final double scale = context.getScale();
@@ -2330,11 +2329,11 @@ public class AlignmentTrack extends AbstractTrack implements IGVEventObserver {
         private Boolean pairedArcView;
         private Boolean flagZeroQualityAlignments;
         private Range groupByPos;
+        private Boolean drawInsertionIntervals;
 
 
         AlignmentTrack.BisulfiteContext bisulfiteContext = BisulfiteContext.CG;
         Map<String, PEStats> peStats;
-        boolean drawInsertionIntervals = false;
 
         DefaultValues defaultValues;
 
@@ -2440,6 +2439,10 @@ public class AlignmentTrack extends AbstractTrack implements IGVEventObserver {
             this.linkedReads = linkedReads;
         }
 
+        public void setDrawInsertionIntervals(boolean drawInsertionIntervals) {
+            this.drawInsertionIntervals = drawInsertionIntervals;
+        }
+
 
         // getters
         public int getMinInsertSize() {
@@ -2471,7 +2474,7 @@ public class AlignmentTrack extends AbstractTrack implements IGVEventObserver {
         }
 
         public boolean isDrawInsertionIntervals() {
-            return drawInsertionIntervals;
+            return drawInsertionIntervals == null ? defaultValues.drawInsertionIntervals : drawInsertionIntervals;
         }
 
         public boolean isFlagZeroQualityAlignments() {
@@ -2708,6 +2711,7 @@ public class AlignmentTrack extends AbstractTrack implements IGVEventObserver {
             public boolean pairedArcView;
             public boolean flagZeroQualityAlignments;
             public Range groupByPos;
+            public boolean drawInsertionIntervals;
 
             DefaultValues(IGVPreferences prefs) {
 
@@ -2754,6 +2758,8 @@ public class AlignmentTrack extends AbstractTrack implements IGVEventObserver {
                         this.groupByPos = new Range(posParts[0], posChromStart, posChromStart + 1);
                     }
                 }
+
+                drawInsertionIntervals = prefs.getAsBoolean(SAM_SHOW_INSERTION_MARKERS);
             }
         }
     }

--- a/src/main/resources/org/broad/igv/prefs/preferences.tab
+++ b/src/main/resources/org/broad/igv/prefs/preferences.tab
@@ -74,7 +74,7 @@ SAM.FLAG_CLIPPING	Flag clipping > flag clipping threshold	boolean	FALSE
 SAM.CLIPPING_THRESHOLD	Flag clipping threshold (bases)	integer	0
 ---
 SAM.QUICK_CONSENSUS_MODE	Quick consensus mode	boolean	FALSE
-SAM.SHOW_INSERTION_MARKERS	Show insertion markers	boolean	FALSE
+SAM.SHOW_INSERTION_MARKERS	Show insertion markers	boolean	TRUE
 ---
 SAM.LINK_READS	Link alignments by tag	boolean	FALSE
 SAM.LINK_TAG	Linking tag	string	READNAME


### PR DESCRIPTION
Improve the insertion markers / expanded insertions logic:
* Connect the "Show insertion markers" preference to the render.
* Support "collapsed" mode BAMs in expanded insertion render.
* Fix an offset issue where the expanded insertion is drawn 3 px below its read.  I could not find which constants to tweak to the get the offset right so added a harcoded "-3".

Related to #591 