### PR TITLE
Add option to color bases by SMRT kinetic values

### DIFF
--- a/src/main/java/org/broad/igv/prefs/Constants.java
+++ b/src/main/java/org/broad/igv/prefs/Constants.java
@@ -175,6 +175,8 @@ final public class Constants {
     public static final String SAM_DISPLAY_PAIRED = "SAM.DISPLAY_PAIRED";
     public static final String KNOWN_SNPS = "KNOWN_SNPS_FILE";
 
+    public static final String SMRT_KINETICS_SHOW_OPTIONS = "SMRT_KINETICS.SHOW_OPTIONS";
+
     // Sequence track settings
     public static final String SEQUENCE_TRANSLATION_STRAND = "SEQUENCE_TRANSLATION_STRAND";
     public static final String SHOW_SEQUENCE_TRANSLATION = "SHOW_SEQUENCE_TRANSLATION";

--- a/src/main/java/org/broad/igv/sam/Alignment.java
+++ b/src/main/java/org/broad/igv/sam/Alignment.java
@@ -167,6 +167,14 @@ public interface Alignment extends LocusScore {
 
     default List<BaseModificationSet> getBaseModificationSets() { return null;}
 
+    default short[] getSmrtSubreadIpd() { return null;}
+
+    default short[] getSmrtSubreadPw() { return null;}
+
+    default short[] getSmrtCcsIpd(boolean isForwardStrand) { return null;}
+
+    default short[] getSmrtCcsPw(boolean isForwardStrand) { return null;}
+
     default String getAlignmentValueString(double position, int mouseX, AlignmentTrack.RenderOptions renderOptions) {
         return getValueString(position, mouseX, (WindowFunction) null);
     }

--- a/src/main/java/org/broad/igv/sam/AlignmentRenderer.java
+++ b/src/main/java/org/broad/igv/sam/AlignmentRenderer.java
@@ -1009,20 +1009,41 @@ public class AlignmentRenderer {
                 blendColorValue(c1.getBlue(), c2.getBlue(), c2Frac));
     }
 
-    private static Color getSmrtFrameCountColor(short frameCount) {
-        final int transition1FrameCount = 127; // Red with Alpha 0->255
-        final int transition2FrameCount = 511; // Red->Yellow
+    /**
+     * Set base color for SMRT sequencing frame count
+     *
+     * This color scheme uses multiple transitions to help visually distinguish a large range of time intervals.
+     *
+     * Color scheme:
+     * The color starts out as transparent at a frame count of 0.
+     * - Color transition 1 goes from transparent to opaque red
+     * - Color transition 2 goes from red to yellow
+     * - Color transition 3 goes from yellow to cyan
+     *
+     * Transition 3 will mostly be visible when uncompressed frame counts are used. It helps to visually distinguish
+     * exceptional polymerase stalling events.
+     */
+    private static Color getSmrtFrameCountColor(short shortFrameCount) {
+        final int transition1MaxFrameCount = 100;
+        final int transition2MaxFrameCount = 600;
+        final int transition3MaxFrameCount = 6000;
         final Color color1 = Color.red;
         final Color color2 = Color.yellow;
-        int alpha = Math.min(255, (frameCount*255)/transition1FrameCount);
+        final Color color3 = Color.cyan;
+
+        final int frameCount = Short.toUnsignedInt(shortFrameCount);
+        final int alpha = Math.min(255, (frameCount*255)/transition1MaxFrameCount);
         Color blendedColor;
-        if (frameCount <= transition1FrameCount) {
+        if (frameCount <= transition1MaxFrameCount) {
             blendedColor = color1;
-        } else if (frameCount <= transition2FrameCount) {
-            float color2Fraction = (frameCount-transition1FrameCount)/((float) (transition2FrameCount-transition1FrameCount));
+        } else if (frameCount <= transition2MaxFrameCount) {
+            float color2Fraction = (frameCount-transition1MaxFrameCount)/((float) (transition2MaxFrameCount-transition1MaxFrameCount));
             blendedColor = blendColors(color1, color2, color2Fraction);
+        } else if (frameCount <= transition3MaxFrameCount) {
+            float color3Fraction = (frameCount-transition2MaxFrameCount)/((float) (transition3MaxFrameCount-transition2MaxFrameCount));
+            blendedColor = blendColors(color2, color3, color3Fraction);
         } else {
-            blendedColor = color2;
+            blendedColor = color3;
         }
         return new Color(blendedColor.getRed(), blendedColor.getGreen(), blendedColor.getBlue(), alpha);
     }

--- a/src/main/java/org/broad/igv/sam/AlignmentRenderer.java
+++ b/src/main/java/org/broad/igv/sam/AlignmentRenderer.java
@@ -315,9 +315,11 @@ public class AlignmentRenderer {
                 double pixelWidth = pixelEnd - pixelStart;
                 Color alignmentColor = getAlignmentColor(alignment, track);
                 final boolean leaveMargin = (this.track.getDisplayMode() != Track.DisplayMode.SQUISHED);
+                final ColorOption colorOption = renderOptions.getColorOption();
                 if ((pixelWidth < 2) &&
-                        !((AlignmentTrack.isBisulfiteColorType(renderOptions.getColorOption()) ||
-                                renderOptions.getColorOption().isBaseMod()) &&
+                        !((AlignmentTrack.isBisulfiteColorType(colorOption) ||
+                                colorOption.isBaseMod() ||
+                                colorOption.isSMRTKinetics()) &&
                                 (pixelWidth >= 1))) {
                     // Optimization for really zoomed out views.  If this alignment occupies screen space already taken,
                     // and it is the default color, skip drawing.
@@ -797,7 +799,8 @@ public class AlignmentRenderer {
                             Color color = null;
                             if (bisulfiteMode) {
                                 color = bisinfo.getDisplayColor(idx);
-                            } else if (colorOption.isBaseMod()) {
+                            } else if (colorOption.isBaseMod() ||
+                                       colorOption.isSMRTKinetics()) {
                                 color = Color.GRAY;
                             } else {
                                 color = nucleotideColors.get(c);
@@ -830,6 +833,56 @@ public class AlignmentRenderer {
         // Base modification
         if (colorOption.isBaseMod()) {
             BaseModificationRenderer.drawModifications(alignment, bpStart, locScale, rowRect, context.getGraphics(), colorOption);
+        }
+
+        // Kinetic data
+        if (colorOption.isSMRTKinetics()) {
+            short[] smrtFrameCounts;
+            if (ColorOption.SMRT_SUBREAD_IPD == colorOption) {
+                smrtFrameCounts = alignment.getSmrtSubreadIpd();
+            } else if (ColorOption.SMRT_SUBREAD_PW == colorOption) {
+                smrtFrameCounts = alignment.getSmrtSubreadPw();
+            } else if (ColorOption.SMRT_CCS_FWD_IPD == colorOption || ColorOption.SMRT_CCS_REV_IPD == colorOption) {
+                final boolean isForwardStrand = (ColorOption.SMRT_CCS_FWD_IPD == colorOption);
+                smrtFrameCounts = alignment.getSmrtCcsIpd(isForwardStrand);
+            } else {
+                final boolean isForwardStrand = (ColorOption.SMRT_CCS_FWD_PW == colorOption);
+                smrtFrameCounts = alignment.getSmrtCcsPw(isForwardStrand);
+            }
+
+            if (smrtFrameCounts != null) {
+                // Compute bounds
+                int pY = (int) rowRect.getY();
+                int dY = (int) rowRect.getHeight();
+                dX = (int) Math.max(1, (1.0 / locScale));
+                Graphics g = context.getGraphics();
+
+                for (AlignmentBlock block : alignment.getAlignmentBlocks()) {
+                    ByteSubarray bases = block.getBases();
+                    final int startOffset = bases.startOffset;
+                    final int stopOffset = startOffset + bases.length;
+                    for (int i = startOffset; i < stopOffset; i++) {
+                        g.setColor(getSmrtFrameCountColor(smrtFrameCounts[i]));
+
+                        int blockIdx = i - block.getBases().startOffset;
+                        int pX = (int) ((block.getStart() + blockIdx - bpStart) / locScale);
+
+                        // Don't draw out of clipping rect
+                        if (pX > rowRect.getMaxX()) {
+                            break;
+                        } else if (pX + dX < rowRect.getX()) {
+                            continue;
+                        }
+
+                        // Expand narrow width to make more visible
+                        if (dX < 3) {
+                            dX = 3;
+                            pX--;
+                        }
+                        g.fillRect(pX, pY, dX, Math.max(1, dY - 2));
+                    }
+                }
+            }
         }
 
         // DRAW Insertions
@@ -943,6 +996,35 @@ public class AlignmentRenderer {
         }
         Color color = ColorUtilities.getCompositeColor(backgroundColor, foregroundColor, alpha);
         return color;
+    }
+
+    private static int blendColorValue(int v1, int v2, float v2Frac) {
+        return Math.min(255, (int) (v1 + (v2 - v1) * v2Frac));
+    }
+
+    private static Color blendColors(Color c1, Color c2, float c2Frac) {
+        assert(c2Frac >= 0.0 && c2Frac <= 1.0);
+        return new Color(blendColorValue(c1.getRed(), c2.getRed(), c2Frac),
+                blendColorValue(c1.getGreen(), c2.getGreen(), c2Frac),
+                blendColorValue(c1.getBlue(), c2.getBlue(), c2Frac));
+    }
+
+    private static Color getSmrtFrameCountColor(short frameCount) {
+        final int transition1FrameCount = 127; // Red with Alpha 0->255
+        final int transition2FrameCount = 511; // Red->Yellow
+        final Color color1 = Color.red;
+        final Color color2 = Color.yellow;
+        int alpha = Math.min(255, (frameCount*255)/transition1FrameCount);
+        Color blendedColor;
+        if (frameCount <= transition1FrameCount) {
+            blendedColor = color1;
+        } else if (frameCount <= transition2FrameCount) {
+            float color2Fraction = (frameCount-transition1FrameCount)/((float) (transition2FrameCount-transition1FrameCount));
+            blendedColor = blendColors(color1, color2, color2Fraction);
+        } else {
+            blendedColor = color2;
+        }
+        return new Color(blendedColor.getRed(), blendedColor.getGreen(), blendedColor.getBlue(), alpha);
     }
 
     private void drawLargeIndelLabel(Graphics2D g, boolean isInsertion, String labelText, int pxCenter,
@@ -1176,6 +1258,12 @@ public class AlignmentRenderer {
             case BASE_MODIFICATION:
             case BASE_MODIFICATION_5MC:
             case BASE_MODIFICATION_C:
+            case SMRT_SUBREAD_IPD:
+            case SMRT_SUBREAD_PW:
+            case SMRT_CCS_FWD_IPD:
+            case SMRT_CCS_FWD_PW:
+            case SMRT_CCS_REV_IPD:
+            case SMRT_CCS_REV_PW:
                 // Just a simple forward/reverse strand color scheme that won't clash with the
                 // methylation rectangles.
                 c = (alignment.getFirstOfPairStrand() == Strand.POSITIVE) ? bisulfiteColorFw1 : bisulfiteColorRev1;

--- a/src/main/java/org/broad/igv/sam/AlignmentTrack.java
+++ b/src/main/java/org/broad/igv/sam/AlignmentTrack.java
@@ -113,10 +113,30 @@ public class AlignmentTrack extends AbstractTrack implements IGVEventObserver {
         YC_TAG,
         BASE_MODIFICATION,
         BASE_MODIFICATION_5MC,
-        BASE_MODIFICATION_C;
+        BASE_MODIFICATION_C,
+        SMRT_SUBREAD_IPD,
+        SMRT_SUBREAD_PW,
+        SMRT_CCS_FWD_IPD,
+        SMRT_CCS_FWD_PW,
+        SMRT_CCS_REV_IPD,
+        SMRT_CCS_REV_PW;
 
         public boolean isBaseMod() {
             return this == BASE_MODIFICATION || this == BASE_MODIFICATION_5MC || this == BASE_MODIFICATION_C;
+        }
+
+        public boolean isSMRTKinetics() {
+            switch (this) {
+                case SMRT_SUBREAD_IPD:
+                case SMRT_SUBREAD_PW:
+                case SMRT_CCS_FWD_IPD:
+                case SMRT_CCS_REV_IPD:
+                case SMRT_CCS_FWD_PW:
+                case SMRT_CCS_REV_PW:
+                    return true;
+                default:
+                    return false;
+            }
         }
     }
 
@@ -1920,6 +1940,20 @@ public class AlignmentTrack extends AbstractTrack implements IGVEventObserver {
                 group.add(mi);
             }
 
+            // SMRT Kinetics
+            mappings.clear();
+            mappings.put("SMRT subread IPD", ColorOption.SMRT_SUBREAD_IPD);
+            mappings.put("SMRT subread PW", ColorOption.SMRT_SUBREAD_PW);
+            mappings.put("SMRT CCS fwd-strand aligned IPD", ColorOption.SMRT_CCS_FWD_IPD);
+            mappings.put("SMRT CCS fwd-strand aligned PW", ColorOption.SMRT_CCS_FWD_PW);
+            mappings.put("SMRT CCS rev-strand aligned IPD", ColorOption.SMRT_CCS_REV_IPD);
+            mappings.put("SMRT CCS rev-strand aligned PW", ColorOption.SMRT_CCS_REV_PW);
+            colorMenu.addSeparator();
+            for (Map.Entry<String, ColorOption> el : mappings.entrySet()) {
+                JRadioButtonMenuItem mi = getColorMenuItem(el.getKey(), el.getValue());
+                colorMenu.add(mi);
+                group.add(mi);
+            }
 
             add(colorMenu);
 

--- a/src/main/java/org/broad/igv/sam/AlignmentTrack.java
+++ b/src/main/java/org/broad/igv/sam/AlignmentTrack.java
@@ -1940,19 +1940,21 @@ public class AlignmentTrack extends AbstractTrack implements IGVEventObserver {
                 group.add(mi);
             }
 
-            // SMRT Kinetics
-            mappings.clear();
-            mappings.put("SMRT subread IPD", ColorOption.SMRT_SUBREAD_IPD);
-            mappings.put("SMRT subread PW", ColorOption.SMRT_SUBREAD_PW);
-            mappings.put("SMRT CCS fwd-strand aligned IPD", ColorOption.SMRT_CCS_FWD_IPD);
-            mappings.put("SMRT CCS fwd-strand aligned PW", ColorOption.SMRT_CCS_FWD_PW);
-            mappings.put("SMRT CCS rev-strand aligned IPD", ColorOption.SMRT_CCS_REV_IPD);
-            mappings.put("SMRT CCS rev-strand aligned PW", ColorOption.SMRT_CCS_REV_PW);
-            colorMenu.addSeparator();
-            for (Map.Entry<String, ColorOption> el : mappings.entrySet()) {
-                JRadioButtonMenuItem mi = getColorMenuItem(el.getKey(), el.getValue());
-                colorMenu.add(mi);
-                group.add(mi);
+            if (getPreferences().getAsBoolean(SMRT_KINETICS_SHOW_OPTIONS)) {
+                // Show additional options to help visualize SMRT kinetics data
+                mappings.clear();
+                mappings.put("SMRT subread IPD", ColorOption.SMRT_SUBREAD_IPD);
+                mappings.put("SMRT subread PW", ColorOption.SMRT_SUBREAD_PW);
+                mappings.put("SMRT CCS fwd-strand aligned IPD", ColorOption.SMRT_CCS_FWD_IPD);
+                mappings.put("SMRT CCS fwd-strand aligned PW", ColorOption.SMRT_CCS_FWD_PW);
+                mappings.put("SMRT CCS rev-strand aligned IPD", ColorOption.SMRT_CCS_REV_IPD);
+                mappings.put("SMRT CCS rev-strand aligned PW", ColorOption.SMRT_CCS_REV_PW);
+                colorMenu.addSeparator();
+                for (Map.Entry<String, ColorOption> el : mappings.entrySet()) {
+                    JRadioButtonMenuItem mi = getColorMenuItem(el.getKey(), el.getValue());
+                    colorMenu.add(mi);
+                    group.add(mi);
+                }
             }
 
             add(colorMenu);

--- a/src/main/java/org/broad/igv/sam/SAMAlignment.java
+++ b/src/main/java/org/broad/igv/sam/SAMAlignment.java
@@ -359,6 +359,10 @@ public class SAMAlignment implements Alignment {
      * Returns the processed frame count array
      */
     private short[] parseSmrtKineticByteCodes(byte[] smrtKineticByteCodes, boolean reverseSequence) {
+        if (smrtKineticByteCodes.length == 0) {
+            return null;
+        }
+
         int hardClipLength = getLeadingHardClipLength();
         int kineticValLength = smrtKineticByteCodes.length - hardClipLength;
         assert(kineticValLength > 0);
@@ -387,6 +391,10 @@ public class SAMAlignment implements Alignment {
      * Returns the processed frame count array
      */
     private short[] parseAuxSmrtKineticFrameCounts(short[] auxSmrtKineticFrameCounts, boolean reverseSequence) {
+        if (auxSmrtKineticFrameCounts.length == 0) {
+            return null;
+        }
+
         int hardClipLength = getLeadingHardClipLength();
         int kineticValLength = auxSmrtKineticFrameCounts.length - hardClipLength;
         assert(kineticValLength > 0);

--- a/src/main/java/org/broad/igv/sam/SAMAlignment.java
+++ b/src/main/java/org/broad/igv/sam/SAMAlignment.java
@@ -783,26 +783,26 @@ public class SAMAlignment implements Alignment {
                     if (colorOption == AlignmentTrack.ColorOption.SMRT_SUBREAD_IPD) {
                         short[] ipdVals = getSmrtSubreadIpd();
                         if (ipdVals != null) {
-                            return "Subread IPD: " + ipdVals[readIndex] + " Frames";
+                            return "Subread IPD: " + Short.toUnsignedInt(ipdVals[readIndex]) + " Frames";
                         }
                     } else if (colorOption == AlignmentTrack.ColorOption.SMRT_SUBREAD_PW) {
                         short[] pwVals = getSmrtSubreadPw();
                         if (pwVals != null) {
-                            return "Subread PW: " + pwVals[readIndex] + " Frames";
+                            return "Subread PW: " + Short.toUnsignedInt(pwVals[readIndex]) + " Frames";
                         }
                     } else if (colorOption == AlignmentTrack.ColorOption.SMRT_CCS_FWD_IPD || colorOption == AlignmentTrack.ColorOption.SMRT_CCS_REV_IPD) {
                         final boolean isForwardStrand = (colorOption == AlignmentTrack.ColorOption.SMRT_CCS_FWD_IPD);
                         short[] ipdVals = getSmrtCcsIpd(isForwardStrand);
                         if (ipdVals != null) {
                             final String strand = (isForwardStrand ? "fwd" : "rev");
-                            return "CCS " + strand + "-strand aligned IPD: " + ipdVals[readIndex] + " Frames";
+                            return "CCS " + strand + "-strand aligned IPD: " + Short.toUnsignedInt(ipdVals[readIndex]) + " Frames";
                         }
                     } else {
                         final boolean isForwardStrand = (colorOption == AlignmentTrack.ColorOption.SMRT_CCS_FWD_PW);
                         short[] pwVals = getSmrtCcsPw(isForwardStrand);
                         if (pwVals != null) {
                             final String strand = (isForwardStrand ? "fwd" : "rev");
-                            return "CCS " + strand + "-strand aligned PW: " + pwVals[readIndex] + " Frames";
+                            return "CCS " + strand + "-strand aligned PW: " + Short.toUnsignedInt(pwVals[readIndex]) + " Frames";
                         }
                     }
                 }

--- a/src/main/java/org/broad/igv/sam/SMRTKineticsDecoder.java
+++ b/src/main/java/org/broad/igv/sam/SMRTKineticsDecoder.java
@@ -1,6 +1,6 @@
 package org.broad.igv.sam;
 
-/// Logic to decode SMRT kinetic values from uint8 compressed code to an approximation of the
+/// Decode SMRT kinetic values from uint8 compressed code to an approximation of the
 /// original frame count.
 ///
 public class SMRTKineticsDecoder {

--- a/src/main/java/org/broad/igv/sam/SMRTKineticsDecoder.java
+++ b/src/main/java/org/broad/igv/sam/SMRTKineticsDecoder.java
@@ -1,0 +1,40 @@
+package org.broad.igv.sam;
+
+/// Logic to decode SMRT kinetic values from uint8 compressed code to an approximation of the
+/// original frame count.
+///
+public class SMRTKineticsDecoder {
+
+    private static final int base = 1 << 6;
+
+    private final short[] frameCounts;
+
+    public SMRTKineticsDecoder() {
+        frameCounts = new short[256];
+        for (int i = 0; i < 256; ++i) {
+            frameCounts[i] = decodeFrameCount((byte) i);
+        }
+    }
+
+    /// Convert compressed byte to frame count from cached LUT
+    public short lookupFrameCount(byte val) {
+        return frameCounts[val & 0xFF];
+    }
+
+    /// Compute frame count from compressed byte
+    ///
+    /// 8-bit compressed V1 codec:
+    ///
+    ///   xxmm'mmmm
+    ///
+    /// where
+    /// * 'x' represents the exponent (2 MSBs)
+    /// * 'm' represents the mantissa (6 LSBs)
+    ///
+    private static short decodeFrameCount(byte val) {
+        int mantissa = val & 0b0011_1111;
+        int exponent = (val & 0b1100_0000) >> 6;
+        int exponentVal = 1 << exponent;
+        return (short) (base * (exponentVal - 1) + exponentVal * mantissa);
+    }
+}

--- a/src/main/resources/org/broad/igv/prefs/preferences.tab
+++ b/src/main/resources/org/broad/igv/prefs/preferences.tab
@@ -189,6 +189,9 @@ SAM.SHOW_INSERTION_MARKERS	Show insertion markers	boolean	TRUE
 SAM.LINK_READS	Link alignments by tag	boolean	FALSE
 SAM.LINK_TAG	Linking tag	string	READNAME
 
+##SMRT Kinetics
+SMRT_KINETICS.SHOW_OPTIONS	Show visibility options for SMRT kinetics data	boolean	FALSE
+
 #Proxy
 PROXY.DISABLE_CHECK	Disable check for system proxy	boolean	FALSE
 PROXY.USE	Use proxy	boolean	FALSE

--- a/src/test/java/org/broad/igv/sam/SMRTKineticsDecoderTest.java
+++ b/src/test/java/org/broad/igv/sam/SMRTKineticsDecoderTest.java
@@ -1,0 +1,49 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2007-2015 Broad Institute
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.broad.igv.sam;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class SMRTKineticsDecoderTest {
+
+    public SMRTKineticsDecoderTest() {
+    }
+
+    @Test
+    public void testDecoder() throws Exception {
+        SMRTKineticsDecoder decoder = new SMRTKineticsDecoder();
+
+        short v0 = decoder.lookupFrameCount((byte) 0);
+        short v128 = decoder.lookupFrameCount((byte) 128);
+        short v255 = decoder.lookupFrameCount((byte) 255);
+
+        assertEquals(0, v0);
+        assertEquals(192, v128);
+        assertEquals(952, v255);
+    }
+}


### PR DESCRIPTION
I created a branch that allows us to view SMRT sequencing polymerase kinetics stored in the BAM file. The kinetics values of interest are the pulse width (PW) and interpulse duration (IPD). The changes allow viewing of these kinetic values from both subread and CCS SMRT sequencing BAM files that include kinetics tags.

As an example, below is a view of E coli CCS sequence, where bases have been colored to indicated the interpulse duration (IPD) on the fwd-aligned strand. The red column corresponds to a 6mA methylation site at the _Dam_ methyltransferase recognition site (GATC).

![image](https://user-images.githubusercontent.com/1349103/188243185-a3b36d7c-0f10-49c1-8390-b0a31f4a18ec.png)

The new feature is added to the "Color alignments by" context menu. The menu has been modified with the following 6 options:

![image](https://user-images.githubusercontent.com/1349103/188243506-c1859b1b-4101-4825-b193-230bb04dbae8.png)

While this is a somewhat specialized feature, I wanted to open a discussion on whether we might bring this into the master branch, or what further changes would make this possible.