### PR TITLE
Fixed issues in the in-code logging configuration

### DIFF
--- a/src/main/java/org/broad/igv/DirectoryManager.java
+++ b/src/main/java/org/broad/igv/DirectoryManager.java
@@ -31,6 +31,8 @@ import org.apache.log4j.Logger;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.appender.RollingFileAppender;
+import org.apache.logging.log4j.core.appender.rolling.DefaultRolloverStrategy;
+import org.apache.logging.log4j.core.appender.rolling.RolloverStrategy;
 import org.apache.logging.log4j.core.appender.rolling.SizeBasedTriggeringPolicy;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.LoggerConfig;
@@ -497,12 +499,15 @@ public class DirectoryManager {
             rootLogger.removeAppender("IGV_ROLLING_APPENDER");
             PatternLayout layout = PatternLayout.newBuilder().withConfiguration(configuration)
                     .withPattern("%p [%d{ISO8601}] [%F:%L]  %m%n").build();
+            RolloverStrategy rolloverStrategy = DefaultRolloverStrategy.newBuilder().withConfig(configuration)
+            		.withMax("1").withMin("1").build();
             RollingFileAppender appender = RollingFileAppender.newBuilder().withName("IGV_ROLLING_APPENDER")
                     .setConfiguration(configuration)
                     .withFileName(logFile.getAbsolutePath()).withAppend(true)
-                    .withFilePattern(getIgvDirectory().getAbsolutePath() + File.pathSeparator + "igv-%i.log")
+                    .withFilePattern(getIgvDirectory().getAbsolutePath() + File.separator + "igv-backup-%i.log")
                     .withLayout(layout)
-                    .withPolicy(SizeBasedTriggeringPolicy.createPolicy("1000K"))
+                    .withPolicy(SizeBasedTriggeringPolicy.createPolicy("500K"))
+                    .withStrategy(rolloverStrategy)
                     .build();
             appender.start();
             configuration.addAppender(appender);


### PR DESCRIPTION
Fixed a bug with the logging file path.
Changed to limit the number of backup "rollover" logs to just one, and
to limit log file size to 500K