### PR TITLE
Fix rounding bug in zoom calculation.

### DIFF
--- a/src/main/java/org/broad/igv/ui/panel/ReferenceFrame.java
+++ b/src/main/java/org/broad/igv/ui/panel/ReferenceFrame.java
@@ -29,7 +29,6 @@
  */
 package org.broad.igv.ui.panel;
 
-import org.broad.igv.logging.*;
 import org.broad.igv.Globals;
 import org.broad.igv.event.IGVEventBus;
 import org.broad.igv.event.ViewChange;
@@ -38,10 +37,11 @@ import org.broad.igv.feature.Locus;
 import org.broad.igv.feature.Range;
 import org.broad.igv.feature.genome.Genome;
 import org.broad.igv.feature.genome.GenomeManager;
+import org.broad.igv.logging.LogManager;
+import org.broad.igv.logging.Logger;
 import org.broad.igv.prefs.Constants;
 import org.broad.igv.prefs.IGVPreferences;
 import org.broad.igv.prefs.PreferencesManager;
-import org.broad.igv.sam.InsertionManager;
 import org.broad.igv.sam.InsertionMarker;
 import org.broad.igv.ui.IGV;
 import org.broad.igv.ui.util.MessageUtils;
@@ -54,7 +54,7 @@ import java.awt.event.MouseEvent;
  */
 public class ReferenceFrame {
 
-    private static Logger log = LogManager.getLogger(ReferenceFrame.class);
+    private static final Logger log = LogManager.getLogger(ReferenceFrame.class);
 
     IGVEventBus eventBus;
 
@@ -714,7 +714,7 @@ public class ReferenceFrame {
     }
 
     /**
-     * Calculate the zoom level given start/end in bp.
+     * Calculate the minimum zoom level which can completely contain the given start/end in bp.
      * Doesn't change anything
      *
      * @param start
@@ -723,8 +723,12 @@ public class ReferenceFrame {
      */
     public int calculateZoom(double start, double end) {
         final double windowLength = Math.min(end - start, getChromosomeLength());
-        return (int) Math.round(Globals.log2((getChromosomeLength() / windowLength) * (((double) widthInPixels) / binsPerTile)));
+        final double exactZoom = Globals.log2((getChromosomeLength() / windowLength) * (((double) widthInPixels) / binsPerTile));
+        //round up so that you get a zoom level which contains the given window
+        return (int) Math.ceil(exactZoom);
     }
+
+
 
 
     private static int getChromosomeLength(String chrName) {

--- a/src/main/java/org/broad/igv/ui/panel/ZoomSliderPanel.java
+++ b/src/main/java/org/broad/igv/ui/panel/ZoomSliderPanel.java
@@ -214,7 +214,7 @@ public class ZoomSliderPanel extends JPanel {
                     .sorted()
                     .distinct()
                     .map(threshold -> this.getReferenceFrame().calculateZoom(0, threshold))
-                    .collect(Collectors.toList());
+                    .toList();
 
             transGraphics.setColor(TRANSPARENT_BLUE);
             Rectangle maxZoom = zoomLevelRects[zoomLevelRects.length - 1];


### PR DESCRIPTION
Fixing a rounding error  in calculateZoom.  Instead of rounding to the closest integer zoom level I believe we should be rounding up to the nearest zoom level which can contain the given window.

This fixes a display issue with the ZoomSliderPanel.  Certain chromosomes would display the blue mark off by 1 because it was sometimes rounding up and sometimes down.  

 I'm not 100% sure I understand the potential consequences of changing this for other code that relies on it, so it would be good to have a second pair of eyes on it. It seems intuitively to be correct now but it's possible the use case of "zoom level which is closest to the width of the given window" was really what was wanted.  I haven't found any obvious issues with some manual testing of this change.