### PR TITLE
option in preferences to enable paired end mode by default

### DIFF
--- a/src/main/java/org/broad/igv/prefs/Constants.java
+++ b/src/main/java/org/broad/igv/prefs/Constants.java
@@ -168,6 +168,7 @@ final public class Constants {
     public static final String SAM_COLOR_G = "SAM.COLOR.G";
     public static final String SAM_COLOR_N = "SAM.COLOR.N";
     public static final String SAM_DISPLAY_MODE = "SAM.DISPLAY_MODE";
+    public static final String SAM_DISPLAY_PAIRED = "SAM.DISPLAY_PAIRED";
     public static final String KNOWN_SNPS = "KNOWN_SNPS_FILE";
 
     // Sequence track settings

--- a/src/main/java/org/broad/igv/sam/AlignmentTrack.java
+++ b/src/main/java/org/broad/igv/sam/AlignmentTrack.java
@@ -271,6 +271,8 @@ public class AlignmentTrack extends AbstractTrack implements IGVEventObserver {
         readNamePalette = new PaletteColorTable(ColorUtilities.getDefaultPalette());
         insertionIntervalsMap = Collections.synchronizedMap(new HashMap<>());
 
+        dataManager.setViewAsPairs(prefs.getAsBoolean(SAM_DISPLAY_PAIRED), renderOptions);
+
         IGVEventBus.getInstance().subscribe(FrameManager.ChangeEvent.class, this);
         IGVEventBus.getInstance().subscribe(AlignmentTrackEvent.class, this);
     }

--- a/src/main/resources/org/broad/igv/prefs/preferences.tab
+++ b/src/main/resources/org/broad/igv/prefs/preferences.tab
@@ -90,6 +90,7 @@ SAM.MAX_VISIBLE_RANGE	Visibility range threshold (kb)	float	30	Range at which al
 SAM.QUALITY_THRESHOLD	Mapping quality threshold	int	0
 SAM.ALIGNMENT_SCORE_THRESHOLD	Alignment score threshold	int	0
 SAM.DISPLAY_MODE	Alignment display mode	string	EXPANDED
+SAM.DISPLAY_PAIRED	Display reads as paired by default	boolean	FALSE
 ---
 SAM.SHOW_MISMATCHES	Show mismatched bases	boolean	TRUE
 SAM.SHOW_ALL_BASES	Show all bases	boolean	FALSE


### PR DESCRIPTION
This change adds an option in preferences so that alignments are loaded with the "View as pairs" option enabled by default.

While it's a minor change, it's a huge a time saver when you have a lot of different files to review, and the paired end signal is important (eg: structural variants). Before this change, I have to laboriously right click and select "View as pairs" on each of my alignment tracks before I can start. With this change, I can enable that as the default in settings so that all files are loaded that way by default.

Since there are only two options, I just made this a checkbox:

<img width="730" alt="image" src="https://user-images.githubusercontent.com/138868/173235142-4e6beac8-b5ab-4418-90fd-109f7610b721.png">

