### PR TITLE
Add the option to split screen chimeric reads.

### DIFF
--- a/src/main/java/org/broad/igv/lists/GeneList.java
+++ b/src/main/java/org/broad/igv/lists/GeneList.java
@@ -168,6 +168,6 @@ public class GeneList {
 //    }
 
     public void sort(Comparator<String> comparator) {
-        Collections.sort(this.loci, comparator);
+        this.loci.sort(comparator);
     }
 }

--- a/src/main/java/org/broad/igv/sam/AlignmentTrackMenu.java
+++ b/src/main/java/org/broad/igv/sam/AlignmentTrackMenu.java
@@ -1205,22 +1205,8 @@ class AlignmentTrackMenu extends IGVPopupMenu {
         final Session currentSession = IGV.getInstance().getSession();
         currentSession.setCurrentGeneList(geneList);
 
-        Comparator<String> geneListComparator = (n0, n1) -> {
-            ReferenceFrame f0 = FrameManager.getFrame(n0);
-            ReferenceFrame f1 = FrameManager.getFrame(n1);
-
-            String chr0 = f0 == null ? "" : f0.getChrName();
-            String chr1 = f1 == null ? "" : f1.getChrName();
-            int s0 = f0 == null ? 0 : f0.getCurrentRange().getStart();
-            int s1 = f1 == null ? 0 : f1.getCurrentRange().getStart();
-
-            int chrComp = ChromosomeNameComparator.get().compare(chr0, chr1);
-            if (chrComp != 0) return chrComp;
-            return s0 - s1;
-        };
-
         //Need to sort the frames by position
-        currentSession.sortGeneList(geneListComparator);
+        currentSession.sortGeneList(FrameManager.getFrameC);
         IGV.getInstance().resetFrames();
     }
 

--- a/src/main/java/org/broad/igv/sam/AlignmentTrackMenu.java
+++ b/src/main/java/org/broad/igv/sam/AlignmentTrackMenu.java
@@ -6,7 +6,6 @@ import org.broad.igv.Globals;
 import org.broad.igv.feature.Locus;
 import org.broad.igv.feature.Range;
 import org.broad.igv.feature.Strand;
-import org.broad.igv.feature.genome.ChromosomeNameComparator;
 import org.broad.igv.jbrowse.CircularViewUtilities;
 import org.broad.igv.lists.GeneList;
 import org.broad.igv.logging.LogManager;
@@ -14,7 +13,6 @@ import org.broad.igv.logging.Logger;
 import org.broad.igv.prefs.Constants;
 import org.broad.igv.prefs.PreferencesManager;
 import org.broad.igv.sashimi.SashimiPlot;
-import org.broad.igv.session.Session;
 import org.broad.igv.tools.PFMExporter;
 import org.broad.igv.track.SequenceTrack;
 import org.broad.igv.track.Track;
