### PR TITLE
Increase scroll increment in preferences dialog.

### DIFF
--- a/src/main/java/org/broad/igv/prefs/PreferenceEditorNew.java
+++ b/src/main/java/org/broad/igv/prefs/PreferenceEditorNew.java
@@ -84,6 +84,7 @@ public class PreferenceEditorNew {
             scrollPane.setPreferredSize(new Dimension(750, 590));
             scrollPane.setMaximumSize(new Dimension(750, 590));
             scrollPane.setName(tabLabel);
+            scrollPane.getVerticalScrollBar().setUnitIncrement(16);
             tabbedPane.addTab(tabLabel, scrollPane);
 
             JPanel content = new JPanel();


### PR DESCRIPTION
The current scroll increment seems to be one pixel at a time, so scrolling the alignments tab in particular (which is significantly larger than the default window size) is ridiculously slow.

This bumps up the scroll increment so that it is usable.