### PR TITLE
Update launcher script messages

### DIFF
--- a/scripts/java11/IGV_mac.app.command
+++ b/scripts/java11/IGV_mac.app.command
@@ -15,10 +15,11 @@ if [ -d "${prefix}/../jdk-11" ]; then
     JAVA_HOME="${prefix}/../jdk-11"
     PATH=$JAVA_HOME/bin:$PATH
 else
-    echo "Bundled JDK not found.  Using system JDK."
+    echo "Using system JDK."
+    java -version
 fi
 
-exec java --module-path="${prefix}/../Java/lib" -Xmx4g \
+exec java -showversion --module-path="${prefix}/../Java/lib" -Xmx4g \
     @"${prefix}/../Java/igv.args" \
     -Xdock:name="IGV" \
     -Xdock:icon="${prefix}/../Resources/IGV_64.png" \

--- a/scripts/java11/igv.bat
+++ b/scripts/java11/igv.bat
@@ -8,8 +8,8 @@ if exist %BatchPath%\jdk-11 (
   set JAVA_HOME=%BatchPath%\jdk-11
   set JAVA_CMD=%BatchPath%\jdk-11\bin\javaw
 ) else (
-  echo "Bundled JDK not found.  Using system JDK."
+  echo "Using system JDK."
   set JAVA_CMD=java
 )
 
-start %JAVA_CMD% --module-path=%BatchPath%\lib -Xmx4g -Dproduction=true @%BatchPath%\igv.args -Djava.net.preferIPv4Stack=true -Dsun.java2d.noddraw=true --module=org.igv/org.broad.igv.ui.Main  %*
+start %JAVA_CMD% -showversion --module-path=%BatchPath%\lib -Xmx4g -Dproduction=true @%BatchPath%\igv.args -Djava.net.preferIPv4Stack=true -Dsun.java2d.noddraw=true --module=org.igv/org.broad.igv.ui.Main  %*

--- a/scripts/java11/igv.command
+++ b/scripts/java11/igv.command
@@ -15,10 +15,10 @@ if [ -d "${prefix}/jdk-11" ]; then
     JAVA_HOME="${prefix}/jdk-11"
     PATH=$JAVA_HOME/bin:$PATH
 else
-    echo "Bundled JDK not found.  Using system JDK."
+    echo "Using system JDK."
 fi
 
-exec java --module-path="${prefix}/lib" -Xmx4g \
+exec java -showversion --module-path="${prefix}/lib" -Xmx4g \
     @"${prefix}/igv.args" \
     -Xdock:name="IGV" \
     -Xdock:icon="${prefix}/IGV_64.png" \

--- a/scripts/java11/igv.sh
+++ b/scripts/java11/igv.sh
@@ -14,10 +14,10 @@ if [ -d "${prefix}/jdk-11" ]; then
     JAVA_HOME="${prefix}/jdk-11"
     PATH=$JAVA_HOME/bin:$PATH
 else
-    echo "Bundled JDK not found.  Using system JDK."
+    echo "Using system JDK."
 fi
 
-exec java --module-path="${prefix}/lib" -Xmx4g \
+exec java -showversion --module-path="${prefix}/lib" -Xmx4g \
     @"${prefix}/igv.args" \
     -Dapple.laf.useScreenMenuBar=true \
     -Djava.net.preferIPv4Stack=true \

--- a/scripts/java11/igv_hidpi.sh
+++ b/scripts/java11/igv_hidpi.sh
@@ -13,10 +13,10 @@ if [ -d "${prefix}/jdk-11" ]; then
     JAVA_HOME="${prefix}/jdk-11"
     PATH=$JAVA_HOME/bin:$PATH
 else
-    echo "Bundled JDK not found.  Using system JDK."
+    echo "Using system JDK."
 fi
 
-exec java --module-path="${prefix}"/lib -Xmx4g \
+exec java -showversion --module-path="${prefix}"/lib -Xmx4g \
     @"${prefix}/igv.args" \
     -Dsun.java2d.uiScale=2 \
     -Dapple.laf.useScreenMenuBar=true \

--- a/scripts/java11/igvtools
+++ b/scripts/java11/igvtools
@@ -7,9 +7,9 @@ if [ -d "${prefix}/jdk-11" ]; then
     JAVA_HOME="${prefix}/jdk-11"
     PATH=$JAVA_HOME/bin:$PATH
 else
-    echo "Bundled JDK not found.  Using system JDK."
+    echo "Using system JDK."
 fi
 
-java -Djava.awt.headless=true --module-path="${prefix}/lib" -Xmx1500m \
+java -showversion -Djava.awt.headless=true --module-path="${prefix}/lib" -Xmx1500m \
     @igv.args \
     --module=org.igv/org.broad.igv.tools.IgvTools  "$@"

--- a/scripts/java11/igvtools.bat
+++ b/scripts/java11/igvtools.bat
@@ -8,8 +8,8 @@ if exist %BatchPath%\jdk-11 (
   set JAVA_HOME=%BatchPath%\jdk-11
   set JAVA_CMD=%BatchPath%\jdk-11\bin\java
 ) else (
-  echo "Bundled JDK not found.  Using system JDK."
+  echo "Using system JDK."
   set JAVA_CMD=java
 )
 
