### PR TITLE
Hide token in the log file for SetAccessToken

### DIFF
--- a/src/main/java/org/broad/igv/batch/CommandListener.java
+++ b/src/main/java/org/broad/igv/batch/CommandListener.java
@@ -181,7 +181,12 @@ public class CommandListener implements Runnable {
 
                 String cmd = inputLine;
                 if (!cmd.contains("/oauthCallback")) {
-                    log.info(cmd);
+                    if (cmd.startsWith("SetAccessToken")) {
+                        log.info(cmd.substring(0,14) + " *****");
+                    }
+                    else {
+                        log.info(cmd);
+                    }
                 }
 
                 boolean isHTTP = cmd.startsWith("OPTIONS") || cmd.startsWith("HEAD") || cmd.startsWith("GET");


### PR DESCRIPTION
Addresses the issue https://github.com/igvteam/igv/issues/1433

Now IGV simply logs only the command itself and ignores the parameters