### PR TITLE
Add feature threshold indicator to zoom widget

### DIFF
--- a/src/main/java/org/broad/igv/Globals.java
+++ b/src/main/java/org/broad/igv/Globals.java
@@ -26,9 +26,7 @@
 package org.broad.igv;
 
 import org.broad.igv.logging.*;
-import org.broad.igv.renderer.SequenceRenderer;
 
-import java.io.IOException;
 import java.text.DecimalFormat;
 import java.util.*;
 import java.util.List;
@@ -88,7 +86,6 @@ public class Globals {
     public static String VERSION;
     public static String BUILD;
     public static String TIMESTAMP;
-    public static double log2 = Math.log(2);
 
 
     final public static boolean IS_WINDOWS =
@@ -197,4 +194,7 @@ public class Globals {
         return curVersion.compareTo(minVersion) >= 0;
     }
 
+    public static double log2(final double value) {
+        return Math.log(value) / Math.log(2);
+    }
 }

--- a/src/main/java/org/broad/igv/data/seg/FreqData.java
+++ b/src/main/java/org/broad/igv/data/seg/FreqData.java
@@ -120,7 +120,7 @@ public class FreqData {
 
                     for (LocusScore seg : segments) {
                         final float segScore = logNormalized ? seg.getScore() :
-                                (float) (Math.log(seg.getScore() / 2) / Globals.log2);
+                                (float) (Globals.log2(seg.getScore() / 2));
 
                         if (segScore > ampThreshold || segScore < delThreshold) {
 

--- a/src/main/java/org/broad/igv/sam/AlignmentTrack.java
+++ b/src/main/java/org/broad/igv/sam/AlignmentTrack.java
@@ -506,10 +506,15 @@ public class AlignmentTrack extends AbstractTrack implements IGVEventObserver {
         dataManager.load(referenceFrame, renderOptions, true);
     }
 
+    @Override
+    public int getVisibilityWindow() {
+        return (int) dataManager.getVisibilityWindow();
+    }
+
     public void render(RenderContext context, Rectangle rect) {
 
         int viewWindowSize = context.getReferenceFrame().getCurrentRange().getLength();
-        if (viewWindowSize > dataManager.getVisibilityWindow()) {
+        if (viewWindowSize > getVisibilityWindow()) {
             Rectangle visibleRect = context.getVisibleRect().intersection(rect);
             Graphics2D g2 = context.getGraphic2DForColor(Color.gray);
             GraphicUtils.drawCenteredText("Zoom in to see alignments.", visibleRect, g2);

--- a/src/main/java/org/broad/igv/sam/CoverageTrack.java
+++ b/src/main/java/org/broad/igv/sam/CoverageTrack.java
@@ -214,10 +214,15 @@ public class CoverageTrack extends AbstractTrack implements ScalableTrack {
         setVisible(false);
     }
 
+    @Override
+    public int getVisibilityWindow() {
+        return (int) dataManager.getVisibilityWindow();
+    }
+
     public void render(RenderContext context, Rectangle rect) {
 
         int viewWindowSize = context.getReferenceFrame().getCurrentRange().getLength();
-        if (viewWindowSize > dataManager.getVisibilityWindow() && dataSource == null) {
+        if (viewWindowSize > getVisibilityWindow() && dataSource == null) {
             Rectangle visibleRect = context.getVisibleRect().intersection(rect);
             Graphics2D g = context.getGraphic2DForColor(Color.gray);
             GraphicUtils.drawCenteredText("Zoom in to see coverage.", visibleRect, g);

--- a/src/main/java/org/broad/igv/sashimi/SashimiJunctionRenderer.java
+++ b/src/main/java/org/broad/igv/sashimi/SashimiJunctionRenderer.java
@@ -362,7 +362,7 @@ public class SashimiJunctionRenderer extends IGVFeatureRenderer {
         int length = pixelJunctionEnd - pixelJunctionStart;
         int minArcHeight = (trackRectangle.height - 1) / 8;
         //We adjust the height slightly by length of junction, just so arcs don't overlap as much
-        int arcHeight = minArcHeight + (int) (Math.log(length) / Globals.log2);
+        int arcHeight = minArcHeight + (int) (Globals.log2(length));
 
         int minY = (int) trackRectangle.getCenterY() + Math.min(pixelYStartOffset - arcHeight, pixelYEndOffset - arcHeight);
         //Check if arc goes too high. All arcs going below have the same height,

--- a/src/main/java/org/broad/igv/tools/converters/ExpressionFormatter.java
+++ b/src/main/java/org/broad/igv/tools/converters/ExpressionFormatter.java
@@ -192,7 +192,7 @@ public class ExpressionFormatter {
                             throw new RuntimeException("Negative value detected in input file: " + line);
                         }
 
-                        double v = Math.log(data[dataIdx]) / Globals.log2;
+                        double v = Globals.log2(data[dataIdx]);
                         scaledData[dataIdx] = v;
                         nonNullData[nNonNull] = v;
                         nNonNull++;

--- a/src/main/java/org/broad/igv/track/AbstractTrack.java
+++ b/src/main/java/org/broad/igv/track/AbstractTrack.java
@@ -806,7 +806,7 @@ public abstract class AbstractTrack implements Track {
             double centerValue = (getTrackType() == TrackType.ALLELE_SPECIFIC_COPY_NUMBER)
                     ? 1.0 : 2.0;
 
-            return (float) (Math.log(Math.max(Float.MIN_VALUE, dataY) / centerValue) / Globals.log2);
+            return (float) (Globals.log2(Math.max(Float.MIN_VALUE, dataY) / centerValue));
         } else {
             return dataY;
         }

--- a/src/main/java/org/broad/igv/ui/panel/ReferenceFrame.java
+++ b/src/main/java/org/broad/igv/ui/panel/ReferenceFrame.java
@@ -498,7 +498,7 @@ public class ReferenceFrame {
 
     protected void calculateMaxZoom() {
         this.maxZoom = Globals.CHR_ALL.equals(this.chrName) ? 0 :
-                (int) Math.ceil(Math.log(getChromosomeLength() / minBP) / Globals.log2);
+                (int) Math.ceil(Globals.log2(getChromosomeLength() / minBP));
     }
 
     public String getChrName() {
@@ -715,7 +715,8 @@ public class ReferenceFrame {
      * @return
      */
     public int calculateZoom(double start, double end) {
-        return (int) Math.round((Math.log((getChromosomeLength() / (end - start)) * (((double) widthInPixels) / binsPerTile)) / Globals.log2));
+        final double windowLength = Math.min(end - start, getChromosomeLength());
+        return (int) Math.round(Globals.log2((getChromosomeLength() / windowLength) * (((double) widthInPixels) / binsPerTile)));
     }
 
 

--- a/src/main/java/org/broad/igv/ui/panel/ReferenceFrame.java
+++ b/src/main/java/org/broad/igv/ui/panel/ReferenceFrame.java
@@ -714,7 +714,7 @@ public class ReferenceFrame {
      * @param end
      * @return
      */
-    private int calculateZoom(double start, double end) {
+    public int calculateZoom(double start, double end) {
         return (int) Math.round((Math.log((getChromosomeLength() / (end - start)) * (((double) widthInPixels) / binsPerTile)) / Globals.log2));
     }
 

--- a/src/main/java/org/broad/igv/ui/panel/ZoomSliderPanel.java
+++ b/src/main/java/org/broad/igv/ui/panel/ZoomSliderPanel.java
@@ -54,7 +54,7 @@ import java.util.stream.Collectors;
 public class ZoomSliderPanel extends JPanel {
 
     private static final Color TRANSPARENT_GRAY = new Color(200, 200, 200, 150);
-    private static final Color TRANSPARENT_BLUE = new Color(27, 96, 246, 50);
+    private static final Color TRANSPARENT_BLUE = new Color(27, 96, 246, 25);
     static Color TICK_GRAY = new Color(90, 90, 90);
     static Color TICK_BLUE = new Color(25, 50, 200);
 

--- a/src/main/java/org/broad/igv/ui/panel/ZoomSliderPanel.java
+++ b/src/main/java/org/broad/igv/ui/panel/ZoomSliderPanel.java
@@ -33,13 +33,20 @@
  */
 package org.broad.igv.ui.panel;
 
+import org.broad.igv.track.Track;
+import org.broad.igv.ui.IGV;
 import org.broad.igv.ui.util.IGVMouseInputAdapter;
 import org.broad.igv.ui.util.IconFactory;
 
 import javax.swing.*;
 import javax.swing.event.MouseInputAdapter;
+
+import java.util.List;
 import java.awt.*;
 import java.awt.event.MouseEvent;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
 
 /**
  * @author jrobinso
@@ -47,6 +54,7 @@ import java.awt.event.MouseEvent;
 public class ZoomSliderPanel extends JPanel {
 
     private static final Color TRANSPARENT_GRAY = new Color(200, 200, 200, 150);
+    private static final Color TRANSPARENT_BLUE = new Color(27, 96, 246, 50);
     static Color TICK_GRAY = new Color(90, 90, 90);
     static Color TICK_BLUE = new Color(25, 50, 200);
 
@@ -103,7 +111,6 @@ public class ZoomSliderPanel extends JPanel {
             numZoomLevels = tmp;
             zoomLevelRects = new Rectangle[numZoomLevels];
         }
-
     }
 
 
@@ -193,7 +200,31 @@ public class ZoomSliderPanel extends JPanel {
                 //g.drawImage(slider, x + 1, y, null);
             }
         }
+
+        paintVisibilityThresholds(transGraphics);
         transGraphics.dispose();
+    }
+
+    //Adds an indicator of which zoom level will display reads/features
+    private void paintVisibilityThresholds(final Graphics2D transGraphics) {
+        if(numZoomLevels > 1) {
+            List<Integer> visibilityThresholds = IGV.getInstance().getAllTracks().stream()
+                    .map(Track::getVisibilityWindow)
+                    .filter(i -> i > 0)
+                    .sorted()
+                    .distinct()
+                    .map(threshold -> this.getReferenceFrame().calculateZoom(0, threshold))
+                    .collect(Collectors.toList());
+
+            transGraphics.setColor(TRANSPARENT_BLUE);
+            Rectangle maxZoom = zoomLevelRects[zoomLevelRects.length - 1];
+            for (Integer window : visibilityThresholds) {
+                final Rectangle currentLevel = zoomLevelRects[window];
+                Rectangle windowBox = new Rectangle(currentLevel.x, currentLevel.y,
+                        maxZoom.x + maxZoom.width - currentLevel.x, currentLevel.height);
+                transGraphics.fill(windowBox);
+            }
+        }
     }
 
     void setZoom(MouseEvent e) {

--- a/test/sessions/base_mods/HIFI_basemodifictions.xml
+++ b/test/sessions/base_mods/HIFI_basemodifictions.xml
@@ -1,22 +1,22 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<Session genome="hg38" locus="chr19:45767361-45767415" nextAutoscaleGroup="2" version="8">
+<Session genome="hg38" locus="chr19:45767313-45767827" nextAutoscaleGroup="2" version="8">
     <Resources>
         <Resource path="https://downloads.pacbcloud.com/public/dataset/HG002-CpG-methylation-202202/HG002.GRCh38.haplotagged.bam" type="bam"/>
     </Resources>
-    <Panel height="674" name="Panel1654055368817" width="1609">
+    <Panel height="631" name="Panel1654055368817" width="1781">
         <Track attributeKey="HG002.GRCh38.haplotagged.bam Coverage" autoScale="true" clazz="org.broad.igv.sam.CoverageTrack" fontSize="10" id="https://downloads.pacbcloud.com/public/dataset/HG002-CpG-methylation-202202/HG002.GRCh38.haplotagged.bam_coverage" name="HG002.GRCh38.haplotagged.bam Coverage" snpThreshold="0.2" visible="true">
-            <DataRange baseline="0.0" drawBaseline="true" flipAxis="false" maximum="37.0" minimum="0.0" type="LINEAR"/>
+            <DataRange baseline="0.0" drawBaseline="true" flipAxis="false" maximum="38.0" minimum="0.0" type="LINEAR"/>
         </Track>
-        <Track attributeKey="HG002.GRCh38.haplotagged.bam Junctions" clazz="org.broad.igv.sam.SpliceJunctionTrack" fontSize="10" groupByStrand="false" height="60" id="https://downloads.pacbcloud.com/public/dataset/HG002-CpG-methylation-202202/HG002.GRCh38.haplotagged.bam_junctions" name="HG002.GRCh38.haplotagged.bam Junctions" visible="false"/>
+        <Track attributeKey="HG002.GRCh38.haplotagged.bam Junctions" autoScale="false" clazz="org.broad.igv.sam.SpliceJunctionTrack" fontSize="10" groupByStrand="false" height="60" id="https://downloads.pacbcloud.com/public/dataset/HG002-CpG-methylation-202202/HG002.GRCh38.haplotagged.bam_junctions" maxdepth="50" name="HG002.GRCh38.haplotagged.bam Junctions" visible="false"/>
         <Track attributeKey="HG002.GRCh38.haplotagged.bam" clazz="org.broad.igv.sam.AlignmentTrack" color="185,185,185" displayMode="EXPANDED" experimentType="THIRD_GEN" fontSize="10" id="https://downloads.pacbcloud.com/public/dataset/HG002-CpG-methylation-202202/HG002.GRCh38.haplotagged.bam" name="HG002.GRCh38.haplotagged.bam" visible="true">
-            <RenderOptions colorOption="BASE_MODIFICATION"/>
+            <RenderOptions colorOption="BASE_MODIFICATION_5MC"/>
         </Track>
     </Panel>
-    <Panel height="421" name="FeaturePanel" width="1609">
+    <Panel height="543" name="FeaturePanel" width="1781">
         <Track attributeKey="Reference sequence" clazz="org.broad.igv.track.SequenceTrack" fontSize="10" id="Reference sequence" name="Reference sequence" sequenceTranslationStrandValue="POSITIVE" shouldShowTranslation="true" visible="true"/>
         <Track attributeKey="Refseq Genes" clazz="org.broad.igv.track.FeatureTrack" fontSize="10" groupByStrand="false" id="https://s3.amazonaws.com/igv.org.genomes/hg38/ncbiRefSeq.txt.gz" name="Refseq Genes" visible="true"/>
     </Panel>
-    <PanelLayout dividerFractions="0.0064794816414686825,0.5399568034557235"/>
+    <PanelLayout dividerFractions="0.006711409395973154,0.540268456375839"/>
     <HiddenAttributes>
         <Attribute name="DATA FILE"/>
         <Attribute name="DATA TYPE"/>


### PR DESCRIPTION
@jrobinso 
This is a minor feature that I have wanted in the past so I figured I would try implementing it.   Good learning project to play with some of the stuff I haven't touched yet.

- implementing getVisibilityWindow() on coverage and alignment tracks
- Adding an indicator to the Zoom control to show which zoom levels will display reads / features


This is what it looks like when there are 2 different thresholds set (variants AND reads) notice the two shades to indicate the separate thresholds.

<img width="230" alt="Screen Shot 2022-08-16 at 3 33 45 PM" src="https://user-images.githubusercontent.com/4700332/184972209-c0ce5f15-b040-4989-8384-18f4546d533f.png">

I implemented it in a kind of hacky way so I'd really like to hear feedback about better ways to get the threshold from the tracks into the widget without poling through them each time you redraw.  It's probably not that expensive so it may not be worth doing anything smarter.

Also happy to change the look of it.

