### PR TITLE
Add a dedicated 6mA color mode

### DIFF
--- a/src/main/java/org/broad/igv/sam/AlignmentRenderer.java
+++ b/src/main/java/org/broad/igv/sam/AlignmentRenderer.java
@@ -1301,6 +1301,7 @@ public class AlignmentRenderer {
             case BASE_MODIFICATION:
             case BASE_MODIFICATION_5MC:
             case BASE_MODIFICATION_C:
+            case BASE_MODIFICATION_6MA:
             case SMRT_SUBREAD_IPD:
             case SMRT_SUBREAD_PW:
             case SMRT_CCS_FWD_IPD:

--- a/src/main/java/org/broad/igv/sam/AlignmentTrack.java
+++ b/src/main/java/org/broad/igv/sam/AlignmentTrack.java
@@ -103,6 +103,7 @@ public class AlignmentTrack extends AbstractTrack implements IGVEventObserver {
         BASE_MODIFICATION,
         BASE_MODIFICATION_5MC,
         BASE_MODIFICATION_C,
+        BASE_MODIFICATION_6MA,
         SMRT_SUBREAD_IPD,
         SMRT_SUBREAD_PW,
         SMRT_CCS_FWD_IPD,
@@ -111,7 +112,7 @@ public class AlignmentTrack extends AbstractTrack implements IGVEventObserver {
         SMRT_CCS_REV_PW;
 
         public boolean isBaseMod() {
-            return this == BASE_MODIFICATION || this == BASE_MODIFICATION_5MC || this == BASE_MODIFICATION_C;
+            return this == BASE_MODIFICATION || this == BASE_MODIFICATION_5MC || this == BASE_MODIFICATION_C || this == BASE_MODIFICATION_6MA;
         }
 
         public boolean isSMRTKinetics() {

--- a/src/main/java/org/broad/igv/sam/AlignmentTrackMenu.java
+++ b/src/main/java/org/broad/igv/sam/AlignmentTrackMenu.java
@@ -636,6 +636,7 @@ class AlignmentTrackMenu extends IGVPopupMenu {
         mappings.put("base modification", AlignmentTrack.ColorOption.BASE_MODIFICATION);
         mappings.put("base modification (5mC)", AlignmentTrack.ColorOption.BASE_MODIFICATION_5MC);
         mappings.put("base modification (all C)", AlignmentTrack.ColorOption.BASE_MODIFICATION_C);
+        mappings.put("base modification (6mA)", AlignmentTrack.ColorOption.BASE_MODIFICATION_6MA);
         colorMenu.addSeparator();
         for (Map.Entry<String, AlignmentTrack.ColorOption> el : mappings.entrySet()) {
             JRadioButtonMenuItem mi = getColorMenuItem(el.getKey(), el.getValue());

--- a/src/main/java/org/broad/igv/sam/mods/BaseModificationCoverageRenderer.java
+++ b/src/main/java/org/broad/igv/sam/mods/BaseModificationCoverageRenderer.java
@@ -32,10 +32,10 @@ public class BaseModificationCoverageRenderer {
                 draw5MC(context, pX, pBottom, dX, barHeight, pos, alignmentCounts, true);
                 break;
             case BASE_MODIFICATION_6MA:
-                draw6MA(context, pX, pBottom, dX, barHeight, pos, alignmentCounts);
+                draw(context, pX, pBottom, dX, barHeight, pos, alignmentCounts, true);
                 break;
             default:
-                draw(context, pX, pBottom, dX, barHeight, pos, alignmentCounts);
+                draw(context, pX, pBottom, dX, barHeight, pos, alignmentCounts, false);
         }
     }
 
@@ -46,7 +46,8 @@ public class BaseModificationCoverageRenderer {
                              int dX,
                              int barHeight,
                              int pos,
-                             AlignmentCounts alignmentCounts) {
+                             AlignmentCounts alignmentCounts,
+                             boolean onlyDraw6mA) {
 
         BaseModificationCounts modificationCounts = alignmentCounts.getModifiedBaseCounts();
 
@@ -56,6 +57,12 @@ public class BaseModificationCoverageRenderer {
 
             for (BaseModificationCounts.Key key : modificationCounts.getAllModifications()) {
 
+                String modification = key.getModification();
+                if (onlyDraw6mA) {
+                    if (key.getCanonicalBase() != 'A' && key.getCanonicalBase() != 'T') continue;
+                    if (!modification.equals("a")) continue;
+                }
+
                 // The number of modification calls, some of which might have likelihood of zero
                 int modificationCount = modificationCounts.getCount(pos, key);
 
@@ -63,8 +70,6 @@ public class BaseModificationCoverageRenderer {
 
                     byte base = (byte) key.getBase();
                     byte complement = SequenceUtil.complement(base);
-                    char modStrand = key.getStrand();
-                    String modification = key.getModification();
 
                     // Count of bases at this location that could potentially be modified, accounting for strand
                     int baseCount = alignmentCounts.getPosCount(pos, base) + alignmentCounts.getNegCount(pos, complement);
@@ -155,82 +160,6 @@ public class BaseModificationCoverageRenderer {
                 Arrays.sort(orderedMods, (o1, o2) -> -1 * o1.compareTo(o2));
                 for (String m : orderedMods) {
                     Color mColor = BaseModificationColors.getModColor(m, (byte) 255, ColorOption.BASE_MODIFICATION_5MC);
-                    int mModHeight = (int) Math.round(((likelihoodSums.get(m)) / t) * calledBarHeight);
-                    if (mModHeight > 0) {
-                        baseY -= mModHeight;
-                        graphics.setColor(mColor);
-                        graphics.fillRect(pX, baseY, dX, mModHeight);
-                    }
-                }
-            }
-        }
-    }
-
-    private static void draw6MA(RenderContext context,
-                                int pX,
-                                int pBottom,
-                                int dX,
-                                int barHeight,
-                                int pos,
-                                AlignmentCounts alignmentCounts) {
-
-        BaseModificationCounts modificationCounts = alignmentCounts.getModifiedBaseCounts();
-
-        if (modificationCounts != null) {
-
-            final byte base = (byte) 'A';
-            final byte complement = (byte) 'T';
-
-            Map<String, Integer> likelihoodSums = new HashMap<>();
-            Map<String, Integer> modCounts = new HashMap<>();
-            for (BaseModificationCounts.Key key : modificationCounts.getAllModifications()) {
-
-                if (key.getCanonicalBase() != 'A' && key.getCanonicalBase() != 'T') continue;
-                if (key.getModification().equals("a")) {
-                    String mod = key.getModification();
-                    final int count = modificationCounts.getCount(pos, key);
-                    if (count > 0) {
-                        modCounts.put(mod, count);
-                        final int likelhoodSum = modificationCounts.getLikelhoodSum(pos, key);
-                        likelihoodSums.put(mod, likelhoodSum);
-                    }
-                }
-            }
-
-            if (likelihoodSums.size() > 0) {
-
-                // Count of bases at this location that could potentially be modified
-                double modifiableBaseCount = alignmentCounts.getPosCount(pos, base) + alignmentCounts.getNegCount(pos, complement);
-
-                // Compute "snp factor", ratio of count of base calls that could be modfied (on either strand) to
-                // total count. This is normally close to 1, but can be less due non CG bases at this location (e.g. snps)
-                double cgCount = alignmentCounts.getCount(pos, base) + alignmentCounts.getCount(pos, complement);
-                double snpFactor = cgCount / alignmentCounts.getTotalCount(pos);
-
-                double calledBarHeight = snpFactor * barHeight;
-                double t = modifiableBaseCount * 255;   // If all bases are called this is the total sum of all likelihoods, including "no mod" likelihood
-
-                // Likelihood of no modification.  It is assumed that the likelihood of no modification == (1 - sum(likelihood))
-                int c = Collections.max(modCounts.values());
-                double noModProb = c * 255;
-                for (String m : modCounts.keySet()) {
-                    if (likelihoodSums.containsKey(m)) {
-                        noModProb -= likelihoodSums.get(m);
-                    }
-                }
-
-                // Draw "no mod" bar
-                int noModHeight = (int) Math.round((noModProb / t) * calledBarHeight);
-                int baseY = pBottom - noModHeight;
-                Graphics2D graphics = context.getGraphics();
-                graphics.setColor(BaseModificationColors.noModColor5MC);
-                graphics.fillRect(pX, baseY, dX, noModHeight);
-
-                // Loop through modifications drawing bar for each
-                String[] orderedMods = likelihoodSums.keySet().toArray(new String[0]);
-                Arrays.sort(orderedMods, (o1, o2) -> -1 * o1.compareTo(o2));
-                for (String m : orderedMods) {
-                    Color mColor = BaseModificationColors.getModColor(m, (byte) 255, ColorOption.BASE_MODIFICATION_6MA);
                     int mModHeight = (int) Math.round(((likelihoodSums.get(m)) / t) * calledBarHeight);
                     if (mModHeight > 0) {
                         baseY -= mModHeight;

--- a/src/main/java/org/broad/igv/sam/mods/BaseModificationCoverageRenderer.java
+++ b/src/main/java/org/broad/igv/sam/mods/BaseModificationCoverageRenderer.java
@@ -31,6 +31,9 @@ public class BaseModificationCoverageRenderer {
             case BASE_MODIFICATION_C:
                 draw5MC(context, pX, pBottom, dX, barHeight, pos, alignmentCounts, true);
                 break;
+            case BASE_MODIFICATION_6MA:
+                draw6MA(context, pX, pBottom, dX, barHeight, pos, alignmentCounts);
+                break;
             default:
                 draw(context, pX, pBottom, dX, barHeight, pos, alignmentCounts);
         }
@@ -152,6 +155,82 @@ public class BaseModificationCoverageRenderer {
                 Arrays.sort(orderedMods, (o1, o2) -> -1 * o1.compareTo(o2));
                 for (String m : orderedMods) {
                     Color mColor = BaseModificationColors.getModColor(m, (byte) 255, ColorOption.BASE_MODIFICATION_5MC);
+                    int mModHeight = (int) Math.round(((likelihoodSums.get(m)) / t) * calledBarHeight);
+                    if (mModHeight > 0) {
+                        baseY -= mModHeight;
+                        graphics.setColor(mColor);
+                        graphics.fillRect(pX, baseY, dX, mModHeight);
+                    }
+                }
+            }
+        }
+    }
+
+    private static void draw6MA(RenderContext context,
+                                int pX,
+                                int pBottom,
+                                int dX,
+                                int barHeight,
+                                int pos,
+                                AlignmentCounts alignmentCounts) {
+
+        BaseModificationCounts modificationCounts = alignmentCounts.getModifiedBaseCounts();
+
+        if (modificationCounts != null) {
+
+            final byte base = (byte) 'A';
+            final byte complement = (byte) 'T';
+
+            Map<String, Integer> likelihoodSums = new HashMap<>();
+            Map<String, Integer> modCounts = new HashMap<>();
+            for (BaseModificationCounts.Key key : modificationCounts.getAllModifications()) {
+
+                if (key.getCanonicalBase() != 'A' && key.getCanonicalBase() != 'T') continue;
+                if (key.getModification().equals("a")) {
+                    String mod = key.getModification();
+                    final int count = modificationCounts.getCount(pos, key);
+                    if (count > 0) {
+                        modCounts.put(mod, count);
+                        final int likelhoodSum = modificationCounts.getLikelhoodSum(pos, key);
+                        likelihoodSums.put(mod, likelhoodSum);
+                    }
+                }
+            }
+
+            if (likelihoodSums.size() > 0) {
+
+                // Count of bases at this location that could potentially be modified
+                double modifiableBaseCount = alignmentCounts.getPosCount(pos, base) + alignmentCounts.getNegCount(pos, complement);
+
+                // Compute "snp factor", ratio of count of base calls that could be modfied (on either strand) to
+                // total count. This is normally close to 1, but can be less due non CG bases at this location (e.g. snps)
+                double cgCount = alignmentCounts.getCount(pos, base) + alignmentCounts.getCount(pos, complement);
+                double snpFactor = cgCount / alignmentCounts.getTotalCount(pos);
+
+                double calledBarHeight = snpFactor * barHeight;
+                double t = modifiableBaseCount * 255;   // If all bases are called this is the total sum of all likelihoods, including "no mod" likelihood
+
+                // Likelihood of no modification.  It is assumed that the likelihood of no modification == (1 - sum(likelihood))
+                int c = Collections.max(modCounts.values());
+                double noModProb = c * 255;
+                for (String m : modCounts.keySet()) {
+                    if (likelihoodSums.containsKey(m)) {
+                        noModProb -= likelihoodSums.get(m);
+                    }
+                }
+
+                // Draw "no mod" bar
+                int noModHeight = (int) Math.round((noModProb / t) * calledBarHeight);
+                int baseY = pBottom - noModHeight;
+                Graphics2D graphics = context.getGraphics();
+                graphics.setColor(BaseModificationColors.noModColor5MC);
+                graphics.fillRect(pX, baseY, dX, noModHeight);
+
+                // Loop through modifications drawing bar for each
+                String[] orderedMods = likelihoodSums.keySet().toArray(new String[0]);
+                Arrays.sort(orderedMods, (o1, o2) -> -1 * o1.compareTo(o2));
+                for (String m : orderedMods) {
+                    Color mColor = BaseModificationColors.getModColor(m, (byte) 255, ColorOption.BASE_MODIFICATION_6MA);
                     int mModHeight = (int) Math.round(((likelihoodSums.get(m)) / t) * calledBarHeight);
                     if (mModHeight > 0) {
                         baseY -= mModHeight;

--- a/src/main/java/org/broad/igv/sam/mods/BaseModificationRenderer.java
+++ b/src/main/java/org/broad/igv/sam/mods/BaseModificationRenderer.java
@@ -25,10 +25,10 @@ public class BaseModificationRenderer {
                 draw5mC(alignment, bpStart, locScale, rowRect, g, true);
                 break;
             case BASE_MODIFICATION_6MA:
-                draw6mA(alignment, bpStart, locScale, rowRect, g);
+                draw(alignment, bpStart, locScale, rowRect, g, true);
                 break;
             default:
-                draw(alignment, bpStart, locScale, rowRect, g);
+                draw(alignment, bpStart, locScale, rowRect, g, false);
         }
 
     }
@@ -47,7 +47,8 @@ public class BaseModificationRenderer {
             double bpStart,
             double locScale,
             Rectangle rowRect,
-            Graphics g) {
+            Graphics g,
+            boolean onlyDraw6mA) {
 
         List<BaseModificationSet> baseModificationSets = alignment.getBaseModificationSets();
 
@@ -75,6 +76,10 @@ public class BaseModificationRenderer {
                     byte lh = 0;
                     String modification = null;
                     for (BaseModificationSet bmSet : baseModificationSets) {
+                        if (onlyDraw6mA) {
+                            if (bmSet.getCanonicalBase() != 'A' && bmSet.getCanonicalBase() != 'T') continue;
+                            if (! bmSet.getModification().equals("a")) continue;
+                        }
                         if (bmSet.containsPosition(i)) {
                             if (modification == null || Byte.toUnsignedInt(bmSet.getLikelihoods().get(i)) > Byte.toUnsignedInt(lh)) {
                                 modification = bmSet.getModification();
@@ -183,79 +188,6 @@ public class BaseModificationRenderer {
                         }
                         g.fillRect(pX, pY, dX, Math.max(1, dY - 2));
                     }
-                }
-            }
-        }
-    }
-
-    /**
-     * Helper function for AlignmentRenderer.  Draw base modifications over alignment for "6mA" mode.
-     * <p>
-     * If multiple modifications are specified for a base the modification with the highest probability is
-     * drawn.
-     *
-     * @param alignment
-     * @param bpStart
-     * @param locScale
-     * @param rowRect
-     * @param g
-     */
-    private static void draw6mA(
-            Alignment alignment,
-            double bpStart,
-            double locScale,
-            Rectangle rowRect,
-            Graphics g) {
-
-        List<BaseModificationSet> baseModificationSets = alignment.getBaseModificationSets();
-        if (baseModificationSets == null) { return; }
-
-        for (AlignmentBlock block : alignment.getAlignmentBlocks()) {
-            // Compute bounds
-            int pY = (int) rowRect.getY();
-            int dY = (int) rowRect.getHeight();
-            int dX = (int) Math.max(1, (1.0 / locScale));
-
-            for (int i = block.getBases().startOffset; i < block.getBases().startOffset + block.getBases().length; i++) {
-
-                int blockIdx = i - block.getBases().startOffset;
-                int pX = (int) ((block.getStart() + blockIdx - bpStart) / locScale);
-
-                // Don't draw out of clipping rect
-                if (pX > rowRect.getMaxX()) {
-                    break;
-                } else if (pX + dX < rowRect.getX()) {
-                    continue;
-                }
-
-                // Search all sets for modifications of this base, select modification with largest likelihood
-                int lh = -1;
-                String modification = null;
-
-                for (BaseModificationSet bmSet : baseModificationSets) {
-
-                    if (bmSet.getCanonicalBase() != 'A' && bmSet.getCanonicalBase() != 'T') continue;
-                    if (! bmSet.getModification().equals("a")) continue;
-
-                    if (bmSet.containsPosition(i)) {
-                        int l = Byte.toUnsignedInt(bmSet.getLikelihoods().get(i));
-                        if (modification == null || l > lh) {
-                            modification = bmSet.getModification();
-                            lh = l;
-                        }
-                    }
-                }
-
-                if (modification != null) {
-                    Color c = BaseModificationColors.getModColor(modification, (byte) lh, AlignmentTrack.ColorOption.BASE_MODIFICATION_6MA);
-                    g.setColor(c);
-
-                    // Expand narrow width to make more visible
-                    if (dX < 3) {
-                        dX = 3;
-                        pX--;
-                    }
-                    g.fillRect(pX, pY, dX, Math.max(1, dY - 2));
                 }
             }
         }


### PR DESCRIPTION
This allows a user to visualize 6mA modifications only when viewing a bam file containing multiple modification types.

----

This is an initial proposal for a dedicated 6mA visualization option. This has come up in the context of Fiber-Seq samples, where the bam is annotated with both 5mC and 6mA modifications, and it can be useful to view the 6mA modifications only.