### PR TITLE
issue_1232

### DIFF
--- a/src/main/java/org/broad/igv/feature/IGVFeature.java
+++ b/src/main/java/org/broad/igv/feature/IGVFeature.java
@@ -37,6 +37,10 @@ import java.util.Map;
 
 public interface IGVFeature extends LocusScore, NamedFeature {
 
+    default String getIdentifier() {
+        return null;
+    }
+
     default Strand getStrand() {
         return Strand.NONE;
     }

--- a/src/main/java/org/broad/igv/track/FeatureTrack.java
+++ b/src/main/java/org/broad/igv/track/FeatureTrack.java
@@ -439,14 +439,23 @@ public class FeatureTrack extends AbstractTrack implements IGVEventObserver {
     }
 
 
+    /**
+     * Return an info URL for a specific feature, constructed as follows
+     *
+     * @param igvFeature
+     * @return
+     */
     private String getFeatureURL(IGVFeature igvFeature) {
-        String url = igvFeature.getURL();
+        String url = igvFeature.getURL();    // Explicity URL setting
         if (url == null) {
-            String trackURL = getFeatureInfoURL();
-            if (trackURL != null && igvFeature.getName() != null) {
-                String name = labelField != null ? igvFeature.getDisplayName(labelField) : igvFeature.getName();
-                String encodedID = StringUtils.encodeURL(name);
-                url = trackURL.replaceAll("\\$\\$", encodedID);
+            String trackURL = getFeatureInfoURL();   // Template
+            if (trackURL != null) {
+                String idOrName = igvFeature.getIdentifier() != null ?
+                        igvFeature.getIdentifier() :
+                        labelField != null ?
+                                igvFeature.getDisplayName(labelField) :
+                                igvFeature.getName();
+                    url = trackURL.replaceAll("\\$\\$", StringUtils.encodeURL(idOrName));
             }
         }
         return url;
@@ -472,7 +481,7 @@ public class FeatureTrack extends AbstractTrack implements IGVEventObserver {
             Iterator<Feature> iter = source.getFeatures(chr, start, end);
             while (iter.hasNext()) {
                 Feature f = iter.next();
-                if(f.getEnd() >= start && f.getStart() <= end) {
+                if (f.getEnd() >= start && f.getStart() <= end) {
                     features.add(f);
                 }
             }

--- a/test/data/bed/infoLink_gffTags.bed
+++ b/test/data/bed/infoLink_gffTags.bed
@@ -1,0 +1,2 @@
+track name="Test track" url="http://chip-atlas.org/view?id=$$" gffTags="on"
+chr1	225887119	225888309	ID=SRX1497383;Name=BRD4;Title=GSM1976289	544	.	225887119	225888309	44,255,0


### PR DESCRIPTION
Use ID for feature info links if ID is set (e.g. from GFF attrribute.  Fixes #1232