### PR TITLE
Fix AWS Glacier/Deep Archive loading of restored objects

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -131,10 +131,10 @@ dependencies {
         [group: 'org.netbeans.external', name: 'AbsoluteLayout', version: 'RELEASE110'],
 
         // Amazon deps
-        [group: 'software.amazon.awssdk', name: 'http-client-spi', version: '2.10.65'],
-        [group: 'software.amazon.awssdk', name: 'cognitoidentity', version: '2.10.65'],
-        [group: 'software.amazon.awssdk', name: 'sts', version: '2.10.65'],
-        [group: 'software.amazon.awssdk', name: 's3', version: '2.10.65'],
+        [group: 'software.amazon.awssdk', name: 'http-client-spi', version: '2.8.5'],
+        [group: 'software.amazon.awssdk', name: 'cognitoidentity', version: '2.8.5'],
+        [group: 'software.amazon.awssdk', name: 'sts', version: '2.8.5'],
+        [group: 'software.amazon.awssdk', name: 's3', version: '2.8.5'],
     )
 
     testImplementation(

--- a/build.gradle
+++ b/build.gradle
@@ -131,10 +131,10 @@ dependencies {
         [group: 'org.netbeans.external', name: 'AbsoluteLayout', version: 'RELEASE110'],
 
         // Amazon deps
-        [group: 'software.amazon.awssdk', name: 'http-client-spi', version: '2.8.5'],
-        [group: 'software.amazon.awssdk', name: 'cognitoidentity', version: '2.8.5'],
-        [group: 'software.amazon.awssdk', name: 'sts', version: '2.8.5'],
-        [group: 'software.amazon.awssdk', name: 's3', version: '2.8.5'],
+        [group: 'software.amazon.awssdk', name: 'http-client-spi', version: '2.10.65'],
+        [group: 'software.amazon.awssdk', name: 'cognitoidentity', version: '2.10.65'],
+        [group: 'software.amazon.awssdk', name: 'sts', version: '2.10.65'],
+        [group: 'software.amazon.awssdk', name: 's3', version: '2.10.65'],
     )
 
     testImplementation(

--- a/src/main/java/org/broad/igv/aws/S3LoadDialog.java
+++ b/src/main/java/org/broad/igv/aws/S3LoadDialog.java
@@ -48,7 +48,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 import software.amazon.awssdk.services.s3.model.S3Exception;
 
 import static org.broad.igv.util.AmazonUtils.isObjectAccessible;
@@ -104,7 +103,7 @@ public class S3LoadDialog extends JDialog {
                 if (isFilePath(path)) {
                     Triple<String, String, String> bucketKeyTier = getBucketKeyTierFromTreePath(path);
 
-                    AmazonUtils.S3ObjectAccessResult res = isObjectAccessible(bucketKeyTier);
+                    AmazonUtils.s3ObjectAccessResult res = isObjectAccessible(bucketKeyTier.getLeft(), bucketKeyTier.getMiddle());
                     if(!res.getObjAvailable()) { MessageUtils.showErrorMessage(res.getErrorReason(), null); return; }
 
                     preLocatorPaths.add(bucketKeyTier);
@@ -242,7 +241,7 @@ public class S3LoadDialog extends JDialog {
                         if (isFilePath(selPath)) {
                             Triple<String, String, String> bucketKeyTier = getBucketKeyTierFromTreePath(selPath);
 
-                            AmazonUtils.S3ObjectAccessResult res = isObjectAccessible(bucketKeyTier);
+                            AmazonUtils.s3ObjectAccessResult res = isObjectAccessible(bucketKeyTier.getLeft(), bucketKeyTier.getMiddle());
                             if(!res.getObjAvailable()) { MessageUtils.showErrorMessage(res.getErrorReason(), null); return;}
 
                             ResourceLocator loc = getResourceLocatorFromBucketKey(bucketKeyTier);

--- a/src/main/java/org/broad/igv/aws/S3LoadDialog.java
+++ b/src/main/java/org/broad/igv/aws/S3LoadDialog.java
@@ -210,7 +210,7 @@ public class S3LoadDialog extends JDialog {
 
         HeadObjectResponse S3Meta;
         boolean ObjAvailable;
-        String objCurrentState = "";
+        String objCurrentState;
 
         if (S3ObjectStorageClass.contains("DEEP_ARCHIVE") ||
                 S3ObjectStorageClass.contains("GLACIER")) {
@@ -225,7 +225,8 @@ public class S3LoadDialog extends JDialog {
 
                 //https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/s3/model/HeadObjectResponse.html#restore--
                 S3Meta = AmazonUtils.getObjectMetadata(S3Obj);
-                objCurrentState = S3Meta.restore();
+                //objCurrentState = S3Meta.restore();
+                objCurrentState = S3Meta.sdkHttpResponse().headers().get("x-amz-restore").toString();
 
                 if(objCurrentState == null) {
                     ObjAvailable = false;

--- a/src/main/java/org/broad/igv/aws/S3LoadDialog.java
+++ b/src/main/java/org/broad/igv/aws/S3LoadDialog.java
@@ -48,7 +48,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import software.amazon.awssdk.services.s3.model.S3Error;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 import software.amazon.awssdk.services.s3.model.S3Exception;
 
 
@@ -208,14 +208,50 @@ public class S3LoadDialog extends JDialog {
         String S3ObjectKey = S3Obj.getMiddle().toString();
         String S3ObjectStorageClass = S3Obj.getRight().toString();
 
+        HeadObjectResponse S3Meta;
+        boolean ObjAvailable;
+        String objCurrentState = "";
+
         if (S3ObjectStorageClass.contains("DEEP_ARCHIVE") ||
                 S3ObjectStorageClass.contains("GLACIER")) {
-            MessageUtils.showErrorMessage("Amazon S3 object is in " + S3ObjectStorageClass + " storage tier, not accessible at this moment. " +
-                    "Please contact your local system administrator about object: s3://" + S3ObjectBucket +  "/" + S3ObjectKey, null);
-            return false;
+                // Determine in which state this object really is:
+                // 1. Archived.
+                // 2. In the process of being restored.
+                // 3. Restored
+                //
+                // This is important because after restoration the object mantains the Tier (DEEP_ARCHIVE) instead of
+                // transitioning that attribute to STANDARD, we must look at head_object response for the "Restore"
+                // attribute.
+
+                //https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/s3/model/HeadObjectResponse.html#restore--
+                S3Meta = AmazonUtils.getObjectMetadata(S3Obj);
+                objCurrentState = S3Meta.restore();
+
+                if(objCurrentState == null) {
+                    ObjAvailable = false;
+                    log.info("Object is archived and is not being restored");
+                } else if(objCurrentState.contains("ongoing-request=\"true\"")) {
+                    MessageUtils.showErrorMessage("Amazon S3 object is in " + S3ObjectStorageClass + " and being restored right now, please be patient, this can take up to 48h. " +
+                            "For further enquiries about this dataset, please use the following path when communicating with your system administrator: s3://" + S3ObjectBucket + "/" + S3ObjectKey, null);
+                    ObjAvailable = false;
+                    log.info("isObjectAccessible(): The object "+ S3ObjectKey +" is being restored, bailing out.");
+                // "If an archive copy is already restored, the header value indicates when Amazon S3 is scheduled to delete the object copy"
+                } else if(objCurrentState.contains("ongoing-request=\"false\"") && objCurrentState.contains("expiry-date=")) {
+                    ObjAvailable = true;
+                    log.info("isObjectAccessible(): The object "+ S3ObjectKey +" has been restored, will be loaded next.");
+                } else {
+                    MessageUtils.showErrorMessage("Amazon S3 object is in " + S3ObjectStorageClass + " storage tier, not accessible at this moment. " +
+                            "Please contact your local system administrator about object: s3://" + S3ObjectBucket + "/" + S3ObjectKey, null);
+                    ObjAvailable = false;
+                    log.info("isObjectAccessible(): The object"+ S3ObjectKey +" is not available.");
+                }
+        } else {
+            // The object must be either in STANDARD, INFREQUENT_ACCESS, INTELLIGENT_TIERING or
+            // any other "immediately available" tier...
+            ObjAvailable = true;
         }
 
-        return true;
+        return ObjAvailable;
     }
 
     private void initComponents() {

--- a/src/main/java/org/broad/igv/ui/action/LoadFromURLMenuAction.java
+++ b/src/main/java/org/broad/igv/ui/action/LoadFromURLMenuAction.java
@@ -29,14 +29,10 @@
  */
 package org.broad.igv.ui.action;
 
-import htsjdk.samtools.util.Tuple;
-import org.apache.commons.lang3.tuple.Triple;
 import org.apache.log4j.Logger;
-import org.broad.igv.aws.S3Object;
 import org.broad.igv.exceptions.HttpResponseException;
 import org.broad.igv.feature.genome.GenomeManager;
 import org.broad.igv.google.GoogleUtils;
-import org.broad.igv.google.OAuthUtils;
 import org.broad.igv.prefs.Constants;
 import org.broad.igv.prefs.PreferencesManager;
 import org.broad.igv.ui.IGV;
@@ -105,14 +101,11 @@ public class LoadFromURLMenuAction extends MenuAction {
                         try {
                             // If AWS support is active, check if objects are in accessible tiers via Load URL menu...
                             if (AmazonUtils.isAwsS3Path(url)) {
-                                Tuple S3ObjTuple = AmazonUtils.bucketAndKey(url);
-                                Triple bucketKeyTier = Triple.of(S3ObjTuple.a, S3ObjTuple.b, "");
+                                String bucket = AmazonUtils.getBucketFromS3URL(url);
+                                String key = AmazonUtils.getKeyFromS3URL(url);
 
-                                AmazonUtils.S3ObjectAccessResult res = isObjectAccessible(bucketKeyTier);
-                                if (!res.getObjAvailable()) {
-                                    MessageUtils.showMessage(res.getErrorReason());
-                                    return;
-                                }
+                                AmazonUtils.s3ObjectAccessResult res = isObjectAccessible(bucket, key);
+                                if (!res.getObjAvailable()) { MessageUtils.showErrorMessage(res.getErrorReason(), null); return; }
                             }
                         } catch (NullPointerException npe) {
                             // User has not yet done Amazon->Login sequence

--- a/src/main/java/org/broad/igv/util/AmazonUtils.java
+++ b/src/main/java/org/broad/igv/util/AmazonUtils.java
@@ -2,6 +2,7 @@ package org.broad.igv.util;
 
 import com.google.gson.JsonObject;
 import htsjdk.samtools.util.Tuple;
+import org.apache.commons.lang3.tuple.Triple;
 import org.apache.log4j.Logger;
 import org.broad.igv.Globals;
 import org.broad.igv.aws.IGVS3Object;
@@ -201,6 +202,18 @@ public class AmazonUtils {
         }
 
         return bucketsFinalList;
+    }
+
+    public static HeadObjectResponse getObjectMetadata(Triple S3Obj) {
+        String S3ObjectBucket = S3Obj.getLeft().toString();
+        String S3ObjectKey = S3Obj.getMiddle().toString();
+
+        HeadObjectRequest HeadObjReq = HeadObjectRequest.builder()
+                                                        .bucket(S3ObjectBucket)
+                                                        .key(S3ObjectKey).build();
+        HeadObjectResponse HeadObjRes = s3Client.headObject(HeadObjReq);
+        log.debug("getObjectMetadata(): "+HeadObjRes.toString());
+        return HeadObjRes;
     }
 
     private static List<String> getReadableBuckets(List<String> buckets) {

--- a/src/main/java/org/broad/igv/util/AmazonUtils.java
+++ b/src/main/java/org/broad/igv/util/AmazonUtils.java
@@ -204,13 +204,10 @@ public class AmazonUtils {
         return bucketsFinalList;
     }
 
-    public static HeadObjectResponse getObjectMetadata(Triple S3Obj) {
-        String S3ObjectBucket = S3Obj.getLeft().toString();
-        String S3ObjectKey = S3Obj.getMiddle().toString();
-
+    public static HeadObjectResponse getObjectMetadata(String bucket, String key) {
         HeadObjectRequest HeadObjReq = HeadObjectRequest.builder()
-                                                        .bucket(S3ObjectBucket)
-                                                        .key(S3ObjectKey).build();
+                                                        .bucket(bucket)
+                                                        .key(key).build();
         HeadObjectResponse HeadObjRes = s3Client.headObject(HeadObjReq);
         log.debug("getObjectMetadata(): "+HeadObjRes.toString());
         return HeadObjRes;
@@ -218,7 +215,7 @@ public class AmazonUtils {
 
 
     // Holds whether a S3 object is accessible or not and reason/error msg in case it's not.
-    public static class S3ObjectAccessResult {
+    public static class s3ObjectAccessResult {
         private boolean objAvailable;
         private String errorReason;
 
@@ -242,18 +239,15 @@ public class AmazonUtils {
     // Determines whether the object is immediately available.
     // On AWS this means present in STANDARD, STANDARD_IA, INTELLIGENT_TIERING object access tiers.
     // Tiers GLACIER and DEEP_ARCHIVE are not immediately retrievable without action.
-    public static S3ObjectAccessResult isObjectAccessible(Triple S3Obj) {
-        String S3ObjectBucket = S3Obj.getLeft().toString();
-        String S3ObjectKey = S3Obj.getMiddle().toString();
-        S3ObjectAccessResult res = new S3ObjectAccessResult();
+    public static s3ObjectAccessResult isObjectAccessible(String bucket, String key) {
+        s3ObjectAccessResult res = new s3ObjectAccessResult();
+        HeadObjectResponse s3Meta;
 
-        HeadObjectResponse S3Meta;
+        String s3ObjectStorageStatus = null;
+        String s3ObjectStorageClass;
 
-        String S3ObjectStorageStatus = null;
-        String S3ObjectStorageClass;
-
-        S3Meta = AmazonUtils.getObjectMetadata(S3Obj);
-        S3ObjectStorageClass = S3Meta.storageClass().toString();
+        s3Meta = AmazonUtils.getObjectMetadata(bucket, key);
+        s3ObjectStorageClass = s3Meta.storageClass().toString();
 
         // Determine in which state this object really is:
         // 1. Archived.
@@ -266,27 +260,28 @@ public class AmazonUtils {
         //
         // Possible error reason messages for the users are:
 
-        String archived = "Amazon S3 object is in " + S3ObjectStorageClass + " storage tier, not accessible at this moment. " +
-                "Please contact your local system administrator about object: s3://" + S3ObjectBucket + "/" + S3ObjectKey;
-        String restoreInProgress = "Amazon S3 object is in " + S3ObjectStorageClass + " and being restored right now, please be patient, this can take up to 48h. " +
-                "For further enquiries about this dataset, please use the following path when communicating with your system administrator: s3://" + S3ObjectBucket + "/" + S3ObjectKey;
+        String archived = "Amazon S3 object is in " + s3ObjectStorageClass + " storage tier, not accessible at this moment. " +
+                "Please contact your local system administrator about object: s3://" + bucket + "/" + key;
+        String restoreInProgress = "Amazon S3 object is in " + s3ObjectStorageClass + " and being restored right now, please be patient, this can take up to 48h. " +
+                "For further enquiries about this dataset, please use the following path when communicating with your system administrator: s3://" + bucket + "/" + key;
 
-        if (S3ObjectStorageClass.contains("DEEP_ARCHIVE") ||
-            S3ObjectStorageClass.contains("GLACIER")) {
+        if (s3ObjectStorageClass.contains("DEEP_ARCHIVE") ||
+            s3ObjectStorageClass.contains("GLACIER")) {
             try {
-                S3ObjectStorageStatus = S3Meta.restore();
+                s3ObjectStorageStatus = s3Meta.sdkHttpResponse().headers().get("x-amz-restore").toString();
+                //S3ObjectStorageStatus = S3Meta.restore();
             } catch(NullPointerException npe) {
                 res.setObjAvailable(false);
                 res.setErrorReason(archived);
                 return res;
             }
 
-            if(S3ObjectStorageStatus.contains("ongoing-request=\"true\"")) {
+            if(s3ObjectStorageStatus.contains("ongoing-request=\"true\"")) {
                 res.setObjAvailable(false);
                 res.setErrorReason(restoreInProgress);
 
             // "If an archive copy is already restored, the header value indicates when Amazon S3 is scheduled to delete the object copy"
-            } else if(S3ObjectStorageStatus.contains("ongoing-request=\"false\"") && S3ObjectStorageStatus.contains("expiry-date=")) {
+            } else if(s3ObjectStorageStatus.contains("ongoing-request=\"false\"") && s3ObjectStorageStatus.contains("expiry-date=")) {
                 res.setObjAvailable(true);
             } else {
             // The object has never been restored?
@@ -389,18 +384,19 @@ public class AmazonUtils {
         return objects;
     }
 
-    public static Tuple<String, String> bucketAndKey(String S3urlString) {
-        AmazonS3URI s3URI = new AmazonS3URI(S3urlString);
-        String bucket = s3URI.getBucket();
-        String key = s3URI.getKey();
+    public static String getBucketFromS3URL(String s3URL) {
+        AmazonS3URI s3URI = new AmazonS3URI(s3URL);
+        return s3URI.getBucket();
 
-        log.debug("bucketAndKey(): " + bucket + " , " + key);
-        return new Tuple(bucket, key);
+    }
+
+    public static String getKeyFromS3URL(String s3URL) {
+        AmazonS3URI s3URI = new AmazonS3URI(s3URL);
+        return s3URI.getKey();
     }
 
     // Amazon S3 Presign URLs
     // Also keeps an internal mapping between ResourceLocator and active/valid signed URLs.
-
     private static String createPresignedURL(String s3Path) throws IOException {
         // Make sure access token are valid (refreshes token internally)
         OAuthProvider provider = OAuthUtils.getInstance().getProvider("Amazon");
@@ -418,11 +414,10 @@ public class AmazonUtils {
                 .region(getAWSREGION())
                 .build();
 
-        Tuple<String, String> bandk = bucketAndKey(s3Path);
-        String bucket = bandk.a;
-        String filename = bandk.b;
+        String bucket = getBucketFromS3URL(s3Path);
+        String key = getKeyFromS3URL(s3Path);
 
-        URI presigned = s3Presigner.presignS3DownloadLink(bucket, filename);
+        URI presigned = s3Presigner.presignS3DownloadLink(bucket, key);
         log.debug("AWS presigned URL from translateAmazonCloudURL is: " + presigned);
         return presigned.toString();
     }

--- a/src/main/java/org/broad/igv/util/AmazonUtils.java
+++ b/src/main/java/org/broad/igv/util/AmazonUtils.java
@@ -274,9 +274,7 @@ public class AmazonUtils {
         if (S3ObjectStorageClass.contains("DEEP_ARCHIVE") ||
             S3ObjectStorageClass.contains("GLACIER")) {
             try {
-                // XXX: .restore() incorrectly returning null, using sdkHttpResponse directly as a workaround for aws-java-sdk-v2 bug
-                //objCurrentState = S3Meta.restore();
-                S3ObjectStorageStatus = S3Meta.sdkHttpResponse().headers().get("x-amz-restore").toString();
+                S3ObjectStorageStatus = S3Meta.restore();
             } catch(NullPointerException npe) {
                 res.setObjAvailable(false);
                 res.setErrorReason(archived);


### PR DESCRIPTION
Up until now, error messages with AWS Glacier were limited to knowing the storage class.

When an object gets "thawed" (restored) from AWS Glacier, it holds the StorageClass (it does not transition to i.e standard). Instead, the header `x-amz-restore` should be parsed accordingly for the different lifecycle stages where the S3 object might be in.

While I was at it, I also added support for directly loading those S3 objects from `Load-> From URL` menu, to be consistent in UX/behaviour with the S3 Tree selector... this is a very **germane** change and goes along with this same PR!

Please @igvteam @jrobinso @davideby, would you please expedite this PR merge and release? Otherwise the Glacier object restoration will remain inoperative and confusing to users :-S

/cc @reisingerf @andrewpatto