### PR TITLE
Improve BAM rendering in alignments with indels

### DIFF
--- a/src/main/java/org/broad/igv/sam/AlignmentRenderer.java
+++ b/src/main/java/org/broad/igv/sam/AlignmentRenderer.java
@@ -654,12 +654,20 @@ public class AlignmentRenderer {
         double pixelLengthOnReference = alignment.getLengthOnReference() / locScale;
         int arrowPxWidth = pixelLengthOnReference == 0 ? 0 : (int) Math.min(Math.min(5, h / 2), pixelLengthOnReference / 6);
 
+        int prevBlockChromEnd = 0;
         boolean tallEnoughForArrow = h > 6;
         for (AlignmentBlock block : blocks) {
+            int blockChromStart = block.getStart();
+            if (hideSmallIndelsBP && (blockChromStart - prevBlockChromEnd < indelThresholdBP)) {
+                blockChromStart = prevBlockChromEnd;
+            }
+            int blockChromEnd = block.getStart() + block.getLength();
+            int blockPxStart = (int) ((blockChromStart - bpStart) / locScale);
+            int blockPxEnd = (int) ((blockChromEnd - bpStart) / locScale);
+            prevBlockChromEnd = blockChromEnd;
 
-            int blockPxStart = (int) ((block.getStart() - bpStart) / locScale);
-            int blockPxWidth = (int) Math.max(1, (block.getLength() / locScale));
-            int blockPxEnd = blockPxStart + blockPxWidth + 1;
+            if (blockPxEnd == blockPxStart) { continue; }
+
             boolean leftmost = block == blocks[0];
             boolean rightmost = block == blocks[blocks.length - 1];
 

--- a/src/main/java/org/broad/igv/sam/AlignmentRenderer.java
+++ b/src/main/java/org/broad/igv/sam/AlignmentRenderer.java
@@ -654,6 +654,7 @@ public class AlignmentRenderer {
         double pixelLengthOnReference = alignment.getLengthOnReference() / locScale;
         int arrowPxWidth = pixelLengthOnReference == 0 ? 0 : (int) Math.min(Math.min(5, h / 2), pixelLengthOnReference / 6);
 
+        boolean tallEnoughForArrow = h > 6;
         for (AlignmentBlock block : blocks) {
 
             int blockPxStart = (int) ((block.getStart() - bpStart) / locScale);
@@ -661,7 +662,6 @@ public class AlignmentRenderer {
             int blockPxEnd = blockPxStart + blockPxWidth + 1;
             boolean leftmost = block == blocks[0];
             boolean rightmost = block == blocks[blocks.length - 1];
-            boolean tallEnoughForArrow = h > 6;
 
             if (h == 1) {
                 gAlignment.drawLine(blockPxStart, y, blockPxEnd, y);
@@ -698,9 +698,6 @@ public class AlignmentRenderer {
                 }
 
                 g.fill(blockShape);
-                if (outlineGraphics != null) {
-                    outlineGraphics.draw(blockShape);
-                }
                 if (leftmost && leftClipped) {
                     clippedGraphics.drawLine(xPoly[0], yPoly[0], xPoly[1], yPoly[1]);
                     clippedGraphics.drawLine(xPoly[5], yPoly[5] - 1, xPoly[0], yPoly[0]);
@@ -710,6 +707,22 @@ public class AlignmentRenderer {
                     clippedGraphics.drawLine(xPoly[3], yPoly[3], xPoly[4], yPoly[4] - 1);
                 }
             }
+        }
+        if (outlineGraphics != null) {
+            int chromStart = blocks[0].getStart(),
+                chromEnd = blocks[blocks.length - 1].getStart() + blocks[blocks.length - 1].getLength();
+            int blockPxStart = (int) ((chromStart - bpStart) / locScale),
+                blockPxEnd = (int) ((chromEnd - bpStart) / locScale);
+
+            int[] xPoly = {blockPxStart - (alignment.isNegativeStrand() && tallEnoughForArrow ? arrowPxWidth : 0),
+                        blockPxStart,
+                        blockPxEnd,
+                        blockPxEnd + (!alignment.isNegativeStrand() && tallEnoughForArrow ? arrowPxWidth : 0),
+                        blockPxEnd,
+                        blockPxStart},
+                    yPoly = {y + h / 2, y, y, y + h / 2, y + h, y + h};
+            Shape alShape = new Polygon(xPoly, yPoly, xPoly.length);
+            outlineGraphics.draw(alShape);
         }
 
 

--- a/src/main/java/org/broad/igv/sam/AlignmentRenderer.java
+++ b/src/main/java/org/broad/igv/sam/AlignmentRenderer.java
@@ -587,6 +587,7 @@ public class AlignmentRenderer {
 
                 int gapPxStart = (int) ((Math.max(bpStart, gapStart) - bpStart) / locScale);
                 int gapPxEnd = (int) ((Math.min(bpEnd, gapEnd) - bpStart) / locScale);
+                if (gapPxEnd == gapPxStart) { continue; }
 
                 if (gapEnd <= bpStart) { // gap ends before the visible context
                     continue; // move to next gap


### PR DESCRIPTION
Improve BAM rendering logic to:
* Prevent overlapping blocks
* Suppress gaps that are less than 1 pixel at current resolution
* Consider "hide small indels" logic in outlining alignments