### PR TITLE
JPasswordField (instead of JTextField) for password in proxy settings

### DIFF
--- a/src/main/java/org/broad/igv/prefs/PreferencesEditor.java
+++ b/src/main/java/org/broad/igv/prefs/PreferencesEditor.java
@@ -223,27 +223,27 @@ public class PreferencesEditor {
                         if (pref.getKey().equals(Constants.PROXY_PW) && fieldText != null && fieldText.length() > 0) {
                             fieldText = Utilities.base64Decode(fieldText);
                         }
-                        JTextField field = new JTextField(fieldText);
-                        Dimension d = field.getPreferredSize();
+                        PreferencesTextField field = new PreferencesTextField(pref.getKey().equals(Constants.PROXY_PW) ? new JPasswordField(fieldText) : new JTextField(fieldText));
+                        Dimension d = field.get().getPreferredSize();
                         d.width = 300;
-                        field.setPreferredSize(d);
-                        field.setMaximumSize(d);
-                        field.addActionListener(event -> {
-                            String text = field.getText();
+                        field.get().setPreferredSize(d);
+                        field.get().setMaximumSize(d);
+                        field.get().addActionListener(event -> {
+                            String text = field.getPreferenceText();
                             if (validate(text, pref.getType())) {
                                 if (pref.getKey().equals(Constants.PROXY_PW)) {
                                     text = Utilities.base64Encode(text);
                                 }
                                 updatedPrefs.put(pref.getKey(), text);
                             } else {
-                                field.setText(preferences.get(pref.getKey()));
+                                field.get().setText(preferences.get(pref.getKey()));
                             }
                         });
-                        field.addFocusListener(new FocusAdapter() {
+                        field.get().addFocusListener(new FocusAdapter() {
                             @Override
                             public void focusLost(FocusEvent e) {
                                 // Validate and save the value if the Preference field loses focus
-                                String text = field.getText();
+                                String text = field.getPreferenceText();
                                 if (validate(text, pref.getType())) {
                                     // TODO -- make base64 an explicit type
                                     if (pref.getKey().equals(Constants.PROXY_PW)) {
@@ -251,19 +251,19 @@ public class PreferencesEditor {
                                     }
                                     updatedPrefs.put(pref.getKey(), text);
                                 } else {
-                                    field.setText(preferences.get(pref.getKey()));
+                                    field.get().setText(preferences.get(pref.getKey()));
                                 }
                             }
                         });
 
                         grid.addLayoutComponent(label, new GridBagConstraints(0, row, 1, 1, 0.0, 0.0, GridBagConstraints.WEST, GridBagConstraints.NONE, new Insets(3, 5, 2, 3), 2, 2));
-                        grid.addLayoutComponent(field, new GridBagConstraints(1, row, 1, 1, 1.0, 0.0, GridBagConstraints.WEST, GridBagConstraints.HORIZONTAL, new Insets(3, 2, 2, 5), 2, 2));
+                        grid.addLayoutComponent(field.get(), new GridBagConstraints(1, row, 1, 1, 1.0, 0.0, GridBagConstraints.WEST, GridBagConstraints.HORIZONTAL, new Insets(3, 2, 2, 5), 2, 2));
                         group.add(label);
-                        group.add(field);
+                        group.add(field.get());
 
                         if (pref.getComment() != null) {
                             label.setToolTipText(pref.getComment());
-                            field.setToolTipText(pref.getComment());
+                            field.get().setToolTipText(pref.getComment());
                         }
                     }
 

--- a/src/main/java/org/broad/igv/prefs/PreferencesTextField.java
+++ b/src/main/java/org/broad/igv/prefs/PreferencesTextField.java
@@ -1,0 +1,25 @@
+package org.broad.igv.prefs;
+
+import javax.swing.*;
+
+public class PreferencesTextField<T extends JTextField>{
+    T obj;
+    PreferencesTextField(T obj) {
+        this.obj = obj;
+    }
+    public String getPreferenceText() {
+        if (obj.getClass() == JTextField.class) {
+            JTextField f = (JTextField) obj;
+            return  f.getText();
+        }
+        if (obj.getClass() == JPasswordField.class) {
+            JPasswordField f = (JPasswordField) obj;
+            return String.valueOf(f.getPassword());
+        }
+        return "";
+    }
+
+    public T get() {
+        return this.obj;
+    }
+}


### PR DESCRIPTION
Currently in the Preferences the proxy password is displayed as a plain text (however, it is stored in the file in an encoded form, which is good). To me it looks like a security issue, since someone may accidentally see the password. This is why I am creating this PR. Please have a look.