### PR TITLE
WIP: basic functionality if access keys are available

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -123,7 +123,9 @@ dependencies {
             // Amazon deps
             [group: 'software.amazon.awssdk', name: 'cognitoidentity', version: '2.16.7'],
             [group: 'software.amazon.awssdk', name: 'sts', version: '2.16.7'],
-            [group: 'software.amazon.awssdk', name: 's3', version: '2.16.7']
+            [group: 'software.amazon.awssdk', name: 's3', version: '2.16.7'],
+            [group: 'software.amazon.awssdk', name: 'auth', version: '2.16.7'],
+            [group: 'software.amazon.awssdk', name: 'profiles', version: '2.16.7']
     )
 
     testImplementation(

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -36,4 +36,5 @@ module org.igv {
     requires software.amazon.awssdk.http;
     requires software.amazon.awssdk.utils;
     requires com.fasterxml.jackson.core;
+    requires software.amazon.awssdk.profiles;
 }

--- a/src/main/java/org/broad/igv/prefs/IGVPreferences.java
+++ b/src/main/java/org/broad/igv/prefs/IGVPreferences.java
@@ -53,12 +53,15 @@ import java.io.PrintWriter;
 import java.util.*;
 
 import static org.broad.igv.prefs.Constants.*;
+import static software.amazon.awssdk.profiles.ProfileProperty.AWS_ACCESS_KEY_ID;
+import static software.amazon.awssdk.profiles.ProfileProperty.AWS_SECRET_ACCESS_KEY;
 
 /**
  * Manages user preferences.
  */
 public class IGVPreferences {
 
+    private static final String AWS_REGION = "aws_region";
     private static Logger log = LogManager.getLogger(IGVPreferences.class);
 
     IGVPreferences parent;
@@ -403,6 +406,18 @@ public class IGVPreferences {
 
     public String getProvisioningURL() {
         return get(PROVISIONING_URL);
+    }
+
+    public String getAWSAccessKeyId() {
+        return get(AWS_ACCESS_KEY_ID);
+    }
+
+    public String getAWSSecretAccessKey() {
+        return get(AWS_SECRET_ACCESS_KEY);
+    }
+
+    public String getAWSRegion(){
+        return get(AWS_REGION);
     }
 
     public String getPortNumber() {

--- a/src/main/java/org/broad/igv/track/TrackLoader.java
+++ b/src/main/java/org/broad/igv/track/TrackLoader.java
@@ -117,7 +117,7 @@ public class TrackLoader {
         final String path = locator.getPath().trim();
 
         // Check if the AWS credentials are still valid. If not, re-login and renew pre-signed urls
-        if (AmazonUtils.isAwsS3Path(path)) {
+        if (AmazonUtils.isAwsS3Path(path) && !AmazonUtils.accessKeyAuthorisationPresent()) {
             AmazonUtils.checkLogin();
         }
 

--- a/src/main/java/org/broad/igv/ui/action/LoadFromURLMenuAction.java
+++ b/src/main/java/org/broad/igv/ui/action/LoadFromURLMenuAction.java
@@ -181,6 +181,9 @@ public class LoadFromURLMenuAction extends MenuAction {
             if (AmazonUtils.isAwsS3Path(url)) {
                 String bucket = AmazonUtils.getBucketFromS3URL(url);
                 String key = AmazonUtils.getKeyFromS3URL(url);
+                if (AmazonUtils.accessKeyAuthorisationPresent()) {
+                    AmazonUtils.updateS3Client(null);
+                }
                 AmazonUtils.s3ObjectAccessResult res = isObjectAccessible(bucket, key);
                 if (!res.isObjectAvailable()) {
                     MessageUtils.showErrorMessage(res.getErrorReason(), null);

--- a/src/main/resources/org/broad/igv/prefs/preferences.tab
+++ b/src/main/resources/org/broad/igv/prefs/preferences.tab
@@ -200,7 +200,10 @@ MASTER_RESOURCE_FILE_KEY	Data registry url	string	https://data.broadinstitute.or
 ---
 PROVISIONING.URL	OAuth provisioning URL	string	null
 ---
-
+aws_access_key_id	AWS access key id	string	null
+aws_secret_access_key	AWS secret access key	string	null
+aws_region	AWS region	string	null
+---
 BLAT_URL	Blat url	String	http://genome.ucsc.edu/cgi-bin/hgBlat?userSeq=$SEQUENCE&type=DNA&db=$DB&output=json
 ---
 


### PR DESCRIPTION
Hi,

I hope we can discuss on this PR based on comments here https://github.com/igvteam/igv/issues/1093

My background is AWS Architect Professional, Devops, Linux admin type of guy. I don't have Java experience. But I am in the business for 10+ years and "know my way around".

For this pull request I have hired Java dev proffesional to help me do a proof of concept.

**If any contributor is interested, I would very much like to pay for this feature/request**

I will try to describe use case for this feature.

Lets say a **Space Genomics** company has many bioinformaticians and reporters that are using IGV on a day to day basis.

- Reporters are interpreting data that is located in S3 buckets.
- Reporters are opening IGV app from a third party software which lists all the samples and provides "quick link" to open IGV with appropriate file location automatically (this already works)

Lets make assumption that S3 files are public. Based on this assumption IGV can open files using standard HTTPS protocol. IGV can be used sucessfully.

But what if **Space Genomics** company uses **private** S3 storage encrypted at rest?
We need to **sign** S3 urls before opening file location in IGV. This also is not such a big deal. We can make functionality in a third party application to sign the URL before opening.

But now reporter wants to share a session with someone. And the session can be opened after couple of days.
Signed URLs will expire. In addition to that, **Space Genomics** will sign URL based on **source ip**, in this case other reporters cannot open the session file since signed url won't work for them.

In **Space Genomics** company reporters log in to their workstations and Windows administrators automated workspace setup after logging in. Each time reporter logs into their account Windows will obtain and set system wide environment variables, among these variables we will have AWS variables set which adhere to AWS Java SDK requirements.

This way we can seamlessly enable reportes to open S3 urls without URL signing and without using Cognito > oAuth authentication/authorization.

In addition to this, we provide **Preferences** menu option to manually input acess_key/secret_access_key combination if a reporter wants or has custom aws keys which one can use to get the S3 object.

I hope this makes sense and is worth to check out and discuss on the pull request.

**EDIT:** I have to write additional notes.
Use case I described is fictional, but I work for bio-informatics company (1000+ employees) where this basic feature would be a life saver for multiple departments. Devops, Networking, Security and Geneticists/Reporters.

IGV should be able to load **both** HTTPS and S3 urls without going AWS Cognito route. AWS Cognito is a nice to have feature. But basic functionality to enable "native cloud api" access is "common sense" so to speak.

P.S. No harsh language or tone intended, I am not a native English speaker especially not a writer :)
