### PR TITLE
Fixing the treatment of PairedAlignment so gotoMate works.

### DIFF
--- a/src/main/java/org/broad/igv/sam/Alignment.java
+++ b/src/main/java/org/broad/igv/sam/Alignment.java
@@ -170,4 +170,15 @@ public interface Alignment extends LocusScore {
     default String getAlignmentValueString(double position, int mouseX, AlignmentTrack.RenderOptions renderOptions) {
         return getValueString(position, mouseX, (WindowFunction) null);
     }
+
+    /**
+     * Get the most specific sub alignment which contains the given chromosome location, implementations which
+     * contain multiple distinct sub alignments should override this to provide the appropriate behavior
+     * Note: no check is performed to validate that the location is on the same chromosome as this alignment
+     * @param location the location on the chromosome to select an alignment from
+     * @return the alignment (or sub-alignment) that contains the given location, null if this alignment does not contain it
+     */
+    default Alignment getSpecificAlignment(double location) {
+        return this.contains(location) ? this : null;
+    }
 }

--- a/src/main/java/org/broad/igv/sam/AlignmentTrack.java
+++ b/src/main/java/org/broad/igv/sam/AlignmentTrack.java
@@ -853,6 +853,13 @@ public class AlignmentTrack extends AbstractTrack implements IGVEventObserver {
     }
 
 
