### PR TITLE
Adding an option to reverse the order when sorting.

### DIFF
--- a/src/main/java/org/broad/igv/batch/CommandExecutor.java
+++ b/src/main/java/org/broad/igv/batch/CommandExecutor.java
@@ -829,7 +829,7 @@ public class CommandExecutor {
 
         if (sort != null) {
             final AlignmentTrack.SortOption sortOption = getAlignmentSortOption(sort);
-            igv.sortAlignmentTracks(sortOption, sortTag);
+            igv.sortAlignmentTracks(sortOption, sortTag, false);
         }
 
         return CommandListener.OK;
@@ -1061,7 +1061,7 @@ public class CommandExecutor {
                     }
                 }
             }
-            igv.sortAlignmentTracks(getAlignmentSortOption(sortArg), location, tag);
+            igv.sortAlignmentTracks(getAlignmentSortOption(sortArg), location, tag, false);
             return "OK";
         }
     }
@@ -1170,6 +1170,7 @@ public class CommandExecutor {
         }
     }
 
+    //todo check that this matches all the existing sorts
     private static AlignmentTrack.SortOption getAlignmentSortOption(String str) {
         str = str == null ? "base" : str;
         if (str.equalsIgnoreCase("start") || str.equalsIgnoreCase("position")) {

--- a/src/main/java/org/broad/igv/prefs/Constants.java
+++ b/src/main/java/org/broad/igv/prefs/Constants.java
@@ -137,6 +137,7 @@ final public class Constants {
     public static final String SAM_SAMPLING_WINDOW = "SAM.SAMPLING_WINDOW";
     public static final String SAM_DOWNSAMPLE_READS = "SAM.DOWNSAMPLE_READS";
     public static final String SAM_SORT_OPTION = "SAM.SORT_OPTION";
+    public static final String SAM_INVERT_SORT = "SAM.INVERT_SORT";
     public static final String SAM_GROUP_OPTION = "SAM.GROUP_OPTION";
     public static final String SAM_SHOW_ALL_BASES = "SAM.SHOW_ALL_BASES";
     public static final String SAM_SHOW_MISMATCHES = "SAM.SHOW_MISMATCHES";

--- a/src/main/java/org/broad/igv/sam/AlignmentDataManager.java
+++ b/src/main/java/org/broad/igv/sam/AlignmentDataManager.java
@@ -35,7 +35,6 @@ import org.broad.igv.feature.Range;
 import org.broad.igv.feature.genome.Genome;
 import org.broad.igv.prefs.IGVPreferences;
 import org.broad.igv.prefs.PreferencesManager;
-import org.broad.igv.sam.AlignmentTrack.SortOption;
 import org.broad.igv.sam.reader.AlignmentReader;
 import org.broad.igv.sam.reader.AlignmentReaderFactory;
 import org.broad.igv.track.Track;
@@ -270,33 +269,6 @@ public class AlignmentDataManager implements IGVEventObserver {
             }
         }
         return null;
-    }
-
-    /**
-     * Sort rows group by group
-     *
-     * @param option
-     * @param location
-     */
-    public boolean sortRows(SortOption option, ReferenceFrame frame, double location, String tag) {
-
-        AlignmentInterval interval = getLoadedInterval(frame);
-        if (interval == null) {
-            return false;
-        } else {
-            PackedAlignments packedAlignments = interval.getPackedAlignments();
-            if (packedAlignments == null) {
-                return false;
-            }
-
-            for (List<Row> alignmentRows : packedAlignments.values()) {
-                for (Row row : alignmentRows) {
-                    row.updateScore(option, location, interval, tag);
-                }
-                Collections.sort(alignmentRows, (o1, o2) -> (int) Math.signum(o1.getScore() - o2.getScore()));
-            }
-            return true;
-        }
     }
 
     public void setViewAsPairs(boolean option, AlignmentTrack.RenderOptions renderOptions) {

--- a/src/main/java/org/broad/igv/sam/AlignmentInterval.java
+++ b/src/main/java/org/broad/igv/sam/AlignmentInterval.java
@@ -97,6 +97,31 @@ public class AlignmentInterval extends Locus {
         return null;
     }
 
+    /**
+     * Sort rows group by group
+     *  @param option
+     * @param location
+     */
+    public void sortRows(AlignmentTrack.SortOption option, double location, String tag, boolean invertSort) {
+
+        PackedAlignments packedAlignments = getPackedAlignments();
+        if (packedAlignments == null) {
+            return;
+        }
+
+        Comparator<Row> rowComparator = (o1, o2) -> (int) Math.signum(o1.getScore() - o2.getScore());
+        if(invertSort){
+            rowComparator = rowComparator.reversed();
+        }
+
+        for (List<Row> alignmentRows : packedAlignments.values()) {
+            for (Row row : alignmentRows) {
+                row.updateScore(option, location, this, tag);
+            }
+            alignmentRows.sort(rowComparator);
+        }
+    }
+
     public byte getReference(int pos) {
         if (genome == null) {
             return 0;

--- a/src/main/java/org/broad/igv/ui/GlobalKeyDispatcher.java
+++ b/src/main/java/org/broad/igv/ui/GlobalKeyDispatcher.java
@@ -53,12 +53,9 @@ import javax.swing.text.JTextComponent;
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.KeyEvent;
-import java.awt.event.KeyListener;
 import java.io.IOException;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import static org.broad.igv.prefs.Constants.*;
 
@@ -257,7 +254,7 @@ public class GlobalKeyDispatcher implements KeyEventDispatcher {
                     try {
                         AlignmentTrack.SortOption option = AlignmentTrack.SortOption.valueOf(sortOptionString);
                         String lastSortTag = prefMgr.get(SAM_SORT_BY_TAG);
-                        igv.sortAlignmentTracks(option, lastSortTag);
+                        igv.sortAlignmentTracks(option, lastSortTag, prefMgr.getAsBoolean(SAM_INVERT_SORT));
                     } catch (IllegalArgumentException e1) {
                         log.error("Unrecognized sort option: " + sortOptionString);
                     }

--- a/src/main/java/org/broad/igv/ui/IGV.java
+++ b/src/main/java/org/broad/igv/ui/IGV.java
@@ -48,11 +48,9 @@ import org.broad.igv.feature.Range;
 import org.broad.igv.feature.RegionOfInterest;
 import org.broad.igv.feature.Strand;
 import org.broad.igv.feature.genome.*;
-import org.broad.igv.jbrowse.CircularViewUtilities;
 import org.broad.igv.lists.GeneList;
 import org.broad.igv.logging.LogManager;
 import org.broad.igv.logging.Logger;
-import org.broad.igv.prefs.Constants;
 import org.broad.igv.prefs.IGVPreferences;
 import org.broad.igv.prefs.PreferencesEditor;
 import org.broad.igv.prefs.PreferencesManager;
@@ -1378,21 +1376,16 @@ public class IGV implements IGVEventObserver {
     }
 
 
-    public void sortAlignmentTracks(AlignmentTrack.SortOption option, String tag) {
-        sortAlignmentTracks(option, null, tag);
+    public void sortAlignmentTracks(AlignmentTrack.SortOption option, String tag, final boolean invertSort) {
+        sortAlignmentTracks(option, null, tag, invertSort);
     }
 
-    public void sortAlignmentTracks(AlignmentTrack.SortOption option, Double location, String tag) {
-        double actloc;
-        List<Track> alignmentTracks = getAllTracks().stream()
+    public void sortAlignmentTracks(AlignmentTrack.SortOption option, Double location, String tag, boolean invertSort) {
+        List<AlignmentTrack> alignmentTracks = getAllTracks().stream()
                 .filter(track -> track instanceof AlignmentTrack)
+                .map(track -> (AlignmentTrack)track)
+                .peek(track -> track.sortRows(option, location, tag, invertSort))
                 .collect(Collectors.toList());
-        for (Track t : alignmentTracks) {
-            for (ReferenceFrame frame : FrameManager.getFrames()) {
-                actloc = location != null ? location : frame.getCenter();
-                ((AlignmentTrack) t).sortRows(option, frame, actloc, tag);
-            }
-        }
         this.repaint(alignmentTracks);
     }
 


### PR DESCRIPTION
* Adding a new option to the sort menu which reverse Alignment sorting when enabled
* Some of the sorting methods were moved and restructured.
* An alternative to #1158

Sorting behavior should remain unchanged if the new option is not activated.
Selecting or unselecting "reverse sort" will trigger a new sort operation at the currently selected location.

2 new fields are saved into the session files, I'm not sure if this is the right approach.  Currently sorting is treated as a global action, initiating a sort sorts all tracks at the same time in the same way. Adding a per-track option to the session file potentially allows manually creating sessions with inconsistent sorting, although I don't think that's a problem in any practical way and might be useful in some extremely rare circumstances.  

Maybe there should be a different place to persist this sort of information.

Sorting is also not persisted in a session file, it might be a good idea to enable that although it seems a bit tricky.