### PR TITLE
Travis java8 compile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,5 @@ install:
 - ./gradlew -b build_java9.gradle assemble
 script:
 - ./gradlew -b build_java9.gradle check
-- export JAVA_HOME=$HOME/openjdk8
-- $TRAVIS_BUILD_DIR/install-jdk.sh --install openjdk8 --target $JAVA_HOME
+- jdk_switcher use openjdk8
 - ./gradlew compileJava

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,8 @@ jdk: openjdk10
 install:
 - ./gradlew -b build_java9.gradle assemble
 script:
+- jdk_switcher use openjdk10
 - ./gradlew -b build_java9.gradle check
+- export JAVA_HOME=$HOME/openjdk8
+- $TRAVIS_BUILD_DIR/install-jdk.sh --install openjdk8 --target $JAVA_HOME
+- ./gradlew compile

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,7 @@ jdk: openjdk10
 install:
 - ./gradlew -b build_java9.gradle assemble
 script:
-- jdk_switcher use openjdk10
 - ./gradlew -b build_java9.gradle check
 - export JAVA_HOME=$HOME/openjdk8
 - $TRAVIS_BUILD_DIR/install-jdk.sh --install openjdk8 --target $JAVA_HOME
-- ./gradlew compile
+- ./gradlew compileJava


### PR DESCRIPTION
Modified the Travis CI build to also compile for Java 8 to avoid errors creeping in on branches/PRs.  It does not *test* under 8 to keep builds fast, since we already do that under 10 and it's unlikely a test would pass under 10 but fail under 8.  I'll port this forward to the Java 11 branch after it goes into master.

This is just a compromise while we still have developers using Java 8 during the switch-over to 11.

You probably want to squash these commits on merge since only the last one is really necessary.  Unfortunately, the only way to test Travis updates is to commit to GitHub where the CI can spot them.