### PR TITLE
Changed ToolTip text for better Windows high-contrast support

### DIFF
--- a/src/main/java/org/broad/igv/track/AbstractTrack.java
+++ b/src/main/java/org/broad/igv/track/AbstractTrack.java
@@ -578,6 +578,9 @@ public abstract class AbstractTrack implements Track {
         String popupText = getValueStringAt(frame.getChrName(), e.getChromosomePosition(), e.getMouseEvent().getX(), e.getMouseEvent().getY(), frame);
 
         if (popupText != null) {
+            Color color = IGV.getRootPane().getJMenuBar().getForeground();
+            String htmlColor = String.format("#%02x%02x%02x", color.getRed(), color.getGreen(), color.getBlue()); 
+            popupText = "<div style=\"color: " + htmlColor + "\">" + popupText + "</div>";
 
             final TooltipTextFrame tf = new TooltipTextFrame(getName(), popupText);
             Point p = me.getComponent().getLocationOnScreen();


### PR DESCRIPTION
For some reason, this widget does not have its foreground (text) color
appropriately set in high-contrast mode on Windows, and potentially
other situations as well.
The fix is to pick up the proper color from a widget that *does* change
appropriately, then wrap the text content in a <div> to set that color
explicitly.