### PR TITLE
Linking project overview dashboard to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ![GitHub issues](https://img.shields.io/github/issues/igvteam/igv)
 ![GitHub closed issues](https://img.shields.io/github/issues-closed/igvteam/igv)
 ![](https://img.shields.io/npm/l/igv.svg)
+[![SourceSpy Dashboard](https://sourcespy.com/shield.svg)](https://sourcespy.com/github/igvteamigv/)
 
 Integrative Genomics Viewer - desktop genome visualization tool for Mac, Windows, and Linux.
 
@@ -37,6 +38,8 @@ The IGV bundles ship with embedded JREs from AdoptOpenJDK.
   
 * Use ```./gradlew test``` to run the test suite.  See 'src/test/README.txt' for more information about running
   the tests.
+  
+* This dashboard describes [project structure and dependencies](https://sourcespy.com/github/igvteamigv/). New contributors can quickly grasp overall structure of the code and technologies involved.  
 
 Note that Gradle creates a number of other subdirectories in 'build'.  These can be safely ignored.
 


### PR DESCRIPTION
Adding a link to the README header. Dashboard describes overall project structure and dependencies. Will be useful for new developers looking to contribute to the project. Direct link: https://sourcespy.com/github/igvteamigv/