### PR TITLE
Update to htsjdk 3.0.0 which includes support for CRAM reference regions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -111,7 +111,7 @@ dependencies {
             [group: 'org.xerial.snappy', name: 'snappy-java', version: '1.1.7.3'],
             [group: 'org.apache.commons', name: 'commons-jexl', version: '2.1.1'],
             [group: 'org.apache.commons', name: 'commons-lang3', version: '3.9'],
-            [group: 'com.github.samtools', name: 'htsjdk', version: '2.24.1'],
+            [group: 'com.github.samtools', name: 'htsjdk', version: '3.0.0'],
             [group: 'org.swinglabs', name: 'swing-layout', version: '1.0.3'],
             //[group: 'org.bidib.com.jidesoft', name: 'jide-common', version: '3.7.3'],  // no longer in Maven Central
             [group: 'com.google.guava', name: 'guava', version: '27.0.1-jre'],

--- a/src/main/java/org/broad/igv/sam/cram/IGVReferenceSource.java
+++ b/src/main/java/org/broad/igv/sam/cram/IGVReferenceSource.java
@@ -50,120 +50,23 @@ public class IGVReferenceSource implements CRAMReferenceSource {
 
     private static Logger log = LogManager.getLogger(IGVReferenceSource.class);
 
-    static ObjectCache<String, byte[]> cachedSequences = new ObjectCache<>(5);
-
-    static GenomeChangeListener genomeChangeListener;
-
-    static HashMap<String, Object> locks = new HashMap<>();
-
     @Override
     public byte[] getReferenceBases(SAMSequenceRecord record, boolean tryNameVariants) {
+        return getReferenceBasesByRegion(record, 0,  record.getSequenceLength());
+    }
 
-        final String name = record.getSequenceName();
+    @Override
+    public byte[] getReferenceBasesByRegion(final SAMSequenceRecord sequenceRecord, final int zeroBasedStart, final int requestedRegionLength) {
+        final String name = sequenceRecord.getSequenceName();
         final Genome currentGenome = GenomeManager.getInstance().getCurrentGenome();
         String chrName = currentGenome.getCanonicalChrName(name);
-        Chromosome chromosome = currentGenome.getChromosome(chrName);
+        byte[] bases = currentGenome.getSequence(chrName, zeroBasedStart, zeroBasedStart + requestedRegionLength, true);
 
-        byte[] bases = cachedSequences.get(chrName);
-
-        if (bases == null) {
-            try {
-                Object lock = getLock(chrName);
-
-                synchronized (lock) {
-
-                    if (IGV.hasInstance()) IGV.getInstance().setStatusBarMessage("Loading sequence");
-                    bases = currentGenome.getSequence(chrName, 0, chromosome.getLength(), false);
-
-                    // CRAM spec requires upper case
-                    for (int i = 0; i < bases.length; i++) {
-                        if (bases[i] >= 97) bases[i] -= 32;
-                    }
-
-                    cachedSequences.put(chrName, bases);
-                }
-            } finally {
-                if (IGV.hasInstance()) IGV.getInstance().setStatusBarMessage("");
-            }
+        // CRAM spec requires upper case
+        for (int i = 0; i < bases.length; i++) {
+            if (bases[i] >= 97) bases[i] -= 32;
         }
-
         return bases;
     }
 
-    static synchronized Object getLock(String chr) {
-        Object lock = locks.get(chr);
-        if (lock == null) {
-            lock = new Object();
-            locks.put(chr, lock);
-        }
-        return lock;
-    }
-
-    public static class GenomeChangeListener implements IGVEventObserver {
-        @Override
-        public void receiveEvent(Object event) {
-            cachedSequences.clear();
-        }
-    }
-
-    static {
-        genomeChangeListener = new GenomeChangeListener();
-        IGVEventBus.getInstance().subscribe(GenomeChangeEvent.class, genomeChangeListener);
-    }
 }
-
-
-// Idea below was to compress the sequences to keep more in memory.  Unfortunately compressing takes a long time.
-//    static class SequenceCache {
-//
-//        Map<String, byte[]> compressedSequences = new HashMap<>();
-//        Map<String, Integer> decompressedSizes = new HashMap<>();
-//
-//        void put(String chr, byte [] sequence) {
-//            Deflater d = new Deflater();
-//            byte [] buffer = new byte[sequence.length];
-//            d.setInput(sequence);
-//            d.finish();
-//            int size = d.deflate(buffer);
-//            byte [] output = new byte[size];
-//            System.arraycopy(buffer, 0, output, 0, size);
-//   System.out.println("Decompressed size: "  + size +  "   (" + ((size * 100.0) / sequence.length) + "%)");
-//            compressedSequences.put(chr, output);
-//            decompressedSizes.put(chr, sequence.length);
-//        }
-//
-//        byte [] get(String chr) {
-//
-//            byte [] compressed = compressedSequences.get(chr);
-//            Integer size = decompressedSizes.get(chr);
-//            if(compressed == null ) {
-//                return null;
-//            }
-//            if(size == null) {
-//                // Should not get here, but just in case free compressed sequence memory
-//                compressedSequences.put(chr, null);
-//                return null;
-//            }
-//
-//            byte [] sequence = new byte[size];
-//            Inflater inflater = new Inflater();
-//            inflater.setInput(compressed);
-//            try {
-//                inflater.inflate(sequence);
-//                inflater.end();
-//                return sequence;
-//            } catch (DataFormatException e) {
-//                decompressedSizes.put(chr, null);
-//                decompressedSizes.put(chr, null);
-//                return null;
-//            }
-//        }
-//
-//
-//        void clear() {
-//            compressedSequences.clear();
-//            decompressedSizes.clear();
-//        }
-//
-//
-//    }


### PR DESCRIPTION
@jrobinso This removes the long wait when loading a cram contig initially.  I thought it added slight scrolling delay when jumping along the contig but with further testing I'm not seeing it anymore and the profiler doesn't show anything significant.  I think my first testing was using different zoom levels by accident so I was seeing read loading lag on one and not the other.  

I removed all the complex code associated with loading the full contig under the assumption that htsjdk is never going to call them method in the CRAM use case.  Does IGV ever write cram files?  

I could replace the original with an UnsupportedOperationException instead so we would know if it ever gets called by accident, or keep the complex caching logic in place, although that seems bad.

