### PR TITLE
Fix for issue #519: Commandline option igvDirectory not working

### DIFF
--- a/src/main/java/org/broad/igv/ui/Main.java
+++ b/src/main/java/org/broad/igv/ui/Main.java
@@ -122,25 +122,24 @@ public class Main {
 
             // doesn't exist -- try to create it
             try {
-                dir.mkdir();
+                if (dir.mkdir()) {
+                    DirectoryManager.setIgvDirectory(dir);
+                } else {
+                    log.error("Unable to create igv directory " + dir.getAbsolutePath());
+                }
             } catch (Exception e) {
                 log.error("Error creating igv directory " + dir.getAbsolutePath(), e);
                 return;
             }
-
-            if (dir.isDirectory()) {
-                if (dir.canWrite()) {
-                    DirectoryManager.setIgvDirectory(dir);
-                } else {
-                    log.error("IGV directory '" + dir.getAbsolutePath() + "'is not writable");
-                }
+        } else if (dir.isDirectory()) {
+            if (dir.canWrite()) {
+                DirectoryManager.setIgvDirectory(dir);
             } else {
-                log.error("'" + dir.getAbsolutePath() + "' is not a directory");
+                log.error("IGV directory '" + dir.getAbsolutePath() + "'is not writable");
             }
         } else {
-            log.error("'" + dir.getAbsolutePath() + "' not found");
+            log.error("'" + dir.getAbsolutePath() + "' is not a directory");
         }
-
     }
 
     private static void initApplication() {


### PR DESCRIPTION
Corrected an error in org.broad.igv.ui.Main which prevented custom IGV directories from being reused between sessions and using already existing directories in general. 