### PR TITLE
Fixes a URL query parsing bug for Vcf to BAM mapping

### DIFF
--- a/src/main/java/org/broad/igv/variant/VariantTrack.java
+++ b/src/main/java/org/broad/igv/variant/VariantTrack.java
@@ -236,8 +236,17 @@ public class VariantTrack extends FeatureTrack implements IGVEventObserver {
 
         boolean bypassFileAutoDiscovery = prefMgr.getAsBoolean(BYPASS_FILE_AUTO_DISCOVERY);
         if (vcfToBamMapping == null && path != null && !bypassFileAutoDiscovery) {
-            if (ParsingUtils.fileExists(path + ".mapping")) {
-                vcfToBamMapping = path + ".mapping";
+	    String mappingFile = "";
+            int queryStart = path.indexOf("?");
+            if (queryStart > -1)
+            {
+                String query =  path.substring(queryStart);
+                path = path.substring(0,queryStart);
+                mappingFile = path + ".mapping" + query;
+            }
+
+            if (ParsingUtils.fileExists(mappingFile)) {
+                vcfToBamMapping = mappingFile;
             }
         }
 


### PR DESCRIPTION
I have found another bug in URL parsing. My authentication token passed inside a URL was treated as a part of the filename and I was getting Error 403. I have implemented a simple fix.