### PR TITLE
fix NPE introduced in #1180

### DIFF
--- a/src/main/java/org/broad/igv/sam/AlignmentTrack.java
+++ b/src/main/java/org/broad/igv/sam/AlignmentTrack.java
@@ -2890,7 +2890,7 @@ public class AlignmentTrack extends AbstractTrack implements IGVEventObserver {
             if (groupByPos != null) {
                 element.setAttribute("groupByPos", groupByPos.toString());
             }
-            if(invertSorting) {
+            if(invertSorting != null) {
                 element.setAttribute("invertSorting", Boolean.toString(invertSorting));
             }
             if(sortOption != null){


### PR DESCRIPTION
* fix for an NPE introduced when saving a session that had a null value for invertSorting

@jrobinso I missed this in my testing.  It started a `boolean` and then I forgot to update this case when it because a `Boolean`