### PR TITLE
Show All Chrom view when search is "*"

### DIFF
--- a/src/main/java/org/broad/igv/ui/action/SearchCommand.java
+++ b/src/main/java/org/broad/igv/ui/action/SearchCommand.java
@@ -431,6 +431,11 @@ public class SearchCommand {
             }
         }
 
+        // Show the "All chromosomes" view if the search string is "*"
+        if (chr.equals("*")) {
+            return new SearchResult(ResultType.CHROMOSOME, Globals.CHR_ALL, 0, 1);
+        }
+
         //startEnd will have coordinates if found.
         chr = genome.getCanonicalChrName(chr);
         Chromosome chromosome = genome.getChromosome(chr);

--- a/src/main/java/org/broad/igv/ui/action/SearchCommand.java
+++ b/src/main/java/org/broad/igv/ui/action/SearchCommand.java
@@ -432,7 +432,7 @@ public class SearchCommand {
         }
 
         // Show the "All chromosomes" view if the search string is "*"
-        if (chr.equals("*")) {
+        if (chr.equals("*") || chr.toLowerCase().equals("all")) {
             return new SearchResult(ResultType.CHROMOSOME, Globals.CHR_ALL, 0, 1);
         }
 


### PR DESCRIPTION
I find the "All chromosomes" view to be useful sometimes.  The only way that I know to get that view is to select "All" from the chromosome dropdown in the navigation bar.  This makes entering "*" in the search box load the "All chromosomes view".  Importantly, that also gives a way for a batch script to get the All Chromosomes view with "goto *"

Credit to @williamrowell for the idea
