### PR TITLE
Added menu items for Save SVG

### DIFF
--- a/src/main/java/org/broad/igv/sashimi/SashimiPlot.java
+++ b/src/main/java/org/broad/igv/sashimi/SashimiPlot.java
@@ -25,6 +25,9 @@
 
 package org.broad.igv.sashimi;
 
+import org.broad.igv.event.IGVEventBus;
+import org.broad.igv.event.IGVEventObserver;
+import org.broad.igv.event.ViewChange;
 import org.broad.igv.feature.IExon;
 import org.broad.igv.prefs.Constants;
 import org.broad.igv.prefs.PreferencesManager;
@@ -33,9 +36,6 @@ import org.broad.igv.track.*;
 import org.broad.igv.ui.IGV;
 import org.broad.igv.ui.color.ColorPalette;
 import org.broad.igv.ui.color.ColorUtilities;
-import org.broad.igv.event.IGVEventBus;
-import org.broad.igv.event.IGVEventObserver;
-import org.broad.igv.event.ViewChange;
 import org.broad.igv.ui.panel.*;
 import org.broad.igv.ui.util.IGVMouseInputAdapter;
 import org.broad.igv.ui.util.UIUtilities;
@@ -46,12 +46,11 @@ import javax.swing.event.PopupMenuListener;
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.geom.Rectangle2D;
 import java.io.File;
-import java.util.*;
 import java.util.List;
