### PR TITLE
Add functionality to get AWS credentials from the Default Credential Provider

### DIFF
--- a/src/main/java/org/broad/igv/google/OAuthProvider.java
+++ b/src/main/java/org/broad/igv/google/OAuthProvider.java
@@ -12,6 +12,7 @@ import org.broad.igv.ui.util.MessageUtils;
 import org.broad.igv.util.AmazonUtils;
 import org.broad.igv.util.HttpUtils;
 import org.broad.igv.util.JWTParser;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.services.sts.model.Credentials;
 
 import java.awt.*;
@@ -225,11 +226,13 @@ public class OAuthProvider {
 
             if (authProvider.equals("Amazon")) {
                 // Get AWS credentials after getting relevant tokens
-                Credentials aws_credentials;
-                aws_credentials = AmazonUtils.GetCognitoAWSCredentials();
+                if (!PreferencesManager.getPreferences().getUseAwsProfile()) {
+                    Credentials aws_credentials;
+                    aws_credentials = AmazonUtils.GetCognitoAWSCredentials();
 
-                // Update S3 client with newly acquired token
-                AmazonUtils.updateS3Client(aws_credentials);
+                    // Update S3 client with newly acquired token
+                    AmazonUtils.updateS3Client(aws_credentials);
+                }
             }
 
 

--- a/src/main/java/org/broad/igv/prefs/Constants.java
+++ b/src/main/java/org/broad/igv/prefs/Constants.java
@@ -257,6 +257,7 @@ final public class Constants {
 
     // OAuth provisioning
     public static final String PROVISIONING_URL = "PROVISIONING.URL";
+    public static final String USE_AWS_DEFAULT_CREDENTIALS = "PROVISIONING.USE_AWS_DEFAULT_CREDENTIALS";
 
     // Experimental
     public static final String SCORE_VARIANTS = "SCORE_VARIANTS";

--- a/src/main/java/org/broad/igv/prefs/IGVPreferences.java
+++ b/src/main/java/org/broad/igv/prefs/IGVPreferences.java
@@ -375,6 +375,10 @@ public class IGVPreferences {
         return get(PROVISIONING_URL);
     }
 
+    public Boolean getUseAwsProfile() {
+        return getAsBoolean(USE_AWS_DEFAULT_CREDENTIALS);
+    }
+
     public String getPortNumber() {
         return get(PORT_NUMBER);
     }

--- a/src/main/resources/org/broad/igv/prefs/preferences.tab
+++ b/src/main/resources/org/broad/igv/prefs/preferences.tab
@@ -190,6 +190,7 @@ IGV.genome.sequence.dir	Genome server URL	string	https://s3.amazonaws.com/igv.or
 MASTER_RESOURCE_FILE_KEY	Data registry url	string	https://data.broadinstitute.org/igvdata/$$_dataServerRegistry.txt
 ---
 PROVISIONING.URL	OAuth provisioning URL	string	null
+PROVISIONING.USE_AWS_DEFAULT_CREDENTIALS	Use AWS native auth chain to use any supported AWS credential location	boolean	FALSE
 ---
 BLAT_URL	Blat url	String	https://genome.cse.ucsc.edu/cgi-bin/hgBlat
 ---


### PR DESCRIPTION
This adds the ability to get AWS credentials for accessing s3 from any of the supported methods on the AWS credentials chain.

https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html#credentials-default

This makes it so Cognito no longer needs to be setup should the organization using AWS not wish to and/or for minimal uses Cognito is overkill.  It also will allow for the instance profile credentials (e.g. you start up an EC2 instance and that instance has the credentials baked into it) to be used.  Overall it increases flexibility for uses that are not organizations that need cognito and/or want to run IGV with s3 access on AWS EC2 instances.


This implementation is a bit of a hack using the OAUTH code/path even though it isn't OAUTH.


My Open Questions:

Are you interested in adding this functionality?

What changes would you like to see to merge this and/or is the current method acceptable?

How long should I sign the S3 urls for? Right now it is set for the max (7 days).  This can be set to the default of 15 minutes or any other time including adding a config parameter for the user to set it.

What text should I put for the settings checkbox and is the current location good? I don't love my current text there, but trying to convey exactly what it is without getting long is difficult.

Thank You