### PR TITLE
Add missing path information to variant track tooltip

### DIFF
--- a/src/main/java/org/broad/igv/variant/VariantTrack.java
+++ b/src/main/java/org/broad/igv/variant/VariantTrack.java
@@ -901,7 +901,7 @@ public class VariantTrack extends FeatureTrack implements IGVEventObserver {
 
     public String getNameValueString(int y) {
         if (y < top + getVariantBandHeight()) {
-            return getName();
+            return super.getNameValueString(y);
         } else {
             String sample = getSampleAtPosition(y);
             return sample;

--- a/src/main/java/org/broad/igv/variant/VariantTrack.java
+++ b/src/main/java/org/broad/igv/variant/VariantTrack.java
@@ -900,7 +900,7 @@ public class VariantTrack extends FeatureTrack implements IGVEventObserver {
     }
 
     public String getNameValueString(int y) {
-        if (y < top + getVariantBandHeight()) {
+        if (y < top + getVariantsHeight()) {
             return super.getNameValueString(y);
         } else {
             String sample = getSampleAtPosition(y);


### PR DESCRIPTION
This adds the track file path to the tooltip when mousing over a variant track name. 
It also fixes a bug which caused the tooltip to not trigger correctly when the variant track genotype header had multiple lines.

Relevant to #1176 but not a solution.  

ex:  
<img width="899" alt="Screen Shot 2022-08-15 at 6 08 09 PM" src="https://user-images.githubusercontent.com/4700332/184727155-ab634a2d-4bfc-4266-ba72-888dda7557df.png">

