### PR TITLE
added method to check for HTTP redirect before using URL

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -142,11 +142,12 @@ dependencies {
         [group: 'software.amazon.awssdk', name: 's3', version: '2.8.5'],
 
         [group: 'javax.ws.rs', name: 'javax.ws.rs-api', version: '2.0'],
-        [group: 'com.sparkjava', name: 'spark-core', version: '2.2']
     )
 
     testImplementation(
-        fileTree(dir: 'test/lib', include: '*.jar')
+        fileTree(dir: 'test/lib', include: '*.jar'), // first search on disk (old behavior), then maven repos
+        [group: 'com.sparkjava', name: 'spark-core', version: '2.2'],
+        [group: 'org.glassfish.jersey.core', name: 'jersey-common', version: '2.22.4']
     )
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -141,7 +141,8 @@ dependencies {
         [group: 'software.amazon.awssdk', name: 'sts', version: '2.8.5'],
         [group: 'software.amazon.awssdk', name: 's3', version: '2.8.5'],
 
-        [group: 'javax.ws.rs', name: 'javax.ws.rs-api', version: '2.0']
+        [group: 'javax.ws.rs', name: 'javax.ws.rs-api', version: '2.0'],
+        [group: 'com.sparkjava', name: 'spark-core', version: '2.2']
     )
 
     testImplementation(
@@ -208,6 +209,7 @@ compileTestJava {
 
 test {
     inputs.property("moduleName", moduleName)
+
     doFirst {
         jvmArgs = [
             '-Dcom.sun.xml.bind.v2.bytecode.ClassTailor.noOptimize',

--- a/build.gradle
+++ b/build.gradle
@@ -139,7 +139,9 @@ dependencies {
         [group: 'software.amazon.awssdk', name: 'http-client-spi', version: '2.8.5'],
         [group: 'software.amazon.awssdk', name: 'cognitoidentity', version: '2.8.5'],
         [group: 'software.amazon.awssdk', name: 'sts', version: '2.8.5'],
-        [group: 'software.amazon.awssdk', name: 's3', version: '2.8.5']
+        [group: 'software.amazon.awssdk', name: 's3', version: '2.8.5'],
+
+        [group: 'javax.ws.rs', name: 'javax.ws.rs-api', version: '2.0']
     )
 
     testImplementation(

--- a/src/main/java/org/broad/igv/util/HttpUtils.java
+++ b/src/main/java/org/broad/igv/util/HttpUtils.java
@@ -307,6 +307,7 @@ public class HttpUtils {
     public InputStream openConnectionStream(URL url, Map<String, String> requestProperties) throws IOException {
 
         HttpURLConnection conn = openConnection(url, requestProperties);
+
         if (conn == null) {
             return null;
         }
@@ -720,7 +721,8 @@ public class HttpUtils {
         if( redirectCache.containsKey(url) ) {
 	    CachedRedirect cr = redirectCache.get(url);
 	    if( ZonedDateTime.now().compareTo( cr.expires ) < 0.0 ) {
-		log.debug("Found URL in redirection cache: " + url + " ->" + redirectCache.get(url));
+		// now() is before our expiration
+		log.debug("Found URL in redirection cache: " + url + " ->" + redirectCache.get(url).url);
 		url = cr.url;
 	    } else {
 		log.debug("Removing expired URL from redirection cache: " + url);
@@ -802,13 +804,13 @@ public class HttpUtils {
                 conn.setRequestProperty("Accept", "text/plain");
             }
 
-
         conn.setConnectTimeout(Globals.CONNECT_TIMEOUT);
         conn.setReadTimeout(Globals.READ_TIMEOUT);
         conn.setRequestMethod(method);
         conn.setRequestProperty("Connection", "Keep-Alive");
         // we'll handle redirects manually, allowing us to cache the new URL
         conn.setInstanceFollowRedirects(false);
+
         if (requestProperties != null) {
             for (Map.Entry<String, String> prop : requestProperties.entrySet()) {
                 conn.setRequestProperty(prop.getKey(), prop.getValue());
@@ -875,6 +877,7 @@ public class HttpUtils {
                         }
                         if( cc != null ) {
                             if( cc.isNoCache() ) {
+				// set expires to null, preventing caching
                                 cr.expires = null;
 			    } else if (cc.getMaxAge() > 0) {
                                 cr.expires = ZonedDateTime.now().plusSeconds(cc.getMaxAge());

--- a/src/main/java/org/broad/igv/util/ResourceLocator.java
+++ b/src/main/java/org/broad/igv/util/ResourceLocator.java
@@ -33,10 +33,8 @@ import org.broad.igv.google.GoogleUtils;
 
 import java.awt.*;
 import java.io.File;
-import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.net.HttpURLConnection;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -129,18 +127,10 @@ public class ResourceLocator {
     public ResourceLocator(String path) {
         this.setPath(path);
 
-        if(path != null && path.startsWith("https://") && GoogleUtils.isGoogleDrive(path)) {
+        if (path != null && path.startsWith("https://") && GoogleUtils.isGoogleDrive(path)) {
             this.resolveGoogleDrive(path);
-        } else if( path != null && (path.startsWith("https://") || path.startsWith("http://"))) {
+        }
 
-	    String final_path = path;
-	    String redirected = checkForRedirect(final_path);
-	    while( redirected != null ) {
-		final_path = redirected;
-		redirected = checkForRedirect(redirected);
-	    }
-	    this.setPath(final_path);
-	}
     }
 
     private void resolveGoogleDrive(String path) {
@@ -148,34 +138,6 @@ public class ResourceLocator {
         JsonObject fileInfo = GoogleUtils.getDriveFileInfo(path);
         this.name = fileInfo.get("name").getAsString();
         this.type = getTypeString(this.name);
-    }
-
-    /**
-     * use an HTTP HEAD to check for a redirect (301, 302, 307, or 308)
-     * @return a String representing the new location, null otherwise
-     */
-    private String checkForRedirect(String url_string) {
-	URL url;
-	try {
-	    url = new URL(url_string);
-	} catch(MalformedURLException e) {
-	    log.error("Error interpreting url: " + url_string, e);
-	    return null;
-	};
-
-	HttpURLConnection connection;
-	try {
-	    connection = (HttpURLConnection) url.openConnection();
-	    connection.setRequestMethod("HEAD");
-	    connection.setInstanceFollowRedirects(false);
-            connection.getInputStream().close();
-	    int code = connection.getResponseCode();
-	    if( code == HttpURLConnection.HTTP_MOVED_PERM || code == HttpURLConnection.HTTP_MOVED_TEMP || code == 307 || code == 308 ) {
-		return connection.getHeaderField("Location");
-	    }
-	} catch(IOException e) {
-	}
-        return null;
     }
 
     /**

--- a/src/main/java/org/broad/igv/util/ResourceLocator.java
+++ b/src/main/java/org/broad/igv/util/ResourceLocator.java
@@ -33,8 +33,10 @@ import org.broad.igv.google.GoogleUtils;
 
 import java.awt.*;
 import java.io.File;
+import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.net.HttpURLConnection;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -127,10 +129,18 @@ public class ResourceLocator {
     public ResourceLocator(String path) {
         this.setPath(path);
 
-        if (path != null && path.startsWith("https://") && GoogleUtils.isGoogleDrive(path)) {
+        if(path != null && path.startsWith("https://") && GoogleUtils.isGoogleDrive(path)) {
             this.resolveGoogleDrive(path);
-        }
+        } else if( path != null && (path.startsWith("https://") || path.startsWith("http://"))) {
 
+	    String final_path = path;
+	    String redirected = checkForRedirect(final_path);
+	    while( redirected != null ) {
+		final_path = redirected;
+		redirected = checkForRedirect(redirected);
+	    }
+	    this.setPath(final_path);
+	}
     }
 
     private void resolveGoogleDrive(String path) {
@@ -138,6 +148,34 @@ public class ResourceLocator {
         JsonObject fileInfo = GoogleUtils.getDriveFileInfo(path);
         this.name = fileInfo.get("name").getAsString();
         this.type = getTypeString(this.name);
+    }
+
+    /**
+     * use an HTTP HEAD to check for a redirect (301, 302, 307, or 308)
+     * @return a String representing the new location, null otherwise
+     */
+    private String checkForRedirect(String url_string) {
+	URL url;
+	try {
+	    url = new URL(url_string);
+	} catch(MalformedURLException e) {
+	    log.error("Error interpreting url: " + url_string, e);
+	    return null;
+	};
+
+	HttpURLConnection connection;
+	try {
+	    connection = (HttpURLConnection) url.openConnection();
+	    connection.setRequestMethod("HEAD");
+	    connection.setInstanceFollowRedirects(false);
+            connection.getInputStream().close();
+	    int code = connection.getResponseCode();
+	    if( code == HttpURLConnection.HTTP_MOVED_PERM || code == HttpURLConnection.HTTP_MOVED_TEMP || code == 307 || code == 308 ) {
+		return connection.getHeaderField("Location");
+	    }
+	} catch(IOException e) {
+	}
+        return null;
     }
 
     /**


### PR DESCRIPTION
This patch is meant to address a performance problem that occurs when IGV loads an indexed BAM file from a host that redirects to a different server.  In our particular case, this redirect operation is expensive, on the order of 3 seconds.  Given an indexed BAM file, IGV makes dozens of Range queries, each incurring a 3s penalty, which means the BAM file takes minutes to load where it should take seconds.

By patching IGV instead of htsjdk (which is the library actually making the Range requests), this should cover file types besides BAM + BAI.

Thanks for taking a look, and any feedback is appreciated!