### PR TITLE
Gradle 7.0 compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@
 // THE SOFTWARE.
 
 apply plugin: 'java'
-apply plugin: 'maven'
+apply plugin: 'maven-publish'
 apply plugin: 'application'
 
 import org.apache.tools.ant.filters.ReplaceTokens


### PR DESCRIPTION
https://docs.gradle.org/7.0/userguide/upgrading_version_6.html#removal_of_the_legacy_maven_plugin

Otherwise:

```
(base) rvalls@m1 igv % gradle run
Starting a Gradle Daemon (subsequent builds will be faster)

FAILURE: Build failed with an exception.

* Where:
Build file '/Users/rvalls/dev/umccr/igv/build.gradle' line: 25

* What went wrong:
A problem occurred evaluating root project 'igv'.
> Plugin with id 'maven' not found.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 9s
```