### PR TITLE
Add java tool chain resolver

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,14 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-apply plugin: 'java'
-apply plugin: 'maven-publish'
-apply plugin: 'application'
-
 import org.apache.tools.ant.filters.ReplaceTokens
-
-mainClassName = 'org.broad.igv.ui.Main'
-ext.moduleName = 'org.igv'
 
 buildscript {
     repositories {
@@ -36,10 +29,20 @@ buildscript {
     }
 }
 
+plugins {
+    id 'java'
+    id 'maven-publish'
+    id 'application'
+}
+
 repositories {
     mavenCentral()
     mavenLocal()
 }
+
+
+mainClassName = 'org.broad.igv.ui.Main'
+ext.moduleName = 'org.igv'
 
 java {
     toolchain {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,5 @@
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.7.0"
+}
+
 rootProject.name = 'igv'


### PR DESCRIPTION
This adds the foojay convention plugin resolver to the `settings.gradle` ([See docs here](https://docs.gradle.org/current/userguide/toolchains.html#sub:download_repositories) and [here](https://github.com/gradle/foojay-toolchains/issues)).   This allows the build to automatically download a java 17 jdk.

I've tested it and it currently downloads temurin 17.  I noticed a weird issue with SNIHostName class files failing to load in some tests.  I don't know if that's because of the docker image I was testing in or something fundamentally weird about this.   I haven't figured out the cause of that yet.

@jrobinso I'm opening this as a draft so you can try it out. 