+
+    Alignment getAlignmentAt(final TrackClickEvent te) {
+        MouseEvent e = te.getMouseEvent();
+        final ReferenceFrame frame = te.getFrame();
+        return frame == null ? null : getAlignmentAt(frame.getChromosomePosition(e), e.getY(), frame);
+    }
+
     Alignment getAlignmentAt(double position, int y, ReferenceFrame frame) {
 
         if (alignmentsRect == null || dataManager == null) {
@@ -885,12 +892,16 @@ public class AlignmentTrack extends AbstractTrack implements IGVEventObserver {
         MouseEvent e = te.getMouseEvent();
         if (Globals.IS_MAC && e.isMetaDown() || (!Globals.IS_MAC && e.isControlDown())) {
             // Selection
-            final ReferenceFrame frame = te.getFrame();
-            if (frame != null) {
-                selectAlignment(e, frame);
-                IGV.getInstance().repaint(this);
-                return true;
+            Alignment alignment = this.getAlignmentAt(te);
+            if (alignment != null) {
+                if (selectedReadNames.containsKey(alignment.getReadName())) {
+                    selectedReadNames.remove(alignment.getReadName());
+                } else {
+                    setSelectedAlignment(alignment);
+                }
+                IGV.getInstance().repaint(this); //todo check if doing this conditionally here is ok
             }
+            return true;
         }
 
         InsertionInterval insertionInterval = getInsertionInterval(te.getFrame(), te.getMouseEvent().getX(), te.getMouseEvent().getY());
@@ -916,19 +927,6 @@ public class AlignmentTrack extends AbstractTrack implements IGVEventObserver {
         }
 
         return false;
-    }
-
-    private void selectAlignment(MouseEvent e, ReferenceFrame frame) {
-        double location = frame.getChromosomePosition(e.getX());
-        Alignment alignment = this.getAlignmentAt(location, e.getY(), frame);
-        if (alignment != null) {
-            if (selectedReadNames.containsKey(alignment.getReadName())) {
-                selectedReadNames.remove(alignment.getReadName());
-            } else {
-                setSelectedAlignment(alignment);
-            }
-
-        }
     }
 
     void setSelectedAlignment(Alignment alignment) {

--- a/src/main/java/org/broad/igv/sam/AlignmentTrackMenu.java
+++ b/src/main/java/org/broad/igv/sam/AlignmentTrackMenu.java
@@ -37,6 +37,7 @@ import java.awt.event.ActionListener;
 import java.awt.event.MouseEvent;
 import java.util.*;
 import java.util.List;
+import java.util.function.BiConsumer;
 
 import static org.broad.igv.prefs.Constants.*;
 
@@ -58,12 +59,7 @@ class AlignmentTrackMenu extends IGVPopupMenu {
         this.alignmentTrack = alignmentTrack;
         this.dataManager = alignmentTrack.getDataManager();
         this.renderOptions = alignmentTrack.getRenderOptions();
-
-        final MouseEvent me = e.getMouseEvent();
-        final ReferenceFrame frame = e.getFrame();
-        final Alignment clickedAlignment = (frame == null) ? null :
-                alignmentTrack.getAlignmentAt(frame.getChromosomePosition(me.getX()), me.getY(), frame);
-
+        final Alignment clickedAlignment = alignmentTrack.getAlignmentAt(e);
 
         // Title
         JLabel popupTitle = new JLabel("  " + alignmentTrack.getName(), JLabel.CENTER);
@@ -350,7 +346,7 @@ class AlignmentTrackMenu extends IGVPopupMenu {
         }
         final Range range = frame.getCurrentRange();
         final String chrom = range.getChr();
-        final int chromStart = (int) frame.getChromosomePosition(me.getX());
+        final int chromStart = (int) frame.getChromosomePosition(me);
 
         // Change track height by attribute
         JMenu groupMenu = new JMenu("Group alignments by");
@@ -623,7 +619,7 @@ class AlignmentTrackMenu extends IGVPopupMenu {
         if (frame == null) {
             item.setEnabled(false);
         } else {
-            final double location = frame.getChromosomePosition(me.getX());
+            final double location = frame.getChromosomePosition(me);
 
             // Change track height by attribute
             item.addActionListener(aEvt -> copyToClipboard(te, alignment, location, me.getX()));
@@ -646,56 +642,30 @@ class AlignmentTrackMenu extends IGVPopupMenu {
         add(item);
     }
 
-    void addGoToMate(final TrackClickEvent te, Alignment alignment) {
-        // Change track height by attribute
+    void addGoToMate(final TrackClickEvent te, Alignment clickedAlignment) {
         JMenuItem item = new JMenuItem("Go to mate");
-        MouseEvent e = te.getMouseEvent();
-
-        final ReferenceFrame frame = te.getFrame();
-        if (frame == null) {
-            item.setEnabled(false);
-        } else {
-            item.addActionListener(aEvt -> gotoMate(te, alignment));
-            if (alignment == null || !alignment.isPaired() || !alignment.getMate().isMapped()) {
-                item.setEnabled(false);
-            }
-        }
+        addActionIfMatesAreMapped(te, clickedAlignment, item, this::gotoMate);
         add(item);
     }
 
     void showMateRegion(final TrackClickEvent te, Alignment clickedAlignment) {
-        // Change track height by attribute
         JMenuItem item = new JMenuItem("View mate region in split screen");
-        MouseEvent e = te.getMouseEvent();
+        addActionIfMatesAreMapped(te, clickedAlignment, item, this::splitScreenMate);
+        add(item);
+    }
 
+    private void addActionIfMatesAreMapped(final TrackClickEvent te, final Alignment clickedAlignment, final JMenuItem item,
+                                           final BiConsumer<ReferenceFrame, Alignment> action) {
         final ReferenceFrame frame = te.getFrame();
         if (frame == null) {
             item.setEnabled(false);
         } else {
-            double location = frame.getChromosomePosition(e.getX());
-
-            if (clickedAlignment instanceof PairedAlignment) {
-                Alignment first = ((PairedAlignment) clickedAlignment).getFirstAlignment();
-                Alignment second = ((PairedAlignment) clickedAlignment).getSecondAlignment();
-                if (first.contains(location)) {
-                    clickedAlignment = first;
-
-                } else if (second.contains(location)) {
-                    clickedAlignment = second;
-
-                } else {
-                    clickedAlignment = null;
-
-                }
-            }
-
-            final Alignment alignment = clickedAlignment;
-            item.addActionListener(aEvt -> splitScreenMate(te, alignment));
+            final Alignment alignment = clickedAlignment.getSpecificAlignment(te.getChromosomePosition()); // handle PairedAlignments and the like
+            item.addActionListener(aEvt -> action.accept(frame, alignment));
             if (alignment == null || !alignment.isPaired() || !alignment.getMate().isMapped()) {
                 item.setEnabled(false);
             }
         }
-        add(item);
     }
 
     void addClearSelectionsMenuItem() {
@@ -788,8 +758,7 @@ class AlignmentTrackMenu extends IGVPopupMenu {
 
     void addShowItems() {
 
-        final CoverageTrack coverageTrack1 = alignmentTrack.getCoverageTrack();
-        final CoverageTrack coverageTrack = coverageTrack1;
+        final CoverageTrack coverageTrack = alignmentTrack.getCoverageTrack();
         if (coverageTrack != null) {
             final JMenuItem item = new JCheckBoxMenuItem("Show Coverage Track");
             item.setSelected(coverageTrack.isVisible());
@@ -835,7 +804,7 @@ class AlignmentTrackMenu extends IGVPopupMenu {
 
         final JMenuItem item = new JMenuItem("Copy read sequence");
         add(item);
-        final Alignment alignment = getSpecficAlignment(te);
+        final Alignment alignment = getSpecificAlignment(te);
         if (alignment == null) {
             item.setEnabled(false);
             return;
@@ -878,7 +847,7 @@ class AlignmentTrackMenu extends IGVPopupMenu {
         final JMenuItem item = new JMenuItem("BLAT read sequence");
         add(item);
 
-        final Alignment alignment = getSpecficAlignment(te);
+        final Alignment alignment = getSpecificAlignment(te);
         if (alignment == null) {
             item.setEnabled(false);
             return;
@@ -900,7 +869,7 @@ class AlignmentTrackMenu extends IGVPopupMenu {
     }
 
     void addBlatClippingItems(final TrackClickEvent te) {
-        final Alignment alignment = getSpecficAlignment(te);
+        final Alignment alignment = getSpecificAlignment(te);
         if (alignment == null) {
             return;
         }
@@ -953,7 +922,7 @@ class AlignmentTrackMenu extends IGVPopupMenu {
         final JMenuItem item = new JMenuItem("ExtView");
         add(item);
 
-        final Alignment alignment = getAlignment(te);
+        final Alignment alignment = alignmentTrack.getAlignmentAt(te);
         if (alignment == null) {
             item.setEnabled(false);
             return;
@@ -1123,9 +1092,7 @@ class AlignmentTrackMenu extends IGVPopupMenu {
     /**
      * Jump to the mate region
      */
-    private void gotoMate(final TrackClickEvent te, Alignment alignment) {
-
-
+    private void gotoMate(final ReferenceFrame frame, Alignment alignment) {
         if (alignment != null) {
             ReadMate mate = alignment.getMate();
             if (mate != null && mate.isMapped()) {
@@ -1136,11 +1103,11 @@ class AlignmentTrackMenu extends IGVPopupMenu {
                 int start = mate.start - 1;
 
                 // Don't change scale
-                double range = te.getFrame().getEnd() - te.getFrame().getOrigin();
+                double range = frame.getEnd() - frame.getOrigin();
                 int newStart = (int) Math.max(0, (start + (alignment.getEnd() - alignment.getStart()) / 2 - range / 2));
                 int newEnd = newStart + (int) range;
-                te.getFrame().jumpTo(chr, newStart, newEnd);
-                te.getFrame().recordHistory();
+                frame.jumpTo(chr, newStart, newEnd);
+                frame.recordHistory();
             } else {
                 MessageUtils.showMessage("Alignment does not have mate, or it is not mapped.");
             }
@@ -1152,7 +1119,7 @@ class AlignmentTrackMenu extends IGVPopupMenu {
      * Split the screen so the current view and mate region are side by side.
      * Need a better name for this method.
      */
-    private void splitScreenMate(final TrackClickEvent te, Alignment alignment) {
+    private void splitScreenMate(ReferenceFrame frame, Alignment alignment) {
 
         if (alignment != null) {
             ReadMate mate = alignment.getMate();
@@ -1163,7 +1130,6 @@ class AlignmentTrackMenu extends IGVPopupMenu {
                 String mateChr = mate.getChr();
                 int mateStart = mate.start - 1;
 
-                ReferenceFrame frame = te.getFrame();
                 String locus1 = frame.getFormattedLocusString();
 
                 // Generate a locus string for the read mate.  Keep the window width (in base pairs) == to the current range
@@ -1203,7 +1169,7 @@ class AlignmentTrackMenu extends IGVPopupMenu {
 
                 GeneList geneList = new GeneList(listName.toString(), loci, false);
                 currentSession.setCurrentGeneList(geneList);
-
+                
                 Comparator<String> geneListComparator = (n0, n1) -> {
                     ReferenceFrame f0 = FrameManager.getFrame(n0);
                     ReferenceFrame f1 = FrameManager.getFrame(n1);
@@ -1229,41 +1195,16 @@ class AlignmentTrackMenu extends IGVPopupMenu {
 
 
     /**
-     * Get the most "specific" alignment at the specified location.  Specificity refers to the smallest alignemnt
+     * Get the most "specific" alignment at the specified location.  Specificity refers to the smallest alignment
      * in a group that contains the location (i.e. if a group of linked alignments overlap take the smallest one).
      *
      * @param te
      * @return
      */
-    Alignment getSpecficAlignment(TrackClickEvent te) {
-
-        Alignment alignment = getAlignment(te);
+    Alignment getSpecificAlignment(TrackClickEvent te) {
+        Alignment alignment = alignmentTrack.getAlignmentAt(te);
         if (alignment != null) {
-            final ReferenceFrame frame = te.getFrame();
-            MouseEvent e = te.getMouseEvent();
-            final double location = frame.getChromosomePosition(e.getX());
-
-            if (alignment instanceof LinkedAlignment) {
-
-                Alignment sa = null;
-                for (Alignment a : ((LinkedAlignment) alignment).alignments) {
-                    if (a.contains(location)) {
-                        if (sa == null || (a.getAlignmentEnd() - a.getAlignmentStart() < sa.getAlignmentEnd() - sa.getAlignmentStart())) {
-                            sa = a;
-                        }
-                    }
-                }
-                alignment = sa;
-
-            } else if (alignment instanceof PairedAlignment) {
-                Alignment sa = null;
-                if (((PairedAlignment) alignment).firstAlignment.contains(location)) {
-                    sa = ((PairedAlignment) alignment).firstAlignment;
-                } else if (((PairedAlignment) alignment).secondAlignment.contains(location)) {
-                    sa = ((PairedAlignment) alignment).secondAlignment;
-                }
-                alignment = sa;
-            }
+            alignment = alignment.getSpecificAlignment(te.getChromosomePosition());
         }
         return alignment;
     }
@@ -1293,17 +1234,6 @@ class AlignmentTrackMenu extends IGVPopupMenu {
         renderOptions.setLinkedReads(linkReads);
         dataManager.packAlignments(renderOptions);
         repaint();
-    }
-
-
-    private Alignment getAlignment(final TrackClickEvent te) {
-        MouseEvent e = te.getMouseEvent();
-        final ReferenceFrame frame = te.getFrame();
-        if (frame == null) {
-            return null;
-        }
-        final double location = frame.getChromosomePosition(e.getX());
-        return alignmentTrack.getAlignmentAt(location, e.getY(), frame);
     }
 
 

--- a/src/main/java/org/broad/igv/sam/LinkedAlignment.java
+++ b/src/main/java/org/broad/igv/sam/LinkedAlignment.java
@@ -411,4 +411,19 @@ public class LinkedAlignment implements Alignment {
         }
     };
 
+    /**
+     * This chooses the smallest overlapping alignment (i.e. if a group of linked alignments overlap take the smallest one).
+     */
+    @Override
+    public Alignment getSpecificAlignment(final double location) {
+        Alignment sa = null;
+        for (Alignment a : alignments) {
+            if (a.contains(location)) {
+                if (sa == null || (a.getLengthOnReference() < sa.getLengthOnReference())) {
+                    sa = a;
+                }
+            }
+        }
+        return sa;
+    }
 }

--- a/src/main/java/org/broad/igv/sam/PairedAlignment.java
+++ b/src/main/java/org/broad/igv/sam/PairedAlignment.java
@@ -332,4 +332,20 @@ public class PairedAlignment implements Alignment {
         return firstAlignment.isSupplementary() && (secondAlignment == null || secondAlignment.isSupplementary());
     }
 
+    /**
+     *
+     * @return the individual Alignment at location or null if neither contains it, if they overlap first is preferred
+     */
+    @Override
+    public Alignment getSpecificAlignment(final double location) {
+        Alignment first = getFirstAlignment();
+        Alignment second = getSecondAlignment();
+        if (first.contains(location)) {
+            return first;
+        } else if (second.contains(location)) {
+            return second;
+        } else {
+            return null;
+        }
+    }
 }

--- a/src/main/java/org/broad/igv/track/FeatureTrack.java
+++ b/src/main/java/org/broad/igv/track/FeatureTrack.java
@@ -633,7 +633,7 @@ public class FeatureTrack extends AbstractTrack implements IGVEventObserver {
         MouseEvent e = te.getMouseEvent();
         final ReferenceFrame referenceFrame = te.getFrame();
         if (referenceFrame != null) {
-            double location = referenceFrame.getChromosomePosition(e.getX());
+            double location = referenceFrame.getChromosomePosition(e);
             List<Feature> features = getAllFeatureAt(location, e.getY(), referenceFrame);
             return (features != null && features.size() > 0) ? features.get(0) : null;
         } else {

--- a/src/main/java/org/broad/igv/track/SelectableFeatureTrack.java
+++ b/src/main/java/org/broad/igv/track/SelectableFeatureTrack.java
@@ -66,7 +66,7 @@ public class SelectableFeatureTrack extends FeatureTrack {
         boolean foundExon = false;
         if (f != null && f instanceof IGVFeature) {
             selectedFeature = (IGVFeature) f;
-            double location = te.getFrame().getChromosomePosition(e.getX());
+            double location = te.getFrame().getChromosomePosition(e);
             if (selectedFeature.getExons() != null) {
                 for (Exon exon : selectedFeature.getExons()) {
                     if (location >= exon.getStart() && location < exon.getEnd()) {

--- a/src/main/java/org/broad/igv/track/TrackClickEvent.java
+++ b/src/main/java/org/broad/igv/track/TrackClickEvent.java
@@ -42,7 +42,7 @@ public class TrackClickEvent {
     public TrackClickEvent(MouseEvent mouseEvent, ReferenceFrame frame) {
         this.mouseEvent = mouseEvent;
         this.frame = frame;
-        this.chromosomePosition = frame == null ? 0 :  frame.getChromosomePosition(mouseEvent.getX());
+        this.chromosomePosition = frame == null ? 0 : frame.getChromosomePosition(mouseEvent);
     }
 
 

--- a/src/main/java/org/broad/igv/ui/panel/DataPanel.java
+++ b/src/main/java/org/broad/igv/ui/panel/DataPanel.java
@@ -571,7 +571,7 @@ public class DataPanel extends JComponent implements Paintable, IGVEventObserver
         public void mouseMoved(MouseEvent e) {
             String position = null;
             if (!frame.getChrName().equals(Globals.CHR_ALL)) {
-                int location = (int) frame.getChromosomePosition(e.getX()) + 1;
+                int location = (int) frame.getChromosomePosition(e) + 1;
                 position = frame.getChrName() + ":" + locationFormatter.format(location);
                 IGV.getInstance().setStatusBarMessag2(position);
             }
@@ -723,11 +723,11 @@ public class DataPanel extends JComponent implements Paintable, IGVEventObserver
                 final Track track = ((DataPanel) e.getSource()).getTrack(e.getX(), e.getY());
 
                 if (e.isShiftDown()) {
-                    final double locationClicked = frame.getChromosomePosition(e.getX());
+                    final double locationClicked = frame.getChromosomePosition(e);
                     frame.doIncrementZoom(3, locationClicked);
                     e.consume();
                 } else if (e.isAltDown()) {
-                    final double locationClicked = frame.getChromosomePosition(e.getX());
+                    final double locationClicked = frame.getChromosomePosition(e);
                     frame.doIncrementZoom(-1, locationClicked);
                     e.consume();
                 } else if ((e.isMetaDown() || e.isControlDown()) && track != null) {
@@ -744,7 +744,7 @@ public class DataPanel extends JComponent implements Paintable, IGVEventObserver
 
                     if (clickTime - lastClickTime < UIConstants.getDoubleClickInterval()) {
                         clickScheduler.cancelClickTask();
-                        final double locationClicked = frame.getChromosomePosition(e.getX());
+                        final double locationClicked = frame.getChromosomePosition(e);
                         frame.doIncrementZoom(1, locationClicked);
 
                     } else {

--- a/src/main/java/org/broad/igv/ui/panel/ReferenceFrame.java
+++ b/src/main/java/org/broad/igv/ui/panel/ReferenceFrame.java
@@ -46,6 +46,8 @@ import org.broad.igv.sam.InsertionMarker;
 import org.broad.igv.ui.IGV;
 import org.broad.igv.ui.util.MessageUtils;
 
+import java.awt.event.MouseEvent;
+
 
 /**
  * @author jrobinso
@@ -508,6 +510,10 @@ public class ReferenceFrame {
     // layout manager?
     public int getWidthInPixels() {
         return widthInPixels;
+    }
+
+    public double getChromosomePosition(final MouseEvent e) {
+        return getChromosomePosition(e.getX());
     }
 
     /**

--- a/src/main/java/org/broad/igv/ui/panel/RegionOfInterestPanel.java
+++ b/src/main/java/org/broad/igv/ui/panel/RegionOfInterestPanel.java
@@ -235,7 +235,7 @@ public class RegionOfInterestPanel extends JPanel {
             if ((e.getModifiers() & MouseEvent.CTRL_MASK) != 0) {
                 focusROI = getRegionOfInterest(e.getX());
                 if (focusROI != null) {
-                    int curPos = (int) frame.getChromosomePosition(e.getX());
+                    int curPos = (int) frame.getChromosomePosition(e);
                     int startDist = Math.abs(focusROI.getStart() - curPos);
                     int endDist = Math.abs(focusROI.getEnd() - curPos);
                     if (startDist < endDist) {
@@ -254,9 +254,9 @@ public class RegionOfInterestPanel extends JPanel {
             dragging = true;
             if (focusROI != null) {
                 if (switchStartOrEnd) {
-                    focusROI.setStart((int) frame.getChromosomePosition(e.getX()));
+                    focusROI.setStart((int) frame.getChromosomePosition(e));
                 } else {
-                    focusROI.setEnd((int) frame.getChromosomePosition(e.getX()));
+                    focusROI.setEnd((int) frame.getChromosomePosition(e));
                 }
                 IGV.getInstance().repaint();
             }

--- a/src/main/java/org/broad/igv/ui/panel/RulerPanel.java
+++ b/src/main/java/org/broad/igv/ui/panel/RulerPanel.java
@@ -444,7 +444,7 @@ public class RulerPanel extends JPanel {
                 try {
 
                     if (!isWholeGenomeView()) {
-                        double newLocation = frame.getChromosomePosition(e.getX());
+                        double newLocation = frame.getChromosomePosition(e);
                         frame.centerOnLocation(newLocation);
                     } else {
                         for (final ClickLink link : chromosomeRects) {


### PR DESCRIPTION
I noticed that 'gotoMate' didn't work when in linked pairs mode, but 'view mate region' in split screen did.  This generalizes the logic so that the same conditions apply to both.  It helps prepare for https://github.com/igvteam/igv/issues/738

* Adding a default method getSpecificAlignment(location) to Alignment which returns the most specific sub alignment at a location, it is specialized in PairedAlignment and LinkedAlignment
* Cleaning up and unifying code so that gotoMate and viewMateInSplit screen work in the same circumstances
* Adding overloads and changing parameters in several methods to reduce boilerplate.