### PR TITLE
CommandExecutor.load should report errors to the client instead of throwing java.lang.Error

### DIFF
--- a/src/main/java/org/broad/igv/batch/CommandExecutor.java
+++ b/src/main/java/org/broad/igv/batch/CommandExecutor.java
@@ -723,7 +723,7 @@ public class CommandExecutor {
             return "Error: If file is a comma-separated list, index must also be a comma-separated list of the same length";
         }
         if (isDataURL && formatString == null) {
-            throw new Error("ERROR: format must be specified for dataURLs");
+            return "Error: format must be specified for dataURLs";
         }
 
         // Fix formats -- backward compatibility
@@ -766,7 +766,7 @@ public class CommandExecutor {
             }
 
             if (isDataURL && formats == null) {
-                throw new Error("ERROR: format must be specified for dataURLs");
+                return "Error: format must be specified for dataURLs";
             }
 
             // Skip already loaded files TODO -- make this optional?  Check for change?
@@ -801,7 +801,7 @@ public class CommandExecutor {
                 if (!isDataURL && rl.isLocal()) {
                     File file = new File(rl.getPath());
                     if (!file.exists()) {
-                        throw new Error("Error: " + f + " does not exist.");
+                        return "Error: " + f + " does not exist.";
                     }
                 }
                 fileLocators.add(rl);


### PR DESCRIPTION
IGV 2.10.0 has some changes to support data URLs. Some changes were necessary to the error handling and ever since certain error conditions result in a java.lang.Error being raised. This type of Throwable is never caught and will leave the client waiting for a
response indefinitely. As java.langError is reserved for unrecoverable errors the raise statements are replaced by return statements (similar to how the rest of the error handling is performed).