### PR TITLE
Fix alignment block rendering regressions related to "hide small indels"

### DIFF
--- a/src/main/java/org/broad/igv/sam/AlignmentRenderer.java
+++ b/src/main/java/org/broad/igv/sam/AlignmentRenderer.java
@@ -653,14 +653,25 @@ public class AlignmentRenderer {
         double pixelLengthOnReference = alignment.getLengthOnReference() / locScale;
         int arrowPxWidth = pixelLengthOnReference == 0 ? 0 : (int) Math.min(Math.min(5, h / 2), pixelLengthOnReference / 6);
 
-        for (AlignmentBlock block : blocks) {
+        int blockChromStart = blocks[0].getStart();
+        boolean leftmost = true;
+        for (int blockIx = 0; blockIx < blocks.length; blockIx++) {
+            AlignmentBlock block = blocks[blockIx];
 
-            int blockPxStart = (int) ((block.getStart() - bpStart) / locScale);
-            int blockPxWidth = (int) Math.max(1, (block.getLength() / locScale));
-            int blockPxEnd = blockPxStart + blockPxWidth + 1;
-            boolean leftmost = block == blocks[0];
-            boolean rightmost = block == blocks[blocks.length - 1];
+            int blockChromEnd = block.getStart() + block.getLength();
+            int blockPxStart = (int) ((blockChromStart - bpStart) / locScale);
+            int blockPxEnd = (int) ((blockChromEnd - bpStart) / locScale);
+            boolean rightmost = blockIx + 1 == blocks.length;
             boolean tallEnoughForArrow = h > 6;
+
+            if (!rightmost) { // consider waiting to draw the block unless it is rightmost
+                if (hideSmallIndelsBP && (blocks[blockIx+1].getStart() - blockChromEnd) < indelThresholdBP) {
+                    continue; // small indel between this block and the next; wait to draw
+                }
+                else {
+                    blockChromStart = blocks[blockIx+1].getStart(); // start position for the next block
+                }
+            }
 
             if (h == 1) {
                 gAlignment.drawLine(blockPxStart, y, blockPxEnd, y);
@@ -709,6 +720,7 @@ public class AlignmentRenderer {
                     clippedGraphics.drawLine(xPoly[3], yPoly[3], xPoly[4], yPoly[4] - 1);
                 }
             }
+            leftmost = false;
         }
 
 


### PR DESCRIPTION
Correct apparent regressions (from 2.7.2 to 2.8.6) in rendering of alignment blocks
with hidden indels. Correct:
1. empty space between alignment blocks at hidden deletions
2. shadows at block boundaries when drawing multiple times at same position
3. outlines at block boundaries for hidden indels

Attempt to improve closed PR #821. 

Session with example dataset: https://dl.dnanex.us/F/D/zfG7yFjY0g1bG7GBQV9vkbYxYgZk9gGx3K6FJ0Gg/hg19_overlap.xml

**2.7.2**
<img width="1337" alt="igv-2_7_2" src="https://user-images.githubusercontent.com/7155109/85375007-82eae300-b4ea-11ea-9216-e74b94bf7e93.png">

**2.8.6**
<img width="1270" alt="igv-2_8_6" src="https://user-images.githubusercontent.com/7155109/85375026-88e0c400-b4ea-11ea-9986-dec4db5990a1.png">

**This pull request**
<img width="1435" alt="pr" src="https://user-images.githubusercontent.com/7155109/85376021-078a3100-b4ec-11ea-8e95-894c2a883e6c.png">

