### PR TITLE
Added empty line to 204 http response

### DIFF
--- a/src/main/java/org/broad/igv/batch/CommandListener.java
+++ b/src/main/java/org/broad/igv/batch/CommandListener.java
@@ -339,6 +339,8 @@ public class CommandListener implements Runnable {
                 out.print(result);
                 out.print(CRLF);
             }
+        } else {
+            out.print(CRLF);
         }
         out.close();
     }


### PR DESCRIPTION
For case when 'result' is null and IGV sends HTTP_NO_RESPONSE http headers are not followed by empty line (but it should be so https://httpcodes.fyi/204/). It results in missing Access-Control-Allow-Origin header in response for 204 code.

Added empty line to http response in case result is null.