-start %JAVA_CMD% --module-path=%BatchPath%\lib -Xmx1500m @igv.args --module=org.igv/org.broad.igv.tools.IgvTools %*
+start %JAVA_CMD% -showversion --module-path=%BatchPath%\lib -Xmx1500m @igv.args --module=org.igv/org.broad.igv.tools.IgvTools %*

--- a/scripts/java11/igvtools_gui
+++ b/scripts/java11/igvtools_gui
@@ -7,9 +7,10 @@ if [ -d "${prefix}/jdk-11" ]; then
     JAVA_HOME="${prefix}/jdk-11"
     PATH=$JAVA_HOME/bin:$PATH
 else
-    echo "Bundled JDK not found.  Using system JDK."
+    echo "Using system JDK."
+    java -version
 fi
 
-java --module-path=$prefix/lib -Xmx1500m \
+java -showversion --module-path=$prefix/lib -Xmx1500m \
     @igv.args \
     --module=org.igv/org.broad.igv.tools.IgvTools  gui

--- a/scripts/java11/igvtools_gui.bat
+++ b/scripts/java11/igvtools_gui.bat
@@ -8,8 +8,8 @@ if exist %BatchPath%\jdk-11 (
   set JAVA_HOME=%BatchPath%\jdk-11
   set JAVA_CMD=%BatchPath%\jdk-11\bin\javaw
 ) else (
-  echo "Bundled JDK not found.  Using system JDK."
+  echo "Using system JDK."
   set JAVA_CMD=java
 )
 
-start %JAVA_CMD% --module-path=%BatchPath%\lib -Xmx1500m @igv.args --module=org.igv/org.broad.igv.tools.IgvTools gui
+start %JAVA_CMD% -showversion --module-path=%BatchPath%\lib -Xmx1500m @igv.args --module=org.igv/org.broad.igv.tools.IgvTools gui

--- a/scripts/java11/igvtools_gui.command
+++ b/scripts/java11/igvtools_gui.command
@@ -8,10 +8,10 @@ if [ -d "${prefix}/jdk-11" ]; then
     JAVA_HOME="${prefix}/jdk-11"
     PATH=$JAVA_HOME/bin:$PATH
 else
-    echo "Bundled JDK not found.  Using system JDK."
+    echo "Using system JDK."
 fi
 
-java --module-path="${prefix}/lib" -Xmx1500m \
+java -showversion --module-path="${prefix}/lib" -Xmx1500m \
     @"${prefix}/igv.args" \
     -Dapple.laf.useScreenMenuBar=true \
     --module=org.igv/org.broad.igv.tools.IgvTools gui

--- a/scripts/java11/igvtools_gui_hidpi
+++ b/scripts/java11/igvtools_gui_hidpi
@@ -7,10 +7,11 @@ if [ -d "${prefix}/jdk-11" ]; then
     JAVA_HOME="${prefix}/jdk-11"
     PATH=$JAVA_HOME/bin:$PATH
 else
-    echo "Bundled JDK not found.  Using system JDK."
+    echo "Using system JDK."
+    java -version
 fi
 
-java --module-path="${prefix}/lib" -Xmx1500m \
+java -showversion --module-path="${prefix}/lib" -Xmx1500m \
     @igv.args \
     -Dsun.java2d.uiScale=2 \
     --module=org.igv/org.broad.igv.tools.IgvTools  gui

--- a/src/main/java/org/broad/igv/ui/Main.java
+++ b/src/main/java/org/broad/igv/ui/Main.java
@@ -28,6 +28,7 @@ package org.broad.igv.ui;
 import com.jidesoft.plaf.LookAndFeelFactory;
 import com.sanityinc.jargs.CmdLineParser;
 import htsjdk.samtools.seekablestream.SeekableStreamFactory;
+
 import org.apache.log4j.Logger;
 import org.broad.igv.DirectoryManager;
 import org.broad.igv.Globals;
@@ -153,9 +154,17 @@ public class Main {
 
         DirectoryManager.initializeLog();
         log.info("Startup  " + Globals.applicationString());
-        log.info("Java " + System.getProperty(Globals.JAVA_VERSION_STRING));
+        log.info("Java " + System.getProperty(Globals.JAVA_VERSION_STRING) 
+            + " (build " + System.getProperty("java.vm.version")
+            + ") " + System.getProperty("java.version.date", ""));
+        log.info("Java Vendor: " + System.getProperty("java.vendor")
+            + " " + System.getProperty("java.vendor.url", ""));
+        log.info("JVM: " + System.getProperty("java.vm.name", "")
+            + " " + System.getProperty("java.vendor.version", "")
+            + "   " + System.getProperty("java.compiler", ""));
         log.info("Default User Directory: " + DirectoryManager.getUserDirectory());
-        log.info("OS: " + System.getProperty("os.name"));
+        log.info("OS: " + System.getProperty("os.name") + " " + System.getProperty("os.version")
+            + " " + System.getProperty("os.arch"));
         System.setProperty("http.agent", Globals.applicationString());
 
         Runtime.getRuntime().addShutdownHook(new ShutdownThread());


### PR DESCRIPTION
Changed the Java command to always pass -showversion to get the actual version of the JVM we're running.
Slightly modify the message when not using the bundled JVM to avoid it sounding like an error.
Logging more info about the JVM and OS at start-up since there are many more viable JVM vendors these days.