### PR TITLE
Set develop flag to true for develop builds

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ vendor=user
 timestamp=not_set
 timestamp_fs=not_set
 dataServerUrl=http://www.broadinstitute.org/igvdata/$$_dataServerRegistry.txt
-development=false
+development=true
 # Jar signing properties; ignored for developer builds
 keystore=not_set
 alias=not_set


### PR DESCRIPTION
It seems like this should be set to true in the default properties.  It appears that it's set to true in the released bundled builds also ( which is weird). 

It might also make sense to just completely remove the isDevelop() flag from the code since it's rarely used and is very likely to cause confusion (as it did in #1430 ). 