### PR TITLE
AWS null while loading an S3 Object from File Tree loader (Load From URL works).

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -113,7 +113,7 @@ dependencies {
         [group: 'org.xerial.snappy', name: 'snappy-java', version: '1.1.7.3'], 
         [group: 'org.apache.commons', name: 'commons-jexl', version: '2.1.1'],
         [group: 'org.apache.commons', name: 'commons-lang3', version: '3.9'],
-        [group: 'com.github.samtools', name: 'htsjdk', version: '2.21.1'],
+        [group: 'com.github.samtools', name: 'htsjdk', version: '2.21.3'],
         [group: 'org.apache.logging.log4j', name: 'log4j-1.2-api', version: '2.11.0'],
         [group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.11.0'],
         [group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.11.0'],
@@ -131,10 +131,10 @@ dependencies {
         [group: 'org.netbeans.external', name: 'AbsoluteLayout', version: 'RELEASE110'],
 
         // Amazon deps
-        [group: 'software.amazon.awssdk', name: 'http-client-spi', version: '2.8.5'],
-        [group: 'software.amazon.awssdk', name: 'cognitoidentity', version: '2.8.5'],
-        [group: 'software.amazon.awssdk', name: 'sts', version: '2.8.5'],
-        [group: 'software.amazon.awssdk', name: 's3', version: '2.8.5'],
+        [group: 'software.amazon.awssdk', name: 'http-client-spi', version: '2.13.23'],
+        [group: 'software.amazon.awssdk', name: 'cognitoidentity', version: '2.13.23'],
+        [group: 'software.amazon.awssdk', name: 'sts', version: '2.13.23'],
+        [group: 'software.amazon.awssdk', name: 's3', version: '2.13.23'],
     )
 
     testImplementation(

--- a/src/main/java/org/broad/igv/aws/S3LoadDialog.java
+++ b/src/main/java/org/broad/igv/aws/S3LoadDialog.java
@@ -111,7 +111,6 @@ public class S3LoadDialog extends JDialog {
             }
 
             for (Triple<String, String, String> preLocator: preLocatorPaths) {
-
                 ResourceLocator locator = getResourceLocatorFromBucketKey(preLocator);
                 finalLocators.add(locator);
             }


### PR DESCRIPTION
A couple of users have reported a regression I unfortunately introduced on PR https://github.com/igvteam/igv/pull/759. This PR aims to solve a NPE that occurs when loading from S3 bucket and loading from "STANDARD" tier objects. This oversight is my fault since we (@UMCCR) do not have many objects in `STANDARD` tier, instead we keep them primarily on `INTELLIGENT TIERING` or `DEEP GLACIER` instead, I should have been more thorough on my case testing :/

AWS S3 `STANDARD` tier does not contain the 'restore' S3 metadata when calling `head-object` method, so NPE got triggered and depending on which loading UI sequence was chosen (File Tree vs Load From URL) it got handled well or not, resulting on successful load or "null" error message. 

The issue is fixed here but unfortunately the upstream `LoadTracks` refactor seems to be affecting the loading of Tracks since right after clicking on a chromosome after successfully loading a BAM:

![Skärmavbild 2020-05-26 kl  16 04 09](https://user-images.githubusercontent.com/175587/82868105-600ef280-9f6f-11ea-8c12-c30662d39d22.png)


IGV hangs while downloading a lot of data in the background... which ends up in an OOM condition:

![Skärmavbild 2020-05-26 kl  11 39 12](https://user-images.githubusercontent.com/175587/82868071-4f5e7c80-9f6f-11ea-96b0-b885e199aac0.png)
![Skärmavbild 2020-05-26 kl  15 37 50](https://user-images.githubusercontent.com/175587/82868079-52596d00-9f6f-11ea-939f-c7f8ee2fd59e.png)


Opening this as draft PR, since the IGV hang on LoadTracks seems to be related to https://github.com/igvteam/igv/commit/734f49c4be81864aff106fafe8b338bce45b44e6 maybe? I need to investigate more.

/cc @reisingerf @pelacables