### PR TITLE
Refactoring BisulfiteContext enum to reduce code duplication

### DIFF
--- a/src/main/java/org/broad/igv/sam/AlignmentTrackMenu.java
+++ b/src/main/java/org/broad/igv/sam/AlignmentTrackMenu.java
@@ -286,8 +286,7 @@ class AlignmentTrackMenu extends IGVPopupMenu {
 
         for (final AlignmentTrack.BisulfiteContext item : AlignmentTrack.BisulfiteContext.values()) {
 
-            String optionStr = getBisulfiteContextPubStr(item);
-            JRadioButtonMenuItem m1 = new JRadioButtonMenuItem(optionStr);
+            JRadioButtonMenuItem m1 = new JRadioButtonMenuItem(item.getLabel());
             m1.setSelected(renderOptions.getColorOption() == AlignmentTrack.ColorOption.BISULFITE && renderOptions.bisulfiteContext == item);
             m1.addActionListener(aEvt -> {
                 alignmentTrack.setColorOption(AlignmentTrack.ColorOption.BISULFITE);
@@ -1327,10 +1326,5 @@ class AlignmentTrackMenu extends IGVPopupMenu {
             }
         }
     }
-
-    private static String getBisulfiteContextPubStr(AlignmentTrack.BisulfiteContext item) {
-        return AlignmentTrack.bisulfiteContextToPubString.get(item);
-    }
-
 
 }

--- a/src/main/java/org/broad/igv/sam/BisulfiteBaseInfo.java
+++ b/src/main/java/org/broad/igv/sam/BisulfiteBaseInfo.java
@@ -209,65 +209,7 @@ public class BisulfiteBaseInfo {
         }
 
         // Get the context and see if it matches our desired context.
-        byte[] preContext = AlignmentTrack.getBisulfiteContextPreContext(bisulfiteContext);
-        byte[] postContext = AlignmentTrack.getBisulfiteContextPostContext(bisulfiteContext);
-
-        boolean matchesContext = true;
-
-        // First do the "post" context
-        int minLen = Math.min(reference.length, read.length);
-        if ((idx + postContext.length) >= minLen) {
-            matchesContext = false;
-        } else {
-            // Cut short whenever we don't match
-            for (int posti = 0; matchesContext && (posti < postContext.length); posti++) {
-                byte contextb = postContext[posti];
-                int offsetidx = idx + 1 + posti;
-                matchesContext &= positionMatchesContext(contextb, reference[offsetidx], read.getByte(offsetidx));
-
-                //				System.err.printf("POST posMatchesContext(posti=%d, contextb=%c, refb=%c, readb=%c, offsetidx=%d) = %s\n",
-                //						posti, contextb, reference[offsetidx], read[offsetidx], offsetidx, matchesContext);
-
-            }
-        }
-
-        // Now do the pre context
-        if ((idx - preContext.length) < 0) {
-            matchesContext = false;
-        } else {
-            // Cut short whenever we don't match
-            for (int prei = 0; matchesContext && (prei < preContext.length); prei++) {
-                byte contextb = preContext[prei];
-                int offsetidx = idx - (preContext.length - prei);
-                matchesContext &= positionMatchesContext(contextb, reference[offsetidx], read.getByte(offsetidx));
-                //				System.err.printf("PRE posMatchesContext(prei=%d, contextb=%c, refb=%c, readb=%c, offsetidx=%d) = %s\n",
-                //						prei, contextb, reference[offsetidx], read[offsetidx], offsetidx, matchesContext);
-            }
-        }
-
-        return (matchesContext) ? bisulfiteContext : null;
-    }
-
-    /**
-     * @param contextb      The residue in the context string (IUPAC)
-     * @param referenceBase The reference sequence (already checked that offsetidx is within bounds)
-     * @param readBase      The read sequence (already checked that offsetidx is within bounds)
-     * @return
-     */
-    protected boolean positionMatchesContext(byte contextb, final byte referenceBase, final byte readBase) {
-
-        boolean matchesContext = AlignmentUtils.compareBases(contextb, referenceBase);
-        if (!matchesContext) {
-            return false; // Don't need to check any further
-        }
-
-        // For the read, we have to handle C separately
-        boolean matchesReadContext = AlignmentUtils.compareBases(contextb, readBase);
-        if (AlignmentUtils.compareBases((byte) 'T', readBase)) {
-            matchesReadContext |= AlignmentUtils.compareBases(contextb, (byte) 'C');
-        }
-
-        return matchesReadContext;
+        return bisulfiteContext.getMatchingBisulfiteContext(reference, read, idx);
     }
 
     public Color getDisplayColor(int idx) {

--- a/src/main/java/org/broad/igv/sam/BisulfiteCounts.java
+++ b/src/main/java/org/broad/igv/sam/BisulfiteCounts.java
@@ -164,68 +164,14 @@ public class BisulfiteCounts {
     protected AlignmentTrack.BisulfiteContext contextIsMatching(byte[] reference, ByteSubarray read, int idx,
                                                                 AlignmentTrack.BisulfiteContext bisulfiteContext) {
 
-
         // TODO -- NOMESEQ
 //        for (AlignmentTrack.BisulfiteContext context : NOMESEQ_CONTEXTS) {
 //            if (super.contextIsMatching(reference, read, idx, context) != null) return context;
 //        }
 //        return null;
 
-
         // Get the context and see if it matches our desired context.
-        byte[] preContext = AlignmentTrack.getBisulfiteContextPreContext(bisulfiteContext);
-        byte[] postContext = AlignmentTrack.getBisulfiteContextPostContext(bisulfiteContext);
-
-        boolean matchesContext = true;
-
-        // First do the "post" context
-        int minLen = Math.min(reference.length, read.length);
-        if ((idx + postContext.length) >= minLen) {
-            matchesContext = false;
-        } else {
-            // Cut short whenever we don't match
-            for (int posti = 0; matchesContext && (posti < postContext.length); posti++) {
-                byte contextb = postContext[posti];
-                int offsetidx = idx + 1 + posti;
-                matchesContext &= positionMatchesContext(contextb, reference[offsetidx], read.getByte(offsetidx));
-            }
-        }
-
-        // Now do the pre context
-        if ((idx - preContext.length) < 0) {
-            matchesContext = false;
-        } else {
-            // Cut short whenever we don't match
-            for (int prei = 0; matchesContext && (prei < preContext.length); prei++) {
-                byte contextb = preContext[prei];
-                int offsetidx = idx - (preContext.length - prei);
-                matchesContext &= positionMatchesContext(contextb, reference[offsetidx], read.getByte(offsetidx));
-            }
-        }
-
-        return (matchesContext) ? bisulfiteContext : null;
-    }
-
-    /**
-     * @param contextb      The residue in the context string (IUPAC)
-     * @param referenceBase The reference sequence (already checked that offsetidx is within bounds)
-     * @param readBase      The read sequence (already checked that offsetidx is within bounds)
-     * @return
-     */
-    protected boolean positionMatchesContext(byte contextb, final byte referenceBase, final byte readBase) {
-
-        boolean matchesContext = AlignmentUtils.compareBases(contextb, referenceBase);
-        if (!matchesContext) {
-            return false; // Don't need to check any further
-        }
-
-        // For the read, we have to handle C separately
-        boolean matchesReadContext = AlignmentUtils.compareBases(contextb, readBase);
-        if (AlignmentUtils.compareBases((byte) 'T', readBase)) {
-            matchesReadContext |= AlignmentUtils.compareBases(contextb, (byte) 'C');
-        }
-
-        return matchesReadContext;
+        return bisulfiteContext.getMatchingBisulfiteContext(reference, read, idx);
     }
 
 

--- a/test/sessions/bisulfite_session.xml
+++ b/test/sessions/bisulfite_session.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<Session genome="hg18" locus="chr11:8563179-8583350" version="8">
+    <Resources>
+        <Resource path="https://s3.amazonaws.com/igv.org.test/data/WGBS/stk33/normal.STK33.bam" type="bam"/>
+        <Resource path="https://s3.amazonaws.com/igv.org.test/data/WGBS/stk33/cpgIslands.bed" type="bed"/>
+        <Resource path="https://s3.amazonaws.com/igv.org.test/data/WGBS/stk33/GM12878 H3k4me3.wig" type="wig"/>
+        <Resource path="https://s3.amazonaws.com/igv.org.test/data/WGBS/stk33/tumor.STK33.bam" type="bam"/>
+    </Resources>
+    <Panel height="91" name="DataPanel" width="1367">
+        <Track attributeKey="GM12878 H3K4me3" autoScale="false" clazz="org.broad.igv.track.DataSourceTrack" color="0,150,0" fontSize="10" id="https://s3.amazonaws.com/igv.org.test/data/WGBS/stk33/GM12878 H3k4me3.wig" name="GM12878 H3K4me3" renderer="BAR_CHART" visible="true" windowFunction="mean">
+            <DataRange baseline="0.0" drawBaseline="true" flipAxis="false" maximum="79.75" minimum="0.0" type="LINEAR"/>
+        </Track>
+    </Panel>
+    <Panel height="1304" name="Panel1654030938565" width="1367">
+        <Track attributeKey="normal.STK33.bam Coverage" autoScale="true" clazz="org.broad.igv.sam.CoverageTrack" fontSize="10" id="https://s3.amazonaws.com/igv.org.test/data/WGBS/stk33/normal.STK33.bam_coverage" name="normal.STK33.bam Coverage" snpThreshold="0.2" visible="true">
+            <DataRange baseline="0.0" drawBaseline="true" flipAxis="false" maximum="86.0" minimum="0.0" type="LINEAR"/>
+        </Track>
+        <Track attributeKey="normal.STK33.bam Junctions" clazz="org.broad.igv.sam.SpliceJunctionTrack" fontSize="10" groupByStrand="false" height="60" id="https://s3.amazonaws.com/igv.org.test/data/WGBS/stk33/normal.STK33.bam_junctions" name="normal.STK33.bam Junctions" visible="false"/>
+        <Track attributeKey="normal.STK33.bam" clazz="org.broad.igv.sam.AlignmentTrack" color="185,185,185" displayMode="EXPANDED" experimentType="OTHER" fontSize="10" id="https://s3.amazonaws.com/igv.org.test/data/WGBS/stk33/normal.STK33.bam" name="normal.STK33.bam" visible="true">
+            <RenderOptions colorOption="BISULFITE"/>
+        </Track>
+    </Panel>
+    <Panel height="1052" name="Panel1654030938572" width="1367">
+        <Track attributeKey="tumor.STK33.bam Coverage" autoScale="true" clazz="org.broad.igv.sam.CoverageTrack" fontSize="10" id="https://s3.amazonaws.com/igv.org.test/data/WGBS/stk33/tumor.STK33.bam_coverage" name="tumor.STK33.bam Coverage" snpThreshold="0.2" visible="true">
+            <DataRange baseline="0.0" drawBaseline="true" flipAxis="false" maximum="68.0" minimum="0.0" type="LINEAR"/>
+        </Track>
+        <Track attributeKey="tumor.STK33.bam Junctions" clazz="org.broad.igv.sam.SpliceJunctionTrack" fontSize="10" groupByStrand="false" height="60" id="https://s3.amazonaws.com/igv.org.test/data/WGBS/stk33/tumor.STK33.bam_junctions" name="tumor.STK33.bam Junctions" visible="false"/>
+        <Track attributeKey="tumor.STK33.bam" clazz="org.broad.igv.sam.AlignmentTrack" color="185,185,185" displayMode="EXPANDED" experimentType="OTHER" fontSize="10" id="https://s3.amazonaws.com/igv.org.test/data/WGBS/stk33/tumor.STK33.bam" name="tumor.STK33.bam" visible="true">
+            <RenderOptions colorOption="BISULFITE"/>
+        </Track>
+    </Panel>
+    <Panel height="182" name="FeaturePanel" width="1367">
+        <Track attributeKey="Reference sequence" clazz="org.broad.igv.track.SequenceTrack" fontSize="10" id="Reference sequence" name="Reference sequence" sequenceTranslationStrandValue="POSITIVE" shouldShowTranslation="true" visible="true"/>
+        <Track attributeKey="Refseq Genes" clazz="org.broad.igv.track.FeatureTrack" colorScale="ContinuousColorScale;0.0;390.0;255,255,255;0,0,178" fontSize="10" groupByStrand="false" id="https://s3.amazonaws.com/igv.org.genomes/hg18/refGene.txt.gz" name="Refseq Genes" visible="true"/>
+        <Track attributeKey="cpgIslands.bed" clazz="org.broad.igv.track.FeatureTrack" colorScale="ContinuousColorScale;0.0;0.0;255,255,255;0,0,178" displayMode="EXPANDED" fontSize="10" groupByStrand="false" id="https://s3.amazonaws.com/igv.org.test/data/WGBS/stk33/cpgIslands.bed" name="CpG Islands" visible="true"/>
+    </Panel>
+    <PanelLayout dividerFractions="0.12416555407209613,0.43658210947930576,0.7503337783711616"/>
+    <HiddenAttributes>
+        <Attribute name="DATA FILE"/>
+        <Attribute name="DATA TYPE"/>
+        <Attribute name="NAME"/>
+    </HiddenAttributes>
+</Session>


### PR DESCRIPTION
I moved a bunch of maps and functions that were used with the enum into actually being part of the enum.  This should remove clutter and make it clearer.