### PR TITLE
Add right-click menu items to BLAT soft-clipped sequence

### DIFF
--- a/src/main/java/org/broad/igv/track/BlatTrack.java
+++ b/src/main/java/org/broad/igv/track/BlatTrack.java
@@ -39,9 +39,9 @@ public class BlatTrack extends FeatureTrack {
 
     List<PSLRecord> features;
 
-    public BlatTrack(String species, String sequence, String db, Genome genome) {
+    public BlatTrack(String species, String sequence, String db, Genome genome, String trackLabel) {
 
-        super(sequence, "Blat");
+        super(sequence, trackLabel);
 
         this.sequence = sequence;
         this.db = db;

--- a/src/main/java/org/broad/igv/util/blat/BlatClient.java
+++ b/src/main/java/org/broad/igv/util/blat/BlatClient.java
@@ -221,6 +221,10 @@ public class BlatClient {
     }
 
     public static void doBlatQuery(final String chr, final int start, final int end, Strand strand) {
+        doBlatQuery(chr, start, end, strand, "Blat");
+    }
+
+    public static void doBlatQuery(final String chr, final int start, final int end, Strand strand, final String trackLabel) {
 
         if((end - start) > 8000) {
             MessageUtils.showMessage("BLAT searches are limited to 8kb.  Please try a shorter sequence.");
@@ -239,7 +243,10 @@ public class BlatClient {
     }
 
     public static void doBlatQuery(final String userSeq) {
+        doBlatQuery(userSeq, "Blat");
+    }
 
+    public static void doBlatQuery(final String userSeq, final String trackLabel) {
         LongRunningTask.submit(new NamedRunnable() {
             public String getName() {
                 return "Blat sequence";
@@ -257,7 +264,7 @@ public class BlatClient {
                         return;
                     }
 
-                    BlatTrack newTrack = new BlatTrack(species, userSeq, db, genome);
+                    BlatTrack newTrack = new BlatTrack(species, userSeq, db, genome, trackLabel);
 
 
                     if (newTrack.getFeatures().isEmpty()) {


### PR DESCRIPTION
As suggested in #632, add right-click menu items to BLAT soft-clipped sequence.

The menu items are only shown when the left/right clipping is longer than the "flag clipping threshold."  The BLAT track is labeled with the name of the searched read.

To test the functionality, you can load the hg19 BAM from https://ftp-trace.ncbi.nlm.nih.gov/giab/ftp/data/AshkenazimTrio/HG002_NA24385_son/PacBio_SequelII_CCS_11kb/HG002.SequelII.pbmm2.hs37d5.whatshap.haplotag.RTG.10x.trio.bam and navigate to chr7:133,769,566-133,815,688.  

*Menu item*
![image](https://user-images.githubusercontent.com/7155109/69196758-3b2f5380-0ae4-11ea-9f96-bd5828ef525d.png)

*Example result*
![image](https://user-images.githubusercontent.com/7155109/69196823-75005a00-0ae4-11ea-84e0-d40f537a1a42.png)
