### PR TITLE
Added nucleotide color options to the preferences menu

### DIFF
--- a/src/main/java/org/broad/igv/renderer/SequenceRenderer.java
+++ b/src/main/java/org/broad/igv/renderer/SequenceRenderer.java
@@ -100,7 +100,7 @@ public class SequenceRenderer {
 
 
     public SequenceRenderer() {
-        if (nucleotideColors == null) setNucleotideColors();
+        setNucleotideColors();
         translatedSequenceDrawer = new TranslatedSequenceDrawer();
     }
 

--- a/src/main/resources/org/broad/igv/prefs/preferences.tab
+++ b/src/main/resources/org/broad/igv/prefs/preferences.tab
@@ -25,6 +25,13 @@ DEFAULT_FONT_SIZE	Default font size	integer	10
 SCALE_FONTS	Scale fonts	boolean	FALSE	Scale fonts for high resolution screens. Requires restart.
 ENABLE_ANTIALIASING	Enable anti-aliasing	boolean	TRUE
 
+##Nucleotide Colors
+COLOR.A	A	color	0,150,0
+COLOR.C	C	color	0,0,255
+COLOR.T	T	color	255,0,0
+COLOR.G	G	color	209,113,5
+COLOR.N	n	color	128,128,128
+
 #Tracks
 IGV.chart.track.height	Default numeric track height (pixels)	integer	40
 IGV.track.height	Default feature track height (pixels)	integer	15
@@ -327,11 +334,6 @@ CBIO_EXPRESSION_DOWN_THRESHOLD	1
 DETAILS_BEHAVIOR	CLICK
 SHOW_SIZE_WARNING	TRUE
 SKIP_VERSION
-COLOR.A	0,150,0
-COLOR.C	0,0,255
-COLOR.T	255,0,0
-COLOR.G	209,113,5
-COLOR.N	128,128,128
 
 SASHIMI.SHOW_COVERAGE	TRUE
 GENE_LIST_BED_FORMAT	FALSE


### PR DESCRIPTION
Added the ability to set nucleotide color options to the preferences menu, under General > Nucleotide Colors.

Also modified SequenceRenderer to update nucleotide colors from preferences when a new SequenceRenderer is instantiated.  This way, the colors will be updated when reloading the session or loading a new session.  I'm not sure if this is the ideal solution to the problem of updating the colors without having to restart, so I'd be very happy to change it if there is a better way.