### PR TITLE
Switch query- and subject-block would be better ?

### DIFF
--- a/src/main/java/org/broad/igv/blast/BlastMapping.java
+++ b/src/main/java/org/broad/igv/blast/BlastMapping.java
@@ -52,9 +52,9 @@ public class BlastMapping extends BasicFeature {
         this.queryBlock = queryBlock;
         this.subjectBlock = subjectBlock;
 
-        this.setStart(Math.min(queryBlock.getStart(), queryBlock.getEnd()));
-        this.setEnd(Math.max(queryBlock.getStart(), queryBlock.getEnd()));
-        this.setName("[" + subjectBlock.getContig() + ":" + subjectBlock.getStart() + "-" + subjectBlock.getEnd() + "]");
+        this.setStart(Math.min(subjectBlock.getStart(), subjectBlock.getEnd()));
+        this.setEnd(Math.max(subjectBlock.getStart(), subjectBlock.getEnd()));
+        this.setName("[" + queryBlock.getContig() + ":" + queryBlock.getStart() + "-" + queryBlock.getEnd() + "]");
         this.setScore(percentIden);
 
     }
@@ -71,11 +71,11 @@ public class BlastMapping extends BasicFeature {
 
     @Override
     public String getChr() {
-        return queryBlock.getContig();
+        return subjectBlock.getContig();
     }
 
     public Strand getStrand() {
-        return subjectBlock.getStrand();
+        return queryBlock.getStrand();
     }
 
     public boolean containsQueryPosition(String contig, int position) {


### PR DESCRIPTION
It seems that more users would use genome sequences as blast-subject instead of blast-query ?
For example, I might want to make a simple TBLASTN of one specific gene 
against the whole genome and visualize them with alignment data to check if there are any missing gene structure annotations.