@@ -178,7 +176,7 @@ class AlignmentTrackMenu extends IGVPopupMenu {
     }
 
     private void addShowChimericRegions(final AlignmentTrack alignmentTrack, final TrackClickEvent e, final Alignment clickedAlignment) {
-        JMenuItem item = new JMenuItem("View supplementary (chimeric) alignments in split screen");
+        JMenuItem item = new JMenuItem("View chimeric alignments in split screen");
         if (clickedAlignment.getAttribute(SAMTag.SA.name()) != null) {
             item.setEnabled(true);
             item.addActionListener(aEvt -> {
@@ -1199,14 +1197,10 @@ class AlignmentTrackMenu extends IGVPopupMenu {
                 .collect(Collectors.toList());
         List<String> loci = createLociList(frame, newLoci);
         String listName = String.join("   ", loci); // TODO check the trailing "   " was unnecessary
-
-        GeneList geneList = new GeneList(listName, loci, false);
-
-        final Session currentSession = IGV.getInstance().getSession();
-        currentSession.setCurrentGeneList(geneList);
-
         //Need to sort the frames by position
-        currentSession.sortGeneList(FrameManager.getFrameC);
+        GeneList geneList = new GeneList(listName, loci, false);
+        geneList.sort(FrameManager.FRAME_COMPARATOR);
+        IGV.getInstance().getSession().setCurrentGeneList(geneList);
         IGV.getInstance().resetFrames();
     }
 

--- a/src/main/java/org/broad/igv/sam/ReadMate.java
+++ b/src/main/java/org/broad/igv/sam/ReadMate.java
@@ -30,9 +30,10 @@
 package org.broad.igv.sam;
 
 
+import htsjdk.samtools.util.Locatable;
 import org.broad.igv.feature.Strand;
 
-public class ReadMate {
+public class ReadMate implements Locatable {
 
     private String chr;
     int start;
@@ -55,8 +56,18 @@ public class ReadMate {
         return chr + ":" + start + " (" + (isNegativeStrand() ? "-" : "+") + ")";
     }
 
+    @Override
+    public String getContig() {
+        return chr;
+    }
+
     public int getStart() {
         return start;
+    }
+
+    @Override
+    public int getEnd() {
+        throw new UnsupportedOperationException("ReadMate has an unknown end.");
     }
 
     public boolean isNegativeStrand() {
@@ -68,6 +79,6 @@ public class ReadMate {
     }
 
     public String getChr() {
-        return chr;
+        return getContig();
     }
 }

--- a/src/main/java/org/broad/igv/sam/SupplementaryAlignment.java
+++ b/src/main/java/org/broad/igv/sam/SupplementaryAlignment.java
@@ -1,8 +1,13 @@
 package org.broad.igv.sam;
 
+import htsjdk.samtools.util.Locatable;
 import org.broad.igv.Globals;
 
-public class SupplementaryAlignment {
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class SupplementaryAlignment implements Locatable {
 
     public String chr;
     public int start;
@@ -28,6 +33,11 @@ public class SupplementaryAlignment {
                 + " (" + strand + ") = " + Globals.DECIMAL_FORMAT.format(lenOnRef) + "bp  @MAPQ " + mapQ + " NM" + numMismatches;
     }
 
+    public static List<SupplementaryAlignment> parseFromSATag(String saTag){
+        return Arrays.stream(Globals.semicolonPattern.split(saTag))
+                .map(SupplementaryAlignment::new)
+                .collect(Collectors.toList());
+    }
 
     int computeLengthOnReference(String cigarString) {
 
@@ -52,5 +62,20 @@ public class SupplementaryAlignment {
 
         }
         return len;
+    }
+
+    @Override
+    public String getContig() {
+        return chr;
+    }
+
+    @Override
+    public int getStart() {
+        return start;
+    }
+
+    @Override
+    public int getEnd() {
+        return start + lenOnRef;
     }
 }

--- a/src/main/java/org/broad/igv/session/Session.java
+++ b/src/main/java/org/broad/igv/session/Session.java
@@ -415,11 +415,6 @@ public class Session implements IGVEventObserver {
         }
     }
 
-    public void sortGeneList(Comparator<String> comparator) {
-        getCurrentGeneList().sort(comparator);
-        this.setCurrentGeneList(getCurrentGeneList());
-    }
-
     public int getVersion() {
         return version;
     }
@@ -486,7 +481,7 @@ public class Session implements IGVEventObserver {
      * position string.  UCSC conventions  are followed for coordinates,
      * specifically the internal representation is "zero" based (first base is
      * numbered 0) but the display representation is "one" based (first base is
-     * numbered 1).   Consequently 1 is substracted from the parsed positions
+     * numbered 1).   Consequently, 1 is subtracted from the parsed positions
      */
     private static int[] getStartEnd(String posString) {
         try {

--- a/src/main/java/org/broad/igv/ui/panel/FrameManager.java
+++ b/src/main/java/org/broad/igv/ui/panel/FrameManager.java
@@ -247,17 +247,14 @@ public class FrameManager implements IGVEventObserver {
 
     public static void sortFrames(final Track t) {
 
-        Collections.sort(frames, new Comparator<ReferenceFrame>() {
-            @Override
-            public int compare(ReferenceFrame o1, ReferenceFrame o2) {
-                float s1 = t.getRegionScore(o1.getChromosome().getName(), (int) o1.getOrigin(), (int) o1.getEnd(),
-                        o1.getZoom(), RegionScoreType.SCORE, o1.getName());
-                float s2 = t.getRegionScore(o2.getChromosome().getName(), (int) o2.getOrigin(), (int) o2.getEnd(),
-                        o2.getZoom(), RegionScoreType.SCORE, o2.getName());
-                return (s1 == s2 ? 0 : (s1 > s2) ? -1 : 1);
-            }
-        });
-
+        frames.sort(Comparator.comparingDouble((ReferenceFrame f) ->
+                t.getRegionScore(f.getChromosome().getName(),
+                        (int) f.getOrigin(),
+                        (int) f.getEnd(),
+                        f.getZoom(),
+                        RegionScoreType.SCORE,
+                        f.getName()))
+                .reversed());
     }
 
     /**
@@ -343,7 +340,12 @@ public class FrameManager implements IGVEventObserver {
         currentSession.setCurrentGeneList(geneList);
 
         // sort the frames by position
-        currentSession.sortGeneList((n0, n1) -> {
+        currentSession.sortGeneList(getFrameComparator());
+        IGV.getInstance().resetFrames();
+    }
+
+    private static Comparator<String> getFrameComparator() {
+        return (n0, n1) -> {
             ReferenceFrame f0 = getFrame(n0);
             ReferenceFrame f1 = getFrame(n1);
 
@@ -355,8 +357,7 @@ public class FrameManager implements IGVEventObserver {
             int chrComp = ChromosomeNameComparator.get().compare(chr0, chr1);
             if (chrComp != 0) return chrComp;
             return s0 - s1;
-        });
-        IGV.getInstance().resetFrames();
+        };
     }
 
 


### PR DESCRIPTION
Adding `View chimeric alignments in split screen` option which shows up when a read has an SA tag.

This resolves #738 
I did some related refactoring to make splitting out frames simpler.  
* I inlined and moved around some of the code that 
* Cleaned up a few comparators and removed a duplicated one
* Added Locatable interface to ReadMate and SupplementaryAlignment so they could be handled without special cases in my code.  I don't know if this is preferred interface to use, happy to change it to one of the IGV specific ones if that would be clearer.
