### PR TITLE
Fix searching for TDF file when url has a query string

### DIFF
--- a/src/main/java/org/broad/igv/track/TrackLoader.java
+++ b/src/main/java/org/broad/igv/track/TrackLoader.java
@@ -952,7 +952,7 @@ public class TrackLoader {
                                 path.contains("dataformat=.bam") ||
                                 path.contains("/query.cgi?");
                 if (!bypassFileAutoDiscovery) {
-                    covPath = path + ".tdf";
+                    covPath = ResourceLocator.appendToPath(locator, ".tdf");
                 }
             }
 

--- a/src/main/java/org/broad/igv/util/ResourceLocator.java
+++ b/src/main/java/org/broad/igv/util/ResourceLocator.java
@@ -531,20 +531,20 @@ public class ResourceLocator {
 
 
     /**
-     * Add the {@code indexExtension} to the path in locator, preserving
+     * Add the {@code extension} to the path in locator, preserving
      * query string elements if present
      *
      * @param locator
-     * @param indexExtension
+     * @param extension
      * @return
      */
-    public static String appendToPath(ResourceLocator locator, String indexExtension) {
-        String indexFile = locator.getURLPath() + indexExtension;
+    public static String appendToPath(ResourceLocator locator, String extension) {
+        String extendedPath = locator.getURLPath() + extension;
         String qs = locator.getURLQueryString();
         if (qs != null && qs.length() > 0) {
-            indexFile += "?" + qs;
+            extendedPath += "?" + qs;
         }
-        return indexFile;
+        return extendedPath;
     }
 
     /**


### PR DESCRIPTION
* Correctly append ".tdf" to a url when there is a query string
* Fixes https://github.com/igvteam/igv/issues/1168

@jrobinso I'm pretty sure this fixes the problem but I'm not sure how to test it.  