### PR TITLE
Make delete/backspace delete tracks in dev/prod mode

### DIFF
--- a/src/main/java/org/broad/igv/ui/panel/TrackPanelComponent.java
+++ b/src/main/java/org/broad/igv/ui/panel/TrackPanelComponent.java
@@ -53,21 +53,15 @@ import java.util.List;
  */
 abstract public class TrackPanelComponent extends JPanel {
 
-    private static Logger log = LogManager.getLogger(TrackPanelComponent.class);
+    private static final String DELETE_TRACKS_KEY = "deleteTracks";
     List<MouseableRegion> mouseRegions;
 
     private TrackPanel trackPanel;
 
-    /**
-     * A scheduler is used to distinguish a click from a double click.
-     */
-    protected ClickTaskScheduler clickScheduler = new ClickTaskScheduler();
-
-
     public TrackPanelComponent(TrackPanel trackPanel) {
         this.trackPanel = trackPanel;
         setFocusable(true);
-        mouseRegions = new ArrayList();
+        mouseRegions = new ArrayList<>();
 
         initKeyDispatcher();
     }
@@ -80,15 +74,13 @@ abstract public class TrackPanelComponent extends JPanel {
             }
         };
 
+        final KeyStroke delKey = KeyStroke.getKeyStroke(KeyEvent.VK_DELETE, 0, false);
+        final KeyStroke backspaceKey = KeyStroke.getKeyStroke(KeyEvent.VK_BACK_SPACE, 0, false);
 
-        if (Globals.isDevelopment()) {
-            final KeyStroke delKey = KeyStroke.getKeyStroke(KeyEvent.VK_DELETE, 0, false);
-            final KeyStroke backspaceKey = KeyStroke.getKeyStroke(KeyEvent.VK_BACK_SPACE, 0, false);
+        getInputMap().put(delKey, DELETE_TRACKS_KEY);
+        getInputMap().put(backspaceKey, DELETE_TRACKS_KEY);
+        getActionMap().put(DELETE_TRACKS_KEY, delTracksAction);
 
-            getInputMap().put(delKey, "deleteTracks");
-            getInputMap().put(backspaceKey, "deleteTracks");
-            getActionMap().put("deleteTracks", delTracksAction);
-        }
     }
 
     public TrackPanel getTrackPanel() {
@@ -186,7 +178,7 @@ abstract public class TrackPanelComponent extends JPanel {
         MouseEvent e = te.getMouseEvent();
 
         final Collection<Track> selectedTracks = getSelectedTracks();
-        if (selectedTracks.size() == 0) {
+        if (selectedTracks.isEmpty()) {
             return;
         }
 


### PR DESCRIPTION
* There is a wierd issue where the delete key removes selected tracks but only if IGV is in develop mode.
However, there's a different weird issue where the production IGV seems to be set to develop mode.
Since it seems like this defaults to being on in practice it's likely that whatever worry made this a developent mode
option is probably unfounded.

This removes the isDevelopment() guard and does some minor refatoring in the same class.
