### PR TITLE
Cleanup tests for travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # Created by .gitignore support plugin (hsz.mobi)
 .idea/workspace.xml
-/out/
+test/data/out/
 /build
 /build_java9
 /bin

--- a/build.gradle
+++ b/build.gradle
@@ -179,6 +179,7 @@ tasks.withType(Test) {
     systemProperties['include.longrunning'] = 'false'
     systemProperties['ignore.ioexceptions'] = 'false'
     maxHeapSize = '2000m'
+    maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
 }
 
 task createDist(type: Copy, dependsOn: fullJar)  {

--- a/build_java9.gradle
+++ b/build_java9.gradle
@@ -109,6 +109,7 @@ tasks.withType(Test) {
     systemProperties['include.longrunning'] = 'false'
     systemProperties['ignore.ioexceptions'] = 'false'
     maxHeapSize = '2000m'
+    maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
 }
 
 compileTestJava {

--- a/src/main/java/org/broad/igv/feature/genome/GenomeManager.java
+++ b/src/main/java/org/broad/igv/feature/genome/GenomeManager.java
@@ -101,7 +101,11 @@ public class GenomeManager {
     private static Logger log = Logger.getLogger(GenomeManager.class);
 
     private static final String ACT_USER_DEFINED_GENOME_LIST_FILE = "user-defined-genomes.txt";
-    public static final String TEST_USER_DEFINED_GENOME_LIST_FILE = "test-user-defined-genomes.txt";
+    
+    // Tacking on a timestamp & random number to avoid file collisions with parallel testing JVMs.  Not guaranteed unique
+    // but highly unlikely to be repeated.
+    public static final String TEST_USER_DEFINED_GENOME_LIST_FILE = "test-user-defined-genomes_" + 
+            System.currentTimeMillis() + "_" + Math.random() + ".txt";
 
     public static final GenomeListItem DEFAULT_GENOME = new GenomeListItem("Human hg19", "http://s3.amazonaws.com/igv.broadinstitute.org/genomes/hg19.genome", "hg19");
 

--- a/src/main/java/org/broad/igv/ui/commandbar/GenomeListManager.java
+++ b/src/main/java/org/broad/igv/ui/commandbar/GenomeListManager.java
@@ -35,7 +35,7 @@ public class GenomeListManager {
     private static Logger log = Logger.getLogger(GenomeManager.class);
 
     private static final String ACT_USER_DEFINED_GENOME_LIST_FILE = "user-defined-genomes.txt";
-    public static final String TEST_USER_DEFINED_GENOME_LIST_FILE = "test-user-defined-genomes.txt";
+    public static final String TEST_USER_DEFINED_GENOME_LIST_FILE = GenomeManager.TEST_USER_DEFINED_GENOME_LIST_FILE;
     public static final GenomeListItem DEFAULT_GENOME = new GenomeListItem("Human (hg19)", "http://s3.amazonaws.com/igv.broadinstitute.org/genomes/hg19.genome", "hg19");
 
     private static GenomeListManager theInstance;

--- a/src/test/java/org/broad/igv/feature/ProbeToGeneMapTest.java
+++ b/src/test/java/org/broad/igv/feature/ProbeToGeneMapTest.java
@@ -65,7 +65,7 @@ public class ProbeToGeneMapTest {
     /**
      * Test of affymetrix critera.
      */
-    @Test
+    @Test @Ignore("Requires largedata bundle")
     public void testAffy() throws FileNotFoundException, IOException {
         File f = new File(TestUtils.LARGE_DATA_DIR + "affy_probe_gene_mapping.txt");
         BufferedReader br = new BufferedReader(new FileReader(f));
@@ -88,7 +88,7 @@ public class ProbeToGeneMapTest {
         br.close();
     }
 
-    @Test
+    @Test @Ignore("Requires largedata bundle")
     public void testAgilent() throws FileNotFoundException, IOException {
         File f = new File(TestUtils.LARGE_DATA_DIR + "agilent_probe_gene_mapping.txt");
         BufferedReader br = new BufferedReader(new FileReader(f));
@@ -113,7 +113,7 @@ public class ProbeToGeneMapTest {
         br.close();
     }
 
-    @Test
+    @Test @Ignore("Requires largedata bundle")
     public void testIllumina() throws FileNotFoundException, IOException {
         File f = new File(TestUtils.LARGE_DATA_DIR + "illumina_probe_gene_mapping.txt");
         BufferedReader br = new BufferedReader(new FileReader(f));

--- a/src/test/java/org/broad/igv/feature/genome/GenomeImporterTest.java
+++ b/src/test/java/org/broad/igv/feature/genome/GenomeImporterTest.java
@@ -44,7 +44,8 @@ public class GenomeImporterTest extends AbstractHeadlessTest {
     @Test
     public void testCreateGenomeArchiveFromDir() throws Exception {
 
-        File genomeFile = new File(TestUtils.DATA_DIR, "out/testSetGenome.genome");
+        File genomeFile = new File(TestUtils.TMP_OUTPUT_DIR, "testSetGenome.genome");
+        genomeFile.deleteOnExit();
         String genomeId = "testSet";
         String genomeDisplayName = genomeId;
         String fastaPath = TestUtils.DATA_DIR + "fasta/set";
@@ -64,7 +65,8 @@ public class GenomeImporterTest extends AbstractHeadlessTest {
     @Test
     public void testCreateGenomeArchiveFromFiles() throws Exception {
 
-        File genomeFile = new File(TestUtils.DATA_DIR, "out/testSetGenome.genome");
+        File genomeFile = new File(TestUtils.TMP_OUTPUT_DIR, "testSetGenome.genome");
+        genomeFile.deleteOnExit();
         String genomeId = "testSet";
         String genomeDisplayName = genomeId;
         String fastaPath = TestUtils.DATA_DIR + "fasta/ecoli_out.padded.fasta";

--- a/src/test/java/org/broad/igv/feature/genome/fasta/FastaUtilsTest.java
+++ b/src/test/java/org/broad/igv/feature/genome/fasta/FastaUtilsTest.java
@@ -32,6 +32,7 @@ import org.broad.igv.feature.genome.GenomeManager;
 import org.broad.igv.feature.genome.fasta.FastaIndex;
 import org.broad.igv.feature.genome.fasta.FastaUtils;
 import org.broad.igv.util.TestUtils;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.File;
@@ -134,7 +135,7 @@ public class FastaUtilsTest extends AbstractHeadlessTest {
         tstCreateIndex(inPath);
     }
 
-    @Test
+    @Test @Ignore("Requires largedata bundle")
     public void testCreateIndexEcoli() throws Exception {
         String inPath = TestUtils.LARGE_DATA_DIR + "ecoli.fasta";
         String outPath = tstCreateIndex(inPath);

--- a/src/test/java/org/broad/igv/feature/genome/fasta/FastaUtilsTest.java
+++ b/src/test/java/org/broad/igv/feature/genome/fasta/FastaUtilsTest.java
@@ -200,7 +200,7 @@ public class FastaUtilsTest extends AbstractHeadlessTest {
     @Test(expected = DataLoadException.class)
     public void testCreateIndexDuplicateContigs() throws Exception{
         String inPath = TestUtils.DATA_DIR + "fasta/dup_contigs.fas";
-        String outPath = TestUtils.DATA_DIR + "out/tmp.fai";
+        String outPath = TestUtils.TMP_OUTPUT_DIR + "tmp.fai";
         File outFile = new File(outPath);
         outFile.delete();
         outFile.deleteOnExit();

--- a/src/test/java/org/broad/igv/feature/tribble/CachingFeatureReaderTest.java
+++ b/src/test/java/org/broad/igv/feature/tribble/CachingFeatureReaderTest.java
@@ -31,6 +31,7 @@ import org.broad.igv.variant.vcf.VCFVariant;
 import htsjdk.tribble.AbstractFeatureReader;
 import htsjdk.tribble.FeatureCodec;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -60,7 +61,7 @@ public class CachingFeatureReaderTest {
 
     }
 
-    @Test
+    @Test @Ignore("Requires largedata bundle")
     /*
     1 182773022 182773023
 1 182773812 182773813
@@ -80,7 +81,7 @@ public class CachingFeatureReaderTest {
         assertEquals(23, seqNames.size());
     }
 
-    @Test
+    @Test @Ignore("Requires largedata bundle")
     public void testQuery() throws Exception {
 
         Set<String> baseReaderLoci = new HashSet();

--- a/src/test/java/org/broad/igv/sam/AlignmentPackerTest.java
+++ b/src/test/java/org/broad/igv/sam/AlignmentPackerTest.java
@@ -36,6 +36,7 @@ import org.broad.igv.sam.reader.AlignmentReader;
 import org.broad.igv.sam.reader.AlignmentReaderFactory;
 import org.broad.igv.util.ResourceLocator;
 import org.broad.igv.util.TestUtils;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.*;
@@ -70,7 +71,7 @@ public class AlignmentPackerTest extends AbstractHeadlessTest {
     /**
      * Test of packAlignments method, of class AlignmentPacker.
      */
-    @Test
+    @Test @Ignore("Requires largedata bundle")
     public void testPackAlignments() throws Exception {
 
         ///////////////////////////
@@ -96,7 +97,7 @@ public class AlignmentPackerTest extends AbstractHeadlessTest {
 
     }
 
-    @Test
+    @Test @Ignore("Requires largedata bundle")
     public void testGroupAlignmentsPairOrientation() throws Exception {
         int expSize = 2; //AlignmentTrack.OrientationType.values().length;
         Map<String, List<Row>> result = tstGroupAlignments(AlignmentTrack.GroupOption.PAIR_ORIENTATION, expSize);

--- a/src/test/java/org/broad/igv/sam/AlignmentTileLoaderTest.java
+++ b/src/test/java/org/broad/igv/sam/AlignmentTileLoaderTest.java
@@ -36,6 +36,7 @@ import org.broad.igv.sam.reader.AlignmentReader;
 import org.broad.igv.sam.reader.AlignmentReaderFactory;
 import org.broad.igv.util.ResourceLocator;
 import org.broad.igv.util.TestUtils;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.HashMap;
@@ -56,7 +57,7 @@ public class AlignmentTileLoaderTest extends AbstractHeadlessTest {
      *
      * @throws Exception
      */
-    @Test
+    @Test @Ignore("Requires largedata bundle")
     public void testKeepPairsDownsample_02() throws Exception {
         String path = TestUtils.LARGE_DATA_DIR + "HG00171.hg18.bam";
 
@@ -74,7 +75,7 @@ public class AlignmentTileLoaderTest extends AbstractHeadlessTest {
      *
      * @throws Exception
      */
-    @Test
+    @Test @Ignore("Requires largedata bundle")
     public void testNoDownsample() throws Exception {
         String path = TestUtils.LARGE_DATA_DIR + "HG00171.hg18.bam";
 

--- a/src/test/java/org/broad/igv/sam/BAMFileReaderTest.java
+++ b/src/test/java/org/broad/igv/sam/BAMFileReaderTest.java
@@ -39,6 +39,7 @@ import org.broad.igv.util.ResourceLocator;
 import org.broad.igv.util.TestUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.List;
@@ -66,7 +67,7 @@ public class BAMFileReaderTest {
     /**
      * Test of close method, of class BAMQueryReader.
      */
-    @Test
+    @Test @Ignore("Requires largedata bundle")
     public void testClose() throws Exception {
         String bamfile = TestUtils.LARGE_DATA_DIR + "HG00171.hg18.bam";
         String chr = "chr1";
@@ -97,7 +98,7 @@ public class BAMFileReaderTest {
     /**
      * Test of query method, of class BAMQueryReader.
      */
-    @Test
+    @Test @Ignore("Requires largedata bundle")
     public void testQueryAgainstSam() throws Exception {
 
         String bamfile = TestUtils.LARGE_DATA_DIR + "HG00171.hg18.bam";

--- a/src/test/java/org/broad/igv/sam/SAMWriterTest.java
+++ b/src/test/java/org/broad/igv/sam/SAMWriterTest.java
@@ -33,6 +33,7 @@ import org.broad.igv.sam.reader.MergedAlignmentReaderTest;
 import org.broad.igv.sam.reader.SAMReader;
 import org.broad.igv.util.ResourceLocator;
 import org.broad.igv.util.TestUtils;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.*;
@@ -141,7 +142,7 @@ public class SAMWriterTest extends AbstractHeadlessTest {
 
     }
 
-    @Test
+    @Test @Ignore("Requires largedata bundle")
     public void testCopyBAMFile_01() throws Exception {
         String sequence = "chr1";
         int end = 300000000;
@@ -151,7 +152,7 @@ public class SAMWriterTest extends AbstractHeadlessTest {
         tstCopyBAMFile(inlocator, sequence, start, end);
     }
 
-    @Test
+    @Test @Ignore("Requires largedata bundle")
     public void testCopyMergedBAM_01() throws Exception {
         String sequence = "chr1";
         int start = 151667156;

--- a/src/test/java/org/broad/igv/sam/SAMWriterTest.java
+++ b/src/test/java/org/broad/igv/sam/SAMWriterTest.java
@@ -100,7 +100,7 @@ public class SAMWriterTest extends AbstractHeadlessTest {
      * @throws Exception
      */
     public void testWriteRecords(String inpath, boolean outStream) throws Exception {
-        String[] outpaths = new String[]{TestUtils.DATA_DIR + "out/tmp_sam.sam", TestUtils.DATA_DIR + "out/tmp_bam.bam"};
+        String[] outpaths = new String[]{TestUtils.TMP_OUTPUT_DIR + "tmp_sam.sam", TestUtils.TMP_OUTPUT_DIR + "tmp_bam.bam"};
         for (String outpath : outpaths) {
             SamHeaderIterator shi = new SamHeaderIterator(inpath);
 

--- a/src/test/java/org/broad/igv/sam/SamIndexTest.java
+++ b/src/test/java/org/broad/igv/sam/SamIndexTest.java
@@ -34,6 +34,7 @@ import org.broad.igv.sam.reader.FeatureIndex;
 import org.broad.igv.util.TestUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.File;
@@ -61,7 +62,7 @@ public class SamIndexTest {
     /**
      * Test of getIndexedChromosomes method, of class SamIndex.
      */
-    @Test
+    @Test @Ignore("Requires largedata bundle")
     public void testGetIndexedChromosomes() {
         FeatureIndex idx = new FeatureIndex(f);
         assertTrue(idx.getIndexedChromosomes().size() > 0);

--- a/src/test/java/org/broad/igv/sam/SamQueryTextReaderTest.java
+++ b/src/test/java/org/broad/igv/sam/SamQueryTextReaderTest.java
@@ -167,7 +167,7 @@ public class SamQueryTextReaderTest {
 
     }
 
-    @Test
+    @Test @Ignore("Requires largedata bundle")
     public void testMoran() throws Exception {
         String testFile = TestUtils.LARGE_DATA_DIR + "r2.allProb.sorted.sam";
         String chr = "mm9chrY";

--- a/src/test/java/org/broad/igv/sam/reader/AlignmentReaderFactoryTest.java
+++ b/src/test/java/org/broad/igv/sam/reader/AlignmentReaderFactoryTest.java
@@ -29,6 +29,7 @@ import org.broad.igv.AbstractHeadlessTest;
 import org.broad.igv.sam.Alignment;
 import org.broad.igv.tools.IGVToolsTest;
 import org.broad.igv.util.TestUtils;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestRule;
@@ -48,7 +49,7 @@ public class AlignmentReaderFactoryTest extends AbstractHeadlessTest {
     @Rule
     public TestRule testTimeout = new Timeout((int) 1e3 * 60);
 
-    @Test
+    @Test @Ignore("Requires largedata bundle")
     public void testGetMergedReader() throws Exception {
         String relfiname = "HG00171.hg18.bam";
         String path = TestUtils.LARGE_DATA_DIR + "temprel.bam.list";

--- a/src/test/java/org/broad/igv/sam/reader/MergedAlignmentReaderTest.java
+++ b/src/test/java/org/broad/igv/sam/reader/MergedAlignmentReaderTest.java
@@ -31,6 +31,7 @@ import org.broad.igv.sam.Alignment;
 import org.broad.igv.tools.IGVToolsTest;
 import org.broad.igv.util.FileUtils;
 import org.broad.igv.util.TestUtils;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.BufferedReader;
@@ -56,7 +57,7 @@ public class MergedAlignmentReaderTest extends AbstractHeadlessTest {
         return IGVToolsTest.generateRepLargebamsList(listPath, "HG00171.hg18.bam", 2);
     }
 
-    @Test
+    @Test @Ignore("Requires largedata bundle")
     public void testSimpleRead() throws Exception {
 
         File listFile = new File(TestUtils.LARGE_DATA_DIR, "2largebams.bam.list");

--- a/src/test/java/org/broad/igv/tools/CoverageCounterTest.java
+++ b/src/test/java/org/broad/igv/tools/CoverageCounterTest.java
@@ -58,7 +58,7 @@ public class CoverageCounterTest extends AbstractHeadlessTest {
     /**
      * Test the "mapping quality" flag.  Also indirectly tests the query parameters.
      */
-    @Test
+    @Test @Ignore("Requires largedata bundle")
     public void testMappingQualityFlag() throws IOException {
         String bamURL = TestUtils.LARGE_DATA_DIR + "HG00171.hg18.bam";
         String queryString = "chr1:152522155-152522155";

--- a/src/test/java/org/broad/igv/tools/CoverageCounterTest.java
+++ b/src/test/java/org/broad/igv/tools/CoverageCounterTest.java
@@ -63,7 +63,7 @@ public class CoverageCounterTest extends AbstractHeadlessTest {
         String bamURL = TestUtils.LARGE_DATA_DIR + "HG00171.hg18.bam";
         String queryString = "chr1:152522155-152522155";
         int minMapQuality = 40;
-        File wigFile = new File(TestUtils.DATA_DIR + "out/testMapQual.wig");
+        File wigFile = new File(TestUtils.TMP_OUTPUT_DIR + "testMapQual.wig");
         int windowSize = 1;
 
         TestDataConsumer dc = new TestDataConsumer();
@@ -82,7 +82,7 @@ public class CoverageCounterTest extends AbstractHeadlessTest {
     public void testPairFlag() throws Exception{
         String bamURL = "http://data.broadinstitute.org/igvdata/1KG/pilot2Bams/NA12878.SLX.bam";
         String queryString = "2:1000-1100";
-        File wigFile = new File(TestUtils.DATA_DIR + "out/testPair.wig");
+        File wigFile = new File(TestUtils.TMP_OUTPUT_DIR + "testPair.wig");
         int windowSize = 1;
 
         TestDataConsumer dc = new TestDataConsumer();
@@ -151,7 +151,8 @@ public class CoverageCounterTest extends AbstractHeadlessTest {
         String ifile = TestUtils.DATA_DIR + "sam/NA12878.muc1.test.sam";
         int expected_cols = 14;
 
-        File wigFile = new File(TestUtils.DATA_DIR + "out", "testCountBases.wig");
+        File wigFile = new File(TestUtils.TMP_OUTPUT_DIR, "testCountBases.wig");
+        wigFile.deleteOnExit();
         int windowSize = 1;
 
         TestDataConsumer dc = new TestDataConsumer();

--- a/src/test/java/org/broad/igv/tools/IGVToolsCountTest.java
+++ b/src/test/java/org/broad/igv/tools/IGVToolsCountTest.java
@@ -125,7 +125,7 @@ public class IGVToolsCountTest extends AbstractHeadlessTest {
         String inputFile = TestUtils.DATA_DIR + "bed/Unigene.sample.sorted.bed";
 
         //Write to a file
-        String fileOutArg = TestUtils.DATA_DIR + "out/testfilewig.wig";
+        String fileOutArg = TestUtils.TMP_OUTPUT_DIR + "testfilewig.wig";
         String input = "count " + inputFile + " " + fileOutArg + " " + hg18id;
         String[] args = input.split("\\s+");
         igvTools.run(args);
@@ -351,7 +351,7 @@ public class IGVToolsCountTest extends AbstractHeadlessTest {
     }
 
     private void tstCountBamList(String listArg) throws Exception {
-        String outputFile = TestUtils.DATA_DIR + "out/file_";
+        String outputFile = TestUtils.TMP_OUTPUT_DIR + "file_";
 
         String[] opts = new String[]{"--strands=read", "--strands=first", ""};
 
@@ -437,7 +437,7 @@ public class IGVToolsCountTest extends AbstractHeadlessTest {
      */
     public void tstCountAliased(String normfile, String aliasedfile, String genfile) throws Exception {
 
-        String outfile = TestUtils.DATA_DIR + "out/tmpcount1.wig";
+        String outfile = TestUtils.TMP_OUTPUT_DIR + "tmpcount1.wig";
         File outFi = new File(outfile);
         outFi.delete();
         outFi.deleteOnExit();
@@ -447,7 +447,7 @@ public class IGVToolsCountTest extends AbstractHeadlessTest {
         igvTools.run(command.split("\\s+"));
 
         //Count non-aliased file
-        String outfile2 = TestUtils.DATA_DIR + "out/tmpcount2.wig";
+        String outfile2 = TestUtils.TMP_OUTPUT_DIR + "tmpcount2.wig";
         File outFi2 = new File(outfile2);
         outFi2.delete();
         //Count aliased file
@@ -481,7 +481,7 @@ public class IGVToolsCountTest extends AbstractHeadlessTest {
     public void testCountIndexedFasta() throws Exception {
         String fasta_file = TestUtils.DATA_DIR + "fasta/ecoli_out.padded.fasta";
         String infile = TestUtils.DATA_DIR + "bed/ecoli_out.test.bed";
-        String outfile = TestUtils.DATA_DIR + "out/findextest.wig";
+        String outfile = TestUtils.TMP_OUTPUT_DIR + "findextest.wig";
         String end_command = infile + " " + outfile + " " + fasta_file;
         String count_command = "count " + end_command;
         igvTools.run(count_command.split("\\s"));
@@ -524,7 +524,7 @@ public class IGVToolsCountTest extends AbstractHeadlessTest {
     }
 
     private void tstCountWindowFunctions(String inputFile, String chr, Iterable<WindowFunction> windowFunctions) throws Exception {
-        String outputFile = TestUtils.DATA_DIR + "out/testCountWindowFunctions.tdf";
+        String outputFile = TestUtils.TMP_OUTPUT_DIR + "testCountWindowFunctions.tdf";
 
 
         String wfs = "";

--- a/src/test/java/org/broad/igv/tools/IGVToolsTest.java
+++ b/src/test/java/org/broad/igv/tools/IGVToolsTest.java
@@ -212,7 +212,7 @@ public class IGVToolsTest extends AbstractHeadlessTest {
     @Test
     public void testTileGCT_01() throws IOException {
         String inputFile = TestUtils.DATA_DIR + "gct/OV.transcriptome__agilentg4502.data.txt";
-        String outFilePath = TestUtils.DATA_DIR + "out/testTileGCT.wig";
+        String outFilePath = TestUtils.TMP_OUTPUT_DIR + "testTileGCT.wig";
         String[] args = {"tile", "-z", "1", "--fileType", "mage-tab", inputFile, outFilePath, hg18id};
         igvTools.run(args);
     }
@@ -220,7 +220,7 @@ public class IGVToolsTest extends AbstractHeadlessTest {
     @Test
     public void testTileGCT_02() throws IOException {
         String inputFile = TestUtils.DATA_DIR + "gct/GBM.methylation__sampled.data.txt";
-        String outFilePath = TestUtils.DATA_DIR + "out/testTileGCT.wig";
+        String outFilePath = TestUtils.TMP_OUTPUT_DIR + "testTileGCT.wig";
         String[] args = new String[]{"tile", "-z", "1", "--fileType", "mage-tab", inputFile, outFilePath, hg18id};
         igvTools.run(args);
 
@@ -228,8 +228,8 @@ public class IGVToolsTest extends AbstractHeadlessTest {
 
 
     private void testTile(String inputFile, int start, int end) throws IOException {
-        String file1 = TestUtils.DATA_DIR + "out/file1.tdf";
-        String file2 = TestUtils.DATA_DIR + "out/file2.tdf";
+        String file1 = TestUtils.TMP_OUTPUT_DIR + "file1.tdf";
+        String file2 = TestUtils.TMP_OUTPUT_DIR + "file2.tdf";
 
         //todo Compare 2 outputs more meaningfully
         String[] args = {"toTDF", "-z", "1", "--windowFunctions", "min", inputFile, file1, hg18id};

--- a/src/test/java/org/broad/igv/tools/IGVToolsTest.java
+++ b/src/test/java/org/broad/igv/tools/IGVToolsTest.java
@@ -145,14 +145,14 @@ public class IGVToolsTest extends AbstractHeadlessTest {
 
     }
 
-    @Test
+    @Test @Ignore("Requires largedata bundle")
     public void testIntervalIndex33() throws Exception {
         String testFile = TestUtils.LARGE_DATA_DIR + "CEU.SRP000032.2010_03_v3.3.genotypes.head.vcf";
         FeatureCodec codec = new VCF3Codec();
         tstIntervalIndex(testFile, codec);
     }
 
-    @Test
+    @Test @Ignore("Requires largedata bundle")
     public void testIntervalIndex40() throws Exception {
         String testFile = TestUtils.LARGE_DATA_DIR + "CEU.SRP000032.2010_03_v4.0.genotypes.head.vcf";
         FeatureCodec codec = new VCFCodec();

--- a/src/test/java/org/broad/igv/tools/converters/ExpressionFormatterTest.java
+++ b/src/test/java/org/broad/igv/tools/converters/ExpressionFormatterTest.java
@@ -47,7 +47,7 @@ public class ExpressionFormatterTest extends AbstractHeadlessTest {
     public void testConvertGCT() throws Exception {
         //String inputPath = TestUtils.DATA_DIR + "gct/igv_test2.gct";
         String inputPath = TestUtils.DATA_DIR + "gct/GBM.methylation__sampled.data.txt";
-        String outputPath = TestUtils.DATA_DIR + "out/testformat.gct";
+        String outputPath = TestUtils.TMP_OUTPUT_DIR + "testformat.gct";
         File inputFile = new File(inputPath);
         File outputFile = new File(outputPath);
 

--- a/src/test/java/org/broad/igv/tools/converters/GFFtoBedTest.java
+++ b/src/test/java/org/broad/igv/tools/converters/GFFtoBedTest.java
@@ -52,7 +52,8 @@ public class GFFtoBedTest {
     public void testConvert() throws Exception {
 
         File inputFile = new File(TestUtils.DATA_DIR, "gff/gene.unsorted.gff3");
-        File outputFile = new File(TestUtils.DATA_DIR, "out/gene.bed");
+        File outputFile = new File(TestUtils.TMP_OUTPUT_DIR, "gene.bed");
+        outputFile.deleteOnExit();
 
         // Convert
         GFFtoBed.convert(inputFile, outputFile);

--- a/src/test/java/org/broad/igv/tools/motiffinder/MotifFinderSourceTest.java
+++ b/src/test/java/org/broad/igv/tools/motiffinder/MotifFinderSourceTest.java
@@ -29,6 +29,8 @@ import org.broad.igv.AbstractHeadlessTest;
 import org.broad.igv.feature.BasicFeature;
 import org.broad.igv.feature.Strand;
 import htsjdk.tribble.Feature;
+
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Iterator;
@@ -208,25 +210,6 @@ public class MotifFinderSourceTest extends AbstractHeadlessTest{
         assertEquals(expFeatureStart + 4, feat.getStart());
         assertEquals(exFeatureEnd + 4, feat.getEnd());
         checkPatternMatches(motif, feat);
-    }
-
-    /**
-     * Test searching chromosome 1 for nonexistent motif. Test is timed at 30 seconds,
-     * this is a loose performance test. Takes ~13 seconds on my machine
-     * @throws Exception
-     */
-    @Test
-    public void testSearchWholeChromo() throws Exception{
-        String chromo = "chr1";
-        String umotif = "GATCRYMKSWHBVDNGATCGATCGATCGATCGATCGATCGATCGATCGATC";
-        int reps = 20;
-
-        //Really long string, probably no matches
-        String motif = umotif;
-        for(int ii=0; ii < reps; ii++) motif += umotif;
-
-        tstSearchGenomeSingResult(motif, Strand.POSITIVE, chromo,
-                0, genome.getChromosome(chromo).getLength(), -1, -1);
     }
 
     private void tstSearchGenome_EGFR(String motif, int expStart, int expEnd) throws Exception {

--- a/src/test/java/org/broad/igv/ui/AbstractHeadedTest.java
+++ b/src/test/java/org/broad/igv/ui/AbstractHeadedTest.java
@@ -66,7 +66,7 @@ public class AbstractHeadedTest {
 
     @AfterClass
     public static void tearDownClass() throws Exception {
-        TestUtils.clearOutputDir();
+        //TestUtils.clearOutputDir();
         stopGUI();
         igv = null;
     }

--- a/src/test/java/org/broad/igv/util/SequenceGCTest.java
+++ b/src/test/java/org/broad/igv/util/SequenceGCTest.java
@@ -41,7 +41,7 @@ public class SequenceGCTest {
     @Test
     public void testSequenceGC() throws Exception {
 
-        String outfile = TestUtils.DATA_DIR + "out/ecoli.wig";
+        String outfile = TestUtils.TMP_OUTPUT_DIR + "ecoli.wig";
         //TODO Remove the Asserts, do a check at a position instead.
         //todo This test is not very meaningful
         SequenceGC sequence = new SequenceGC(5, 1);

--- a/src/test/java/org/broad/igv/util/TestUtils.java
+++ b/src/test/java/org/broad/igv/util/TestUtils.java
@@ -50,6 +50,8 @@ import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.*;
 
 import static junit.framework.Assert.assertTrue;
@@ -62,8 +64,19 @@ import static org.junit.Assert.assertFalse;
  */
 @Ignore
 public class TestUtils {
-    public static final String DATA_DIR = "test/data/";
-    public static final String TMP_OUTPUT_DIR = DATA_DIR + "out/";
+    // Tacking on a timestamp & random number to avoid file collisions with parallel testing JVMs.  Not guaranteed unique
+    // but highly unlikely to be repeated.
+    public static final String TEST_UNIQUE_RUN_BASE = System.currentTimeMillis() + "_" + Math.random();
+    private static final String TESTPREFS_PROPERTIES = "testprefs_" + TEST_UNIQUE_RUN_BASE + ".properties";
+    public static final String DATA_DIR = "test/data/";    
+    public static final String TMP_OUTPUT_DIR = DATA_DIR + "out/" + TEST_UNIQUE_RUN_BASE + "/";
+    
+    static {
+        File tmpOutputDir = new File(TMP_OUTPUT_DIR);
+        tmpOutputDir.mkdirs();
+        tmpOutputDir.deleteOnExit();
+    }
+    
     public static final String defaultGenome = DATA_DIR + "genomes/hg18.unittest.genome";
 
     //This is so ant can set the large data directory
@@ -91,7 +104,7 @@ public class TestUtils {
     }
 
     public static void resetPrefsFile(){
-        File prefsFile = new File("testprefs.properties");
+        File prefsFile = new File(TESTPREFS_PROPERTIES);
         prefsFile.delete();
         prefsFile.deleteOnExit();
         PreferencesManager.setPrefsFile(prefsFile.getAbsolutePath());
@@ -162,6 +175,14 @@ public class TestUtils {
         }
     }
 
+//    public static File foo_createTempOutputDir() throws IOException {
+//        File directory = new File(DATA_DIR + "out/"); //new File(TMP_OUTPUT_DIR);
+//        Path tempDirPath = Files.createTempDirectory(directory.toPath(), "tmp");
+//        File tempDir = tempDirPath.toFile();
+//        tempDir.deleteOnExit();
+//        return tempDir;
+//    }
+    
     /**
      * Returns either 1 or 2, representing the number of
      * bytes used to end a line. Reads only from first line of a file

--- a/src/test/java/org/broad/tribble/TribbleFeatureReaderTest.java
+++ b/src/test/java/org/broad/tribble/TribbleFeatureReaderTest.java
@@ -37,6 +37,7 @@ import htsjdk.variant.vcf.VCFCodec;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.BufferedOutputStream;
@@ -56,6 +57,7 @@ import static org.junit.Assert.assertEquals;
  * Date: Jul 17, 2010
  * Time: 9:28:49 PM
  */
+@Ignore("Requires largedata bundle")
 public class TribbleFeatureReaderTest {
 
     static String testFile = TestUtils.LARGE_DATA_DIR + "CEU.SRP000032.2010_03_v4.0.genotypes.head.vcf";
@@ -75,7 +77,7 @@ public class TribbleFeatureReaderTest {
         bfr.close();
     }
 
-    @Test
+    @Test @Ignore("Requires largedata bundle")
     public void testQuery() throws IOException {
 
         String chr = "1";
@@ -98,7 +100,7 @@ public class TribbleFeatureReaderTest {
 
     }
 
-    @Test
+    @Test @Ignore("Requires largedata bundle")
     public void testGetSequenceNames() throws Exception {
         Set<String> expectedSequences = new HashSet(Arrays.asList("1", "2"));
 


### PR DESCRIPTION
Cleaning up the tests for Travis CI integration so we get feedback quickly on commit / PR.

The important change here is is to give the test suite a different tempDir per-JVM.  Each JVM still runs its tests in series, meaning there was no need for *per-test* tempDirs so long as each JVM has its own.  Likewise for the test files for Prefs and the Genome List.

I took a low-key approach to tempDir naming that should be "unique enough" (timestamp + random #).  There are ways to do better if we decide it's important.

Beside that, I cleaned up tests that required transfer of large file resources or run too long in the context of Travis and also changed a few tests that weren't going through the global reference for the tempDir.