### PR TITLE
Upate to htsjdk 4.0.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -111,7 +111,7 @@ dependencies {
             [group: 'org.xerial.snappy', name: 'snappy-java', version: '1.1.7.3'],
             [group: 'org.apache.commons', name: 'commons-jexl', version: '2.1.1'],
             [group: 'org.apache.commons', name: 'commons-lang3', version: '3.9'],
-            [group: 'com.github.samtools', name: 'htsjdk', version: '3.0.5'],
+            [group: 'com.github.samtools', name: 'htsjdk', version: '4.0.2'],
             [group: 'org.swinglabs', name: 'swing-layout', version: '1.0.3'],
             [group: 'com.formdev', name: 'jide-oss', version: '3.7.12'],
             [group: 'com.google.guava', name: 'guava', version: '27.0.1-jre'],

--- a/src/main/java/org/broad/igv/feature/Cytoband.java
+++ b/src/main/java/org/broad/igv/feature/Cytoband.java
@@ -26,7 +26,7 @@
 package org.broad.igv.feature;
 
 
-public class Cytoband implements NamedFeature {
+public class Cytoband implements IGVNamedFeature {
     String chromosome;
     String name;
     String longName;

--- a/src/main/java/org/broad/igv/feature/FeatureDB.java
+++ b/src/main/java/org/broad/igv/feature/FeatureDB.java
@@ -53,11 +53,11 @@ public class FeatureDB {
     /**
      * Map for all features other than genes.
      */
-    //private static Map<String, NamedFeature> featureMap = new HashMap(10000);
-    private static Map<String, List<NamedFeature>> featureMap = Collections.synchronizedSortedMap(new TreeMap<String, List<NamedFeature>>());
+    //private static Map<String, IGVNamedFeature> featureMap = new HashMap(10000);
+    private static Map<String, List<IGVNamedFeature>> featureMap = Collections.synchronizedSortedMap(new TreeMap<String, List<IGVNamedFeature>>());
     private static final int MAX_DUPLICATE_COUNT = 20;
 
-    public static void addFeature(NamedFeature feature, Genome genome) {
+    public static void addFeature(IGVNamedFeature feature, Genome genome) {
 
         final String name = feature.getName();
         if (name != null && name.length() > 0 && !name.equals(".")) {
@@ -81,7 +81,7 @@ public class FeatureDB {
         }
     }
 
-    public static void removeFeature(NamedFeature feature, Genome genome) {
+    public static void removeFeature(IGVNamedFeature feature, Genome genome) {
 
         final String name = feature.getName();
         if (name != null && name.length() > 0 && !name.equals(".")) {
@@ -134,7 +134,7 @@ public class FeatureDB {
      * @param genome  The genome which these features belong to. Used for checking chromosomes
      * @return true if successfully added, false if not
      */
-    static boolean put(String name, NamedFeature feature, Genome genome) {
+    static boolean put(String name, IGVNamedFeature feature, Genome genome) {
         String key = name.toUpperCase();
         if (!Globals.isHeadless()) {
             Genome currentGenome = genome != null ? genome : GenomeManager.getInstance().getCurrentGenome();
@@ -144,9 +144,9 @@ public class FeatureDB {
         }
 
         synchronized (featureMap) {
-            List<NamedFeature> currentList = featureMap.get(key);
+            List<IGVNamedFeature> currentList = featureMap.get(key);
             if (currentList == null) {
-                List<NamedFeature> newList = new SortedList<NamedFeature>(
+                List<IGVNamedFeature> newList = new SortedList<IGVNamedFeature>(
                         new ArrayList<>(), FeatureComparator.get(true));
                 boolean added = newList.add(feature);
                 if (added) {
@@ -170,7 +170,7 @@ public class FeatureDB {
 
         Genome currentGenome = GenomeManager.getInstance().getCurrentGenome();
         if (currentGenome == null || currentGenome.getChromosome(feature.getChr()) != null) {
-            NamedFeature currentFeature = featureMap.get(key);
+            IGVNamedFeature currentFeature = featureMap.get(key);
             if (currentFeature == null) {
                 featureMap.put(key, feature);
             } else {
@@ -200,7 +200,7 @@ public class FeatureDB {
      */
 
 
-    public static void addFeature(String name, NamedFeature feature, Genome genome) {
+    public static void addFeature(String name, IGVNamedFeature feature, Genome genome) {
         put(name.toUpperCase(), feature, genome);
     }
 
@@ -228,9 +228,9 @@ public class FeatureDB {
     /**
      * Return a feature with the given name.
      */
-    public static NamedFeature getFeature(String name) {
+    public static IGVNamedFeature getFeature(String name) {
         String nm = name.trim().toUpperCase();
-        List<NamedFeature> features = featureMap.get(nm);
+        List<IGVNamedFeature> features = featureMap.get(nm);
 
         if (features != null) {
             return features.get(0);
@@ -255,9 +255,9 @@ public class FeatureDB {
      *             string will be found.
      * @return
      */
-    static Map<String, List<NamedFeature>> getFeaturesMap(String name) {
+    static Map<String, List<IGVNamedFeature>> getFeaturesMap(String name) {
         String nm = name.trim().toUpperCase();
-        SortedMap<String, List<NamedFeature>> treeMap = (SortedMap) featureMap;
+        SortedMap<String, List<IGVNamedFeature>> treeMap = (SortedMap) featureMap;
         //Search is inclusive to first argument, exclusive to second
         return treeMap.subMap(nm, nm + Character.MAX_VALUE);
     }
@@ -270,7 +270,7 @@ public class FeatureDB {
      * @return
      * @see #getFeaturesList(String, int, boolean)
      */
-    public static List<NamedFeature> getFeaturesList(String name, int limit) {
+    public static List<IGVNamedFeature> getFeaturesList(String name, int limit) {
         return getFeaturesList(name, limit, true);
     }
 
@@ -283,18 +283,18 @@ public class FeatureDB {
      * @param longestOnly Whether to take only the longest feature for each name
      * @return
      */
-    public static List<NamedFeature> getFeaturesList(String name, int limit, boolean longestOnly) {
+    public static List<IGVNamedFeature> getFeaturesList(String name, int limit, boolean longestOnly) {
 
         //Note: We are iterating over submap, this needs
         //to be synchronized over the main map.
         synchronized (featureMap) {
-            Map<String, List<NamedFeature>> resultMap = getFeaturesMap(name);
+            Map<String, List<IGVNamedFeature>> resultMap = getFeaturesMap(name);
             Set<String> names = resultMap.keySet();
             Iterator<String> nameIter = names.iterator();
-            ArrayList<NamedFeature> features = new ArrayList<NamedFeature>((Math.min(limit, names.size())));
+            ArrayList<IGVNamedFeature> features = new ArrayList<IGVNamedFeature>((Math.min(limit, names.size())));
             int ii = 0;
             while (nameIter.hasNext() && ii < limit) {
-                List<NamedFeature> subFeats = resultMap.get(nameIter.next());
+                List<IGVNamedFeature> subFeats = resultMap.get(nameIter.next());
                 if (longestOnly) {
                     features.add(subFeats.get(0));
                 } else {
@@ -328,11 +328,11 @@ public class FeatureDB {
         }
 
         Map<Integer, BasicFeature> results = new HashMap<Integer, BasicFeature>();
-        List<NamedFeature> possibles = featureMap.get(nm);
+        List<IGVNamedFeature> possibles = featureMap.get(nm);
 
         if (possibles != null) {
             synchronized (featureMap) {
-                for (NamedFeature f : possibles) {
+                for (IGVNamedFeature f : possibles) {
                     if (!(f instanceof BasicFeature)) {
                         continue;
                     }
@@ -381,13 +381,13 @@ public class FeatureDB {
         }
 
         Map<Integer, BasicFeature> results = new HashMap<Integer, BasicFeature>();
-        List<NamedFeature> possibles = featureMap.get(nm);
+        List<IGVNamedFeature> possibles = featureMap.get(nm);
         String tempNT;
         String brefNT = refNT.toUpperCase();
 
         if (possibles != null) {
             synchronized (featureMap) {
-                for (NamedFeature f : possibles) {
+                for (IGVNamedFeature f : possibles) {
                     if (!(f instanceof BasicFeature)) {
                         continue;
                     }

--- a/src/main/java/org/broad/igv/feature/IGVFeature.java
+++ b/src/main/java/org/broad/igv/feature/IGVFeature.java
@@ -29,13 +29,12 @@ package org.broad.igv.feature;
 import java.awt.*;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Interface for features in IGV annotation tracks  (FeatureTrack and derived classes).
  */
 
-public interface IGVFeature extends LocusScore, NamedFeature {
+public interface IGVFeature extends LocusScore, IGVNamedFeature {
 
     default String getIdentifier() {
         return null;

--- a/src/main/java/org/broad/igv/feature/IGVNamedFeature.java
+++ b/src/main/java/org/broad/igv/feature/IGVNamedFeature.java
@@ -25,13 +25,11 @@
 
 package org.broad.igv.feature;
 
-import htsjdk.tribble.Feature;
-
 /**
  * @author jrobinso
  * @date Sep 16, 2010
  */
-public interface  NamedFeature extends Feature {
+public interface IGVNamedFeature extends htsjdk.tribble.NamedFeature {
 
     String getName();
 

--- a/src/main/java/org/broad/igv/feature/Locus.java
+++ b/src/main/java/org/broad/igv/feature/Locus.java
@@ -35,7 +35,7 @@ import java.util.Locale;
 /**
  * @author jrobinso
  */
-public class Locus extends Range implements NamedFeature {
+public class Locus extends Range implements IGVNamedFeature {
 
     private static NumberFormat NUMBER_FORMAT = NumberFormat.getInstance(Locale.US);
 

--- a/src/main/java/org/broad/igv/feature/genome/load/JsonGenomeLoader.java
+++ b/src/main/java/org/broad/igv/feature/genome/load/JsonGenomeLoader.java
@@ -7,11 +7,11 @@ import com.google.gson.JsonParser;
 import htsjdk.tribble.CloseableTribbleIterator;
 import htsjdk.tribble.Feature;
 import htsjdk.tribble.FeatureReader;
+import org.broad.igv.feature.IGVNamedFeature;
 import org.broad.igv.logging.*;
 import org.broad.igv.Globals;
 import org.broad.igv.feature.CytoBandFileParser;
 import org.broad.igv.feature.FeatureDB;
-import org.broad.igv.feature.NamedFeature;
 import org.broad.igv.feature.genome.Genome;
 import org.broad.igv.feature.genome.fasta.FastaBlockCompressedSequence;
 import org.broad.igv.feature.genome.fasta.FastaIndexedSequence;
@@ -26,8 +26,6 @@ import org.broad.igv.util.liftover.Liftover;
 
 import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.util.*;
 
 public class JsonGenomeLoader extends GenomeLoader {
@@ -288,8 +286,8 @@ public class JsonGenomeLoader extends GenomeLoader {
                 CloseableTribbleIterator<Feature> iter = featureReader.iterator();
                 while (iter.hasNext()) {
                     Feature f = iter.next();
-                    if (f instanceof NamedFeature) {
-                        FeatureDB.addFeature((NamedFeature) f, genome);
+                    if (f instanceof IGVNamedFeature) {
+                        FeatureDB.addFeature((IGVNamedFeature) f, genome);
                     }
                 }
             } catch (IOException e) {

--- a/src/main/java/org/broad/igv/feature/tribble/IGVFeatureReader.java
+++ b/src/main/java/org/broad/igv/feature/tribble/IGVFeatureReader.java
@@ -28,6 +28,7 @@ package org.broad.igv.feature.tribble;
 
 
 
+import htsjdk.samtools.util.CloseableIterator;
 import htsjdk.tribble.Feature;
 import htsjdk.tribble.index.Index;
 
@@ -49,7 +50,7 @@ public interface IGVFeatureReader {
 
     public Iterator<Feature> query(final String chr, final int start, final int end) throws IOException;
 
-    public Iterator<Feature> iterator() throws IOException;
+    public CloseableIterator<Feature> iterator() throws IOException;
 
     public List<String> getSequenceNames();
 

--- a/src/main/java/org/broad/igv/track/TribbleFeatureSource.java
+++ b/src/main/java/org/broad/igv/track/TribbleFeatureSource.java
@@ -25,6 +25,7 @@
 
 package org.broad.igv.track;
 
+import htsjdk.samtools.util.CloseableIterator;
 import htsjdk.tribble.*;
 import htsjdk.tribble.index.Index;
 import org.broad.igv.Globals;
@@ -332,10 +333,8 @@ abstract public class TribbleFeatureSource implements org.broad.igv.track.Featur
             super(basicReader, codec, genome);
 
             featureMap = new HashMap<>(25);
-            Iterator<Feature> iter = null;
 
-            try {
-                iter = reader.iterator();
+            try (CloseableIterator<Feature> iter = reader.iterator()) {
                 while (iter.hasNext()) {
                     Feature f = iter.next();
                     if (f == null) continue;
@@ -343,33 +342,20 @@ abstract public class TribbleFeatureSource implements org.broad.igv.track.Featur
                     String seqName = f.getChr();
                     String igvChr = genome == null ? seqName : genome.getCanonicalChrName(seqName);
 
-                    List<Feature> featureList = featureMap.get(igvChr);
-                    if (featureList == null) {
-                        featureList = new ArrayList();
-                        featureMap.put(igvChr, featureList);
-                    }
+                    List<Feature> featureList = featureMap.computeIfAbsent(igvChr, k -> new ArrayList<>());
                     featureList.add(f);
-                    if (f instanceof org.broad.igv.feature.NamedFeature) FeatureDB.addFeature((org.broad.igv.feature.NamedFeature) f, genome);
+                    if (f instanceof IGVNamedFeature named) FeatureDB.addFeature(named, genome);
 
-                    if (this.isVCF && f instanceof Variant) {
-                        Variant v = (Variant) f;
+                    if (this.isVCF && f instanceof Variant v) {
                         String chr2 = v.getAttributeAsString("CHR2");
                         String pos2 = v.getAttributeAsString("END");
                         if (chr2 != null && pos2 != null) {
                             String mateChr = genome == null ? chr2 : genome.getCanonicalChrName(chr2);
                             MateVariant mate = new MateVariant(mateChr, Integer.parseInt(pos2), v);
-                            featureList = featureMap.get(mateChr);
-                            if (featureList == null) {
-                                featureList = new ArrayList();
-                                featureMap.put(mateChr, featureList);
-                            }
+                            featureList = featureMap.computeIfAbsent(mateChr, k -> new ArrayList<>());
                             featureList.add(mate);
                         }
                     }
-                }
-            } finally {
-                if (iter instanceof CloseableTribbleIterator) {
-                    ((CloseableTribbleIterator) iter).close();
                 }
             }
 

--- a/src/main/java/org/broad/igv/ui/action/SearchCommand.java
+++ b/src/main/java/org/broad/igv/ui/action/SearchCommand.java
@@ -49,7 +49,6 @@ import org.broad.igv.util.liftover.Liftover;
 import javax.swing.*;
 import java.awt.*;
 import java.awt.event.MouseEvent;
-import java.io.IOException;
 import java.net.URL;
 import java.util.List;
 import java.util.*;
@@ -336,7 +335,7 @@ public class SearchCommand {
      */
     private SearchResult parseToken(String token) {
 
-        List<NamedFeature> features;
+        List<IGVNamedFeature> features;
 
         //Guess at token type via regex.
         //We don't assume success
@@ -392,7 +391,7 @@ public class SearchCommand {
             }
         } else if (types.contains(ResultType.FEATURE)) {
             //Check if we have an exact name for the feature name
-            NamedFeature feat = searchFeatureDBs(token);
+            IGVNamedFeature feat = searchFeatureDBs(token);
             if (feat != null) {
                 return new SearchResult(feat);
             }
@@ -400,8 +399,8 @@ public class SearchCommand {
         return null;
     }
 
-    private NamedFeature searchFeatureDBs(String str) {
-        NamedFeature feat = FeatureDB.getFeature(str.toUpperCase().trim());
+    private IGVNamedFeature searchFeatureDBs(String str) {
+        IGVNamedFeature feat = FeatureDB.getFeature(str.toUpperCase().trim());
         if (feat != null) {
             return feat;
         } else {
@@ -575,7 +574,7 @@ public class SearchCommand {
 
         private String locus;
         private String message;
-        private NamedFeature feature;
+        private IGVNamedFeature feature;
 
         public SearchResult() {
             this(ResultType.ERROR, null, -1, -1);
@@ -589,7 +588,7 @@ public class SearchCommand {
             this.locus = Locus.getFormattedLocusString(chr, start, end);
         }
 
-        public SearchResult(NamedFeature feature) {
+        public SearchResult(IGVNamedFeature feature) {
             this(ResultType.FEATURE, feature.getChr(), feature.getStart(), feature.getEnd());
             this.feature = feature;
             this.locus = Locus.getFormattedLocusString(chr, start, end);
@@ -655,21 +654,21 @@ public class SearchCommand {
 
         //May be null
         @ForTesting
-        public NamedFeature getFeature() {
+        public IGVNamedFeature getFeature() {
             return feature;
         }
     }
 
     /**
      * Get a list of search results from the provided objects,
-     * which must be NamedFeature objects.
+     * which must be IGVNamedFeature objects.
      *
      * @param objects
      * @return
      */
-    public static List<SearchResult> getResults(List<NamedFeature> objects) {
+    public static List<SearchResult> getResults(List<IGVNamedFeature> objects) {
         List<SearchResult> results = new ArrayList<SearchResult>(objects.size());
-        for (NamedFeature f : objects) {
+        for (IGVNamedFeature f : objects) {
             results.add(new SearchCommand.SearchResult(f));
         }
         return results;

--- a/src/main/java/org/broad/igv/ui/commandbar/SearchTextField.java
+++ b/src/main/java/org/broad/igv/ui/commandbar/SearchTextField.java
@@ -2,20 +2,14 @@ package org.broad.igv.ui.commandbar;
 
 import com.jidesoft.hints.ListDataIntelliHints;
 import org.broad.igv.feature.FeatureDB;
-import org.broad.igv.feature.NamedFeature;
+import org.broad.igv.feature.IGVNamedFeature;
 import org.broad.igv.logging.LogManager;
 import org.broad.igv.logging.Logger;
-import org.broad.igv.ui.GlobalKeyDispatcher;
-import org.broad.igv.ui.IGV;
 import org.broad.igv.ui.action.SearchCommand;
 import org.broad.igv.ui.panel.FrameManager;
 
 import javax.swing.*;
 import javax.swing.text.JTextComponent;
-import java.awt.event.FocusEvent;
-import java.awt.event.FocusListener;
-import java.awt.event.KeyEvent;
-import java.awt.event.KeyListener;
 import java.util.List;
 
 /**
@@ -63,8 +57,8 @@ public class SearchTextField extends JTextField {
                 return false;
             } else {
                 //TODO Uncomment to use comprehensive feature search, note that it should support partial matches
-                //List<NamedFeature> features = SearchCommand.comprehensiveFeatureSearch(text);
-                List<NamedFeature> features = FeatureDB.getFeaturesList(text, SearchCommand.SEARCH_LIMIT);
+                //List<IGVNamedFeature> features = SearchCommand.comprehensiveFeatureSearch(text);
+                List<IGVNamedFeature> features = FeatureDB.getFeaturesList(text, SearchCommand.SEARCH_LIMIT);
                 final List<SearchCommand.SearchResult> results = SearchCommand.getResults(features);
                 Object[] list = SearchCommand.getSelectionList(results, false);
                 if (list.length >= 1) {

--- a/src/test/java/org/broad/igv/feature/FeatureDBTest.java
+++ b/src/test/java/org/broad/igv/feature/FeatureDBTest.java
@@ -25,13 +25,11 @@
 
 package org.broad.igv.feature;
 
-import junit.framework.AssertionFailedError;
 import org.broad.igv.AbstractHeadlessTest;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -76,7 +74,7 @@ public class FeatureDBTest extends AbstractHeadlessTest {
 
     @Test
     public void testFeaturesMap() throws Exception {
-        Map<String, List<NamedFeature>> fMap = FeatureDB.getFeaturesMap(CHECK_STR);
+        Map<String, List<IGVNamedFeature>> fMap = FeatureDB.getFeaturesMap(CHECK_STR);
 
         for (String k : fMap.keySet()) {
 
@@ -87,7 +85,7 @@ public class FeatureDBTest extends AbstractHeadlessTest {
 
     @Test
     public void testFeatureListSize() throws Exception {
-        List<NamedFeature> features = FeatureDB.getFeaturesList(CHECK_STR, 3);
+        List<IGVNamedFeature> features = FeatureDB.getFeaturesList(CHECK_STR, 3);
         assertEquals(3, features.size());
 
         features = FeatureDB.getFeaturesList(CHECK_STR, LARGE);
@@ -98,8 +96,8 @@ public class FeatureDBTest extends AbstractHeadlessTest {
 
     @Test
     public void testFeatureList() throws Exception {
-        List<NamedFeature> features = FeatureDB.getFeaturesList(CHECK_STR, LARGE);
-        for (NamedFeature f : features) {
+        List<IGVNamedFeature> features = FeatureDB.getFeaturesList(CHECK_STR, LARGE);
+        for (IGVNamedFeature f : features) {
             assertTrue(f.getName().startsWith(CHECK_STR));
             assertNotNull(FeatureDB.getFeature(f.getName()));
         }
@@ -109,21 +107,21 @@ public class FeatureDBTest extends AbstractHeadlessTest {
     @Test
     public void testMultiRetrieve() throws Exception {
         String checkstr = "EGFLAM";
-        Map<String, List<NamedFeature>> fMap = FeatureDB.getFeaturesMap(checkstr);
-        List<NamedFeature> data = fMap.get(checkstr);
+        Map<String, List<IGVNamedFeature>> fMap = FeatureDB.getFeaturesMap(checkstr);
+        List<IGVNamedFeature> data = fMap.get(checkstr);
         assertEquals(4, data.size());
     }
 
     @Test
     public void testMultipleEntries() throws Exception {
         String checkstr = "EG";
-        Map<String, List<NamedFeature>> fMap = FeatureDB.getFeaturesMap(checkstr);
+        Map<String, List<IGVNamedFeature>> fMap = FeatureDB.getFeaturesMap(checkstr);
         for (String k : fMap.keySet()) {
-            List<NamedFeature> data = fMap.get(k);
+            List<IGVNamedFeature> data = fMap.get(k);
             //System.out.println("key " + k + " has " + data.size());
             for (int ii = 0; ii < data.size() - 1; ii++) {
-                NamedFeature feat1 = data.get(ii);
-                NamedFeature feat2 = data.get(ii + 1);
+                IGVNamedFeature feat1 = data.get(ii);
+                IGVNamedFeature feat2 = data.get(ii + 1);
                 int len1 = feat1.getEnd() - feat1.getStart();
                 int len2 = feat2.getEnd() - feat2.getStart();
                 assertTrue("Data for key " + k + " not sorted", len1 >= len2);

--- a/src/test/java/org/broad/igv/feature/aa/CodonTest.java
+++ b/src/test/java/org/broad/igv/feature/aa/CodonTest.java
@@ -28,8 +28,7 @@ package org.broad.igv.feature.aa;
 import org.broad.igv.AbstractHeadlessTest;
 import org.broad.igv.feature.BasicFeature;
 import org.broad.igv.feature.FeatureDB;
-import org.broad.igv.feature.NamedFeature;
-import org.broad.igv.feature.aa.Codon;
+import org.broad.igv.feature.IGVNamedFeature;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -70,7 +69,7 @@ public class CodonTest extends AbstractHeadlessTest {
         tstGetCodon(KRAS, expected);
     }
 
-    public void tstGetCodon(NamedFeature feature, char[] expected) {
+    public void tstGetCodon(IGVNamedFeature feature, char[] expected) {
         BasicFeature bf = (BasicFeature) feature;
 
         for (int pos = 0; pos < expected.length; pos++) {
@@ -90,8 +89,8 @@ public class CodonTest extends AbstractHeadlessTest {
         //valid for these ids:
         //NM_003661, NM_145343, NM_001136540
 
-        List<NamedFeature> featuresList = FeatureDB.getFeaturesList(geneName, 50, false);
-        for (NamedFeature feat : featuresList) {
+        List<IGVNamedFeature> featuresList = FeatureDB.getFeaturesList(geneName, 50, false);
+        for (IGVNamedFeature feat : featuresList) {
             BasicFeature bf = (BasicFeature) feat;
             System.out.println(bf.getIdentifier());
             Codon c = bf.getCodon(genome, bf.getChr(),  proteinPos);

--- a/src/test/java/org/broad/igv/ui/action/SearchCommandTest.java
+++ b/src/test/java/org/broad/igv/ui/action/SearchCommandTest.java
@@ -27,8 +27,6 @@ package org.broad.igv.ui.action;
 
 import junit.framework.AssertionFailedError;
 import org.broad.igv.AbstractHeadlessTest;
-import org.broad.igv.feature.BasicFeature;
-import org.broad.igv.feature.NamedFeature;
 import org.broad.igv.feature.genome.Genome;
 import org.broad.igv.util.TestUtils;
 import org.junit.Before;

--- a/src/test/java/org/broad/igv/util/TestUtils.java
+++ b/src/test/java/org/broad/igv/util/TestUtils.java
@@ -29,7 +29,7 @@ import com.google.common.base.Function;
 import com.google.common.base.Supplier;
 import org.broad.igv.DirectoryManager;
 import org.broad.igv.Globals;
-import org.broad.igv.feature.NamedFeature;
+import org.broad.igv.feature.IGVNamedFeature;
 import org.broad.igv.feature.genome.Genome;
 import org.broad.igv.ui.commandbar.GenomeListManager;
 import org.broad.igv.prefs.PreferencesManager;
@@ -229,7 +229,7 @@ public class TestUtils {
      * @param exp
      * @param act
      */
-    public static void assertNamedFeaturesEqual(NamedFeature exp, NamedFeature act) {
+    public static void assertNamedFeaturesEqual(IGVNamedFeature exp, IGVNamedFeature act) {
         assertFeaturesEqual(exp, act);
         assertEquals(exp.getName().toUpperCase(), act.getName().toUpperCase());
     }


### PR DESCRIPTION
Htsjdk added a new NamedFeature interface that is clashing with IGV's slightly different NamedFeature. Renamed NamedFeature -> IGVNamedFeature
Slight change to IGVFeatureReader interface to make it return a CloseableIterator so that it can be handled with try-with-resources.

It might be worth updating the new Htsjdk interface to include the displayName() method as well so that can just be used directly?