### PR TITLE
Update dependencies that have reported vulnerabilities to new versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -104,17 +104,17 @@ configurations {
 dependencies {
     implementation(
             fileTree(dir: 'lib', include: '*.jar'), // first search on disk (old behavior), then maven repos
-            [group: 'com.google.code.gson', name: 'gson', version: '2.8.5'],
+            [group: 'com.google.code.gson', name: 'gson', version: '2.8.9'],
             [group: 'org.apache.commons', name: 'commons-math3', version: '3.6.1'],
-            [group: 'commons-io', name: 'commons-io', version: '2.6'],
-            [group: 'org.apache.commons', name: 'commons-compress', version: '1.18'],
+            [group: 'commons-io', name: 'commons-io', version: '2.7'],
+            [group: 'org.apache.commons', name: 'commons-compress', version: '1.21'],
             [group: 'org.xerial.snappy', name: 'snappy-java', version: '1.1.7.3'],
             [group: 'org.apache.commons', name: 'commons-jexl', version: '2.1.1'],
             [group: 'org.apache.commons', name: 'commons-lang3', version: '3.9'],
             [group: 'com.github.samtools', name: 'htsjdk', version: '3.0.5'],
             [group: 'org.swinglabs', name: 'swing-layout', version: '1.0.3'],
             [group: 'com.formdev', name: 'jide-oss', version: '3.7.12'],
-            [group: 'com.google.guava', name: 'guava', version: '27.0.1-jre'],
+            [group: 'com.google.guava', name: 'guava', version: '32.1.3-jre'],
             [group: 'org.apache.xmlgraphics', name: 'batik-dom', version: '1.11'],
             [group: 'org.apache.xmlgraphics', name: 'batik-svggen', version: '1.11'],
             [group: 'org.apache.xmlgraphics', name: 'batik-codec', version: '1.11'],
@@ -128,9 +128,9 @@ dependencies {
     )
 
     testImplementation(
-            [group: 'junit', name: 'junit', version: '4.13'],
-            [group: 'com.sparkjava', name: 'spark-core', version: '2.2'],
-            [group: 'org.glassfish.jersey.core', name: 'jersey-common', version: '2.22.4']
+            [group: 'junit', name: 'junit', version: '4.13.1'],
+            [group: 'com.sparkjava', name: 'spark-core', version: '2.7.2'],
+            [group: 'org.glassfish.jersey.core', name: 'jersey-common', version: '2.34']
     )
     testRuntimeOnly(
            [group: 'org.junit.vintage', name:'junit-vintage-engine', version:'5.8.2']

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -9,7 +9,7 @@ module org.igv {
 
     requires com.google.common;
     requires commons.math3;
-    requires gson;
+    requires com.google.gson;
     requires htsjdk;
     requires java.datatransfer;
     requires java.desktop;


### PR DESCRIPTION
A number of our dependencies have reported vulnerabilities, this updates those to new versions without any known problems.  

I suspect that most of them aren't actually relevant to us but probably best to fix them if we can.   Since we're moving java versions it seems like a good time to update stuff too.