### PR TITLE
Set focus on OK button in LoginDialog

### DIFF
--- a/src/main/java/org/broad/igv/util/LoginDialog.java
+++ b/src/main/java/org/broad/igv/util/LoginDialog.java
@@ -165,6 +165,7 @@ public class LoginDialog extends org.broad.igv.ui.IGVDialog  {
                         okButtonActionPerformed(e);
                     }
                 });
+                this.getRootPane().setDefaultButton(okButton);
                 buttonBar.add(okButton, new GridBagConstraints(1, 0, 1, 1, 0.0, 0.0,
                         GridBagConstraints.CENTER, GridBagConstraints.BOTH,
                         new Insets(0, 0, 0, 5), 0, 0));


### PR DESCRIPTION
A small change that sets a focus on OK button for the login dialog (e.g. if a proxy server is used). Currently if a user types in credentials and hits Enter, nothing happens. After incorporating this tiny fix, OK button will be pressed on hitting Enter.