### PR TITLE
Multiple IGV instances

### DIFF
--- a/src/main/java/org/broad/igv/google/OAuthProvider.java
+++ b/src/main/java/org/broad/igv/google/OAuthProvider.java
@@ -7,6 +7,7 @@ import org.apache.log4j.Logger;
 import org.broad.igv.Globals;
 import org.broad.igv.batch.CommandListener;
 import org.broad.igv.event.IGVEventBus;
+import org.broad.igv.prefs.PreferencesManager;
 import org.broad.igv.ui.util.MessageUtils;
 import org.broad.igv.util.AmazonUtils;
 import org.broad.igv.util.HttpUtils;
@@ -39,7 +40,8 @@ public class OAuthProvider {
     private static final String REFRESH_TOKEN_KEY = "oauth_refresh_token";
 
     private String state = UUID.randomUUID().toString(); // "RFC6749: An opaque value used by the client to maintain state"
-    private String redirectURI = "http%3A%2F%2Flocalhost%3A60151%2FoauthCallback";
+    private String portNumber = PreferencesManager.getPreferences().getPortNumber();
+    private String redirectURI = "http%3A%2F%2Flocalhost%3A"+portNumber+"%2FoauthCallback";
     private String oobURI = "urn%3Aietf%3Awg%3Aoauth%3A2.0%3Aoob";
     private String clientId;
     private String clientSecret;

--- a/src/main/java/org/broad/igv/google/OAuthUtils.java
+++ b/src/main/java/org/broad/igv/google/OAuthUtils.java
@@ -104,32 +104,26 @@ public class OAuthUtils {
             loadProvisioningURL(provisioningURL);
         }
 
-        String propString = HttpUtils.getInstance().getContentsAsGzippedString(HttpUtils.createURL(provisioningURL));
-        JsonParser parser = new JsonParser();
-        JsonObject obj = parser.parse(propString).getAsJsonObject();
-        defaultProvider = new OAuthProvider(obj);
-
         // Local config takes precendence, overriding URL provisioned and Broad's default oauth-config.json.gz
-//        String oauthConfig = DirectoryManager.getIgvDirectory() + "/oauth-config.json";
-//        if ((new File(oauthConfig)).exists()) {
-//            try {
-//                log.debug("Loading Oauth properties from: " + oauthConfig);
-//                String json = FileUtils.getContents(oauthConfig);
-//                parseProviderJson(json, oauthConfig);
-//            } catch (IOException e) {
-//                log.error(e);
-//            }
-//        }
+        String oauthConfig = DirectoryManager.getIgvDirectory() + "/oauth-config.json";
+        if ((new File(oauthConfig)).exists()) {
+            try {
+                log.debug("Loading Oauth properties from: " + oauthConfig);
+                String json = FileUtils.getContents(oauthConfig);
+                parseProviderJson(json, oauthConfig);
+            } catch (IOException e) {
+                log.error(e);
+            }
+        }
 
-
-//        if (defaultProvider == null || urlProvisioned == false) {
-//            // IGV default
-//            log.debug("$HOME/igv/oauth-config.json not found, reading Java .properties instead from Broad's IGV properties endpoint: " + PROPERTIES_URL);
-//            String propString = HttpUtils.getInstance().getContentsAsGzippedString(HttpUtils.createURL(PROPERTIES_URL));
-//            JsonParser parser = new JsonParser();
-//            JsonObject obj = parser.parse(propString).getAsJsonObject().get("installed").getAsJsonObject();
-//            defaultProvider = new OAuthProvider(obj);
-//        }
+        if (defaultProvider == null) {
+            // IGV default
+            log.debug("$HOME/igv/oauth-config.json not found, reading Java .properties instead from Broad's IGV properties endpoint: " + PROPERTIES_URL);
+            String propString = HttpUtils.getInstance().getContentsAsGzippedString(HttpUtils.createURL(PROPERTIES_URL));
+            JsonParser parser = new JsonParser();
+            JsonObject obj = parser.parse(propString).getAsJsonObject().get("installed").getAsJsonObject();
+            defaultProvider = new OAuthProvider(obj);
+        }
     }
 
     public void loadProvisioningURL(String provisioningURL) throws IOException {

--- a/src/main/java/org/broad/igv/prefs/IGVPreferences.java
+++ b/src/main/java/org/broad/igv/prefs/IGVPreferences.java
@@ -371,6 +371,14 @@ public class IGVPreferences {
         return get(GENOMES_SERVER_URL);
     }
 
+    public String getProvisioningURL() {
+        return get(PROVISIONING_URL);
+    }
+
+    public String getPortNumber() {
+        return get(PORT_NUMBER);
+    }
+
     public void overrideGenomeServerURL(String url) {
         userPreferences.put(GENOMES_SERVER_URL, url);
         overrideKeys.add(GENOMES_SERVER_URL);

--- a/src/main/java/org/broad/igv/util/ParsingUtils.java
+++ b/src/main/java/org/broad/igv/util/ParsingUtils.java
@@ -43,6 +43,7 @@ import java.io.*;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -117,6 +118,8 @@ public class ParsingUtils {
         }
 
         if (locator.getPath().endsWith("gz")) {
+//            String contents = new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+//            log.debug("The raw contents of the GZipped files are: "+contents);
             return new GZIPInputStream(inputStream);
         } else {
             return inputStream;

--- a/src/main/java/org/broad/igv/util/ParsingUtils.java
+++ b/src/main/java/org/broad/igv/util/ParsingUtils.java
@@ -43,7 +43,6 @@ import java.io.*;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
-import java.nio.charset.StandardCharsets;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -118,8 +117,6 @@ public class ParsingUtils {
         }
 
         if (locator.getPath().endsWith("gz")) {
-//            String contents = new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
-//            log.debug("The raw contents of the GZipped files are: "+contents);
             return new GZIPInputStream(inputStream);
         } else {
             return inputStream;


### PR DESCRIPTION
This pull request closes the loop on parametrising the IGV commands port via user preferences, as it is already via the `prefs.properties` settings:

```
$ cat ~/igv/prefs.properties
(...)
PORT_NUMBER=60151
PORT_ENABLED=true
```

This essentially fixes https://github.com/igvteam/igv/issues/794. As you know, we use Google as IDP, so this change should work as well for Google-only folks since all it's doing is parametrising the IGV command port(s). The usecase @umccr is to have two IGV instances connected to two separated AWS accounts:

One local IGV instance is configured on port `60151` by default, for prod.
The other is configured against port `60152`, for dev.

Hope this helps others.

/cc @ohofmann