### PR TITLE
Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: java
+before_cache:
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/
+jdk: openjdk10
+install:
+- ./gradlew -b build_java9.gradle assemble
+script:
+- ./gradlew -b build_java9.gradle check

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # igv
+[![Build Status](https://travis-ci.org/igvteam/igv.svg?branch=master)](https://travis-ci.org/igvteam/igv)
 
 Integrative Genomics Viewer - dekstop genome visualization tool for Mac, Windows, and Linux.
 


### PR DESCRIPTION
Travis CI integration

I'm choosing to have this build/test with OpenJDK 10 instead of Java 8 since that's closer to the future direction of OpenJDK 11.  We *could* build both, but it doubles the runtime since we have to do it twice.

There's a tiny amount of missed coverage this way but not much.  Specifically, it's the few classes under src/main/java8.