+import java.util.*;
 
 /**
  * Window for displaying sashimi style junction plot
@@ -426,11 +425,20 @@ public class SashimiPlot extends JFrame implements IGVEventObserver {
             strandGroup.add(minusStrand);
 
 
-            JMenuItem saveImageItem = new JMenuItem("Save Image...");
-            saveImageItem.addActionListener(new ActionListener() {
+            JMenuItem savePngImageItem = new JMenuItem("Save PNG Image...");
+            savePngImageItem.addActionListener(new ActionListener() {
                 @Override
                 public void actionPerformed(ActionEvent e) {
                     File defaultFile = new File("Sashimi.png");
+                    IGV.getInstance().createSnapshot(SashimiPlot.this.getContentPane(), defaultFile);
+                }
+            });
+
+            JMenuItem saveSvgImageItem = new JMenuItem("Save SVG Image...");
+            saveSvgImageItem.addActionListener(new ActionListener() {
+                @Override
+                public void actionPerformed(ActionEvent e) {
+                    File defaultFile = new File("Sashimi.svg");
                     IGV.getInstance().createSnapshot(SashimiPlot.this.getContentPane(), defaultFile);
                 }
             });
@@ -449,7 +457,7 @@ public class SashimiPlot extends JFrame implements IGVEventObserver {
             menu.addSeparator();
             menu.add(textShape);
             menu.add(circleShape);
-           // menu.add(ellipseShape);
+            // menu.add(ellipseShape);
             menu.add(noShape);
 
             // Strand options -- applies to all plots
@@ -459,7 +467,8 @@ public class SashimiPlot extends JFrame implements IGVEventObserver {
             menu.add(minusStrand);
             menu.addSeparator();
 
-            menu.add(saveImageItem);
+            menu.add(savePngImageItem);
+            menu.add(saveSvgImageItem);
 
             return menu;
         }

--- a/src/main/java/org/broad/igv/ui/IGV.java
+++ b/src/main/java/org/broad/igv/ui/IGV.java
@@ -671,14 +671,16 @@ public class IGV implements IGVEventObserver {
     }
 
 
-    final public void saveImage(Component target) {
-        saveImage(target, "igv_snapshot");
+    final public void saveImage(Component target, String extension) {
+        saveImage(target, "igv_snapshot", extension);
     }
 
-    final public void saveImage(Component target, String title) {
-        contentPane.getStatusBar().setMessage("Creating image...");
-        File defaultFile = new File(title + ".png");
-        createSnapshot(target, defaultFile);
+    final public void saveImage(Component target, String title, String extension) {
+        if ("png".equalsIgnoreCase(extension) || "svg".equalsIgnoreCase(extension)) {
+            contentPane.getStatusBar().setMessage("Creating image...");
+            File defaultFile = new File(title + "." + extension);
+            createSnapshot(target, defaultFile);
+        }
     }
 
     final public void createSnapshot(final Component target, final File defaultFile) {

--- a/src/main/java/org/broad/igv/ui/IGVMenuBar.java
+++ b/src/main/java/org/broad/igv/ui/IGVMenuBar.java
@@ -36,7 +36,6 @@ import org.broad.igv.event.GenomeChangeEvent;
 import org.broad.igv.event.IGVEventBus;
 import org.broad.igv.event.IGVEventObserver;
 import org.broad.igv.feature.genome.GenomeManager;
-import org.broad.igv.ui.commandbar.RemoveGenomesDialog;
 import org.broad.igv.google.GoogleUtils;
 import org.broad.igv.google.OAuthProvider;
 import org.broad.igv.google.OAuthUtils;
@@ -47,6 +46,7 @@ import org.broad.igv.tools.motiffinder.MotifFinderPlugin;
 import org.broad.igv.track.CombinedDataSourceDialog;
 import org.broad.igv.ui.action.*;
 import org.broad.igv.ui.commandbar.GenomeComboBox;
+import org.broad.igv.ui.commandbar.RemoveGenomesDialog;
 import org.broad.igv.ui.legend.LegendDialog;
 import org.broad.igv.ui.panel.FrameManager;
 import org.broad.igv.ui.panel.MainPanel;
@@ -336,15 +336,27 @@ public class IGVMenuBar extends JMenuBar implements IGVEventObserver {
         // ***** Snapshots
         // Snapshot Application
         menuAction =
-                new MenuAction("Save Image ...", null, KeyEvent.VK_A) {
+                new MenuAction("Save PNG Image ...", null, KeyEvent.VK_A) {
                     @Override
                     public void actionPerformed(ActionEvent e) {
-                        igv.saveImage(igv.getMainPanel());
+                        igv.saveImage(igv.getMainPanel(), "png");
 
                     }
                 };
 
-        menuAction.setToolTipText(SAVE_IMAGE_TOOLTIP);
+        menuAction.setToolTipText(SAVE_PNG_IMAGE_TOOLTIP);
+        menuItems.add(MenuAndToolbarUtils.createMenuItem(menuAction));
+
+        menuAction =
+                new MenuAction("Save SVG Image ...", null) {
+                    @Override
+                    public void actionPerformed(ActionEvent e) {
+                        igv.saveImage(igv.getMainPanel(), "svg");
+
+                    }
+                };
+
+        menuAction.setToolTipText(SAVE_SVG_IMAGE_TOOLTIP);
         menuItems.add(MenuAndToolbarUtils.createMenuItem(menuAction));
 
         // TODO -- change "Exit" to "Close" for BioClipse
@@ -880,11 +892,23 @@ public class IGVMenuBar extends JMenuBar implements IGVEventObserver {
 
         // Save entire window
         menuAction =
-                new MenuAction("Save Screenshot ...", null, KeyEvent.VK_A) {
+                new MenuAction("Save PNG Screenshot ...", null, KeyEvent.VK_A) {
 
                     @Override
                     public void actionPerformed(ActionEvent e) {
-                        IGV.getInstance().saveImage(IGV.getInstance().getContentPane());
+                        IGV.getInstance().saveImage(IGV.getInstance().getContentPane(), "png");
+
+                    }
+                };
+
+        menuItems.add(MenuAndToolbarUtils.createMenuItem(menuAction));
+
+        menuAction =
+                new MenuAction("Save SVG Screenshot ...", null) {
+
+                    @Override
+                    public void actionPerformed(ActionEvent e) {
+                        IGV.getInstance().saveImage(IGV.getInstance().getContentPane(), "svg");
 
                     }
                 };

--- a/src/main/java/org/broad/igv/ui/UIConstants.java
+++ b/src/main/java/org/broad/igv/ui/UIConstants.java
@@ -50,7 +50,8 @@ public class UIConstants {
     // Menu tooltips
     static final public String LOAD_TRACKS_TOOLTIP = "Load tracks or sample information";
     static final public String LOAD_SERVER_DATA_TOOLTIP = "Load tracks or sample information from a server";
-    static final public String SAVE_IMAGE_TOOLTIP = "Capture and save an image";
+    static final public String SAVE_PNG_IMAGE_TOOLTIP = "Capture and save a PNG image";
+    static final public String SAVE_SVG_IMAGE_TOOLTIP = "Capture and save an SVG image";
     static final public String NEW_SESSION_TOOLTIP = "Create a new session";
     static final public String SAVE_SESSION_TOOLTIP = "Save the current session";
     static final public String OPEN_SESSION_TOOLTIP = "Load a session";

--- a/src/main/java/org/broad/igv/ui/panel/TrackPanelComponent.java
+++ b/src/main/java/org/broad/igv/ui/panel/TrackPanelComponent.java
@@ -214,11 +214,14 @@ abstract public class TrackPanelComponent extends JPanel {
 
             TrackMenuUtils.addPluginItems(menu, selectedTracks, te);
 
-            // Add saveImage
+            // Add saveImage items
             menu.addSeparator();
-            JMenuItem item = new JMenuItem("Save image...");
-            item.addActionListener(e1 -> saveImage());
-            menu.add(item);
+            JMenuItem savePng = new JMenuItem("Save PNG image...");
+            savePng.addActionListener(e1 -> saveImage("png"));
+            menu.add(savePng);
+            JMenuItem saveSvg = new JMenuItem("Save SVG image...");
+            saveSvg.addActionListener(e1 -> saveImage("svg"));
+            menu.add(saveSvg);
 
             // Add export features
             ReferenceFrame frame = FrameManager.getDefaultFrame();
@@ -274,8 +277,8 @@ abstract public class TrackPanelComponent extends JPanel {
     }
 
 
-    public void saveImage() {
-        IGV.getInstance().saveImage(getTrackPanel().getScrollPane(), "igv_panel");
+    public void saveImage(String extension) {
+        IGV.getInstance().saveImage(getTrackPanel().getScrollPane(), "igv_panel", extension);
     }
 
 


### PR DESCRIPTION
Dedicated menu items for saving as SVG vs PNG.  This just sets the desired extension on the default file, it does not 
actually force the use of it through that workflow or auto-correct it if it's not set.  There's nothing to prevent a user from changing or removing the extension on their own.

That is, using "Save SVG Image" but changing the file to "my_track.png" will still save as PNG.

Note: I have not assigned a File Menu hotkey for the SVG option.