### PR TITLE
fixing null pointers when sorting by mate chromosome

### DIFF
--- a/src/main/java/org/broad/igv/sam/SortOption.java
+++ b/src/main/java/org/broad/igv/sam/SortOption.java
@@ -1,6 +1,7 @@
 package org.broad.igv.sam;
 
 import java.util.Comparator;
+import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.ToIntFunction;
 
@@ -87,8 +88,9 @@ public enum SortOption {
         @Override
         Comparator<Alignment> getAlignmentComparator(final int center, final String tag, final byte referenceBase) {
             return Comparator.comparing((Alignment a) -> a.getMate() == null)
-                    .thenComparing(a -> a.getMate().getChr().equals(a.getChr()))
-                    .thenComparing(a -> a.getMate().getChr());
+                    .thenComparing(a -> a.getMate() != null && Objects.equals(a.getMate().getChr(),a.getChr()))
+                    .thenComparing(nullSafeComparator(a -> a.getMate() == null ? null : a.getMate().getChr()));
+
         }
     }, TAG {
         @Override


### PR DESCRIPTION
It looks like my comparator changes had another set of NPE's when mate or mate.chr() are null.  I must have tested on a region that had complete mate information.