### PR TITLE
Switch to Cloudtrail supported user access audit

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -138,9 +138,10 @@ dependencies {
         [group: 'org.netbeans.external', name: 'AbsoluteLayout', version: 'RELEASE110'],
 
         // Amazon deps
-        [group: 'software.amazon.awssdk', name: 'http-client-spi', version: '2.7.8'],
-        [group: 'software.amazon.awssdk', name: 'cognitoidentity', version: '2.7.8'],
-        [group: 'software.amazon.awssdk', name: 's3', version: '2.7.8']
+        [group: 'software.amazon.awssdk', name: 'http-client-spi', version: '2.8.5'],
+        [group: 'software.amazon.awssdk', name: 'cognitoidentity', version: '2.8.5'],
+        [group: 'software.amazon.awssdk', name: 'sts', version: '2.8.5'],
+        [group: 'software.amazon.awssdk', name: 's3', version: '2.8.5']
     )
 
     testImplementation(

--- a/src/main/java/org/broad/igv/google/OAuthUtils.java
+++ b/src/main/java/org/broad/igv/google/OAuthUtils.java
@@ -38,7 +38,7 @@ import org.broad.igv.util.AmazonUtils;
 import org.broad.igv.util.FileUtils;
 import org.broad.igv.util.HttpUtils;
 import org.broad.igv.util.JWTParser;
-import software.amazon.awssdk.services.cognitoidentity.model.Credentials;
+import software.amazon.awssdk.services.sts.model.Credentials;
 
 import java.awt.*;
 import java.io.BufferedReader;

--- a/src/main/java11/module-info.java
+++ b/src/main/java11/module-info.java
@@ -36,6 +36,7 @@ module org.igv {
     requires software.amazon.awssdk.services.s3;
     requires software.amazon.awssdk.auth;
     requires software.amazon.awssdk.services.cognitoidentity;
+    requires software.amazon.awssdk.services.sts;
     requires software.amazon.awssdk.http;
     requires software.amazon.awssdk.utils;
 }


### PR DESCRIPTION
The enhanced flow does not support security audits (only the Role name appears on the logs). This change helps us a ton on things like accreditation and security audits (to see possible unauthorized user accesses to data).

This change requires just one additional line on `oauth-config.json`, pushed and documented on the public IGV-AWS backend blog post right now:

https://github.com/umccr-svc/site/commit/ef4efb5d0828f78516a89f9d0d0e7685eacff1fd

/cc @andrewpatto, change your `oauth-config.json` accordingly after this gets merged ;)