### PR TITLE
Catch errors parsing supplementary alignments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # igv
+
 ![Build Status](https://github.com/igvteam/igv/actions/workflows/gradle_test.yml/badge.svg)
 ![GitHub issues](https://img.shields.io/github/issues/igvteam/igv)
 ![GitHub closed issues](https://img.shields.io/github/issues-closed/igvteam/igv)
@@ -8,12 +9,13 @@ Integrative Genomics Viewer - desktop genome visualization tool for Mac, Windows
 
 ### Building
 
-These instructions are meant for developers interested in working on the IGV code.  For normal use,
-we recommend the pre-built releases available at [http://software.broadinstitute.org/software/igv/download](http://software.broadinstitute.org/software/igv/download).
+These instructions are meant for developers interested in working on the IGV code. For normal use,
+we recommend the pre-built releases available
+at [http://software.broadinstitute.org/software/igv/download](http://software.broadinstitute.org/software/igv/download).
 
-Builds are executed from the IGV project directory.  Files will be created in the 'build' subdirectory.
+Builds are executed from the IGV project directory. Files will be created in the 'build' subdirectory.
 
-IGV requires **Java 11** to build and run.   Later versions of Java should work but we build and test  on **Java 11**. Previous (versions =< 2.6.3) running on Java8 have been deprecated.
+IGV requires **Java 17** to build and run. Later versions of Java should work but we build and test on **Java 17**.
 
 NOTE: If on a Windows platform use ```./gradlew.bat'``` in the instructions below
 
@@ -21,38 +23,40 @@ NOTE: If on a Windows platform use ```./gradlew.bat'``` in the instructions belo
 
 The IGV bundles ship with embedded JREs from AdoptOpenJDK.
 
-* Install Gradle for your platform.  See https://gradle.org/ for details.
+* Install Gradle for your platform. See https://gradle.org/ for details.
 
-* Use ```./gradlew createDist``` to build a distribution directory (found in ```build/IGV-dist```) containing 
+* Use ```./gradlew createDist``` to build a distribution directory (found in ```build/IGV-dist```) containing
   the igv.jar and its required runtime third-party dependencies as well as helper scripts for launching.
 
     * Launch IGV with `igv.sh` or `igv_hidpi.sh` on Linux, `igv.command` on Mac, and `igv.bat` on Windows.
 
     * To run igvtools from the command line use the script `igvtools` on Linux and Mac, or igvtools.bat
-      on Windows.  See the instructions in igvtools_readme.txt in that directory.
+      on Windows. See the instructions in igvtools_readme.txt in that directory.
 
     * The launcher scripts expect this folder structure in order to run IGV.
-  
-* Use ```./gradlew test``` to run the test suite.  See 'src/test/README.txt' for more information about running
+
+* Use ```./gradlew test``` to run the test suite. See 'src/test/README.txt' for more information about running
   the tests.
-  
-* See this [README](https://raw.githubusercontent.com/igvteam/igv/master/scripts/readme.txt) for tips about using the IGV launcher scripts.
 
-* This dashboard describes [project structure and dependencies](https://sourcespy.com/github/igvteamigv/). 
+* See this [README](https://raw.githubusercontent.com/igvteam/igv/master/scripts/readme.txt) for tips about using the
+  IGV launcher scripts.
 
+* This dashboard describes [project structure and dependencies](https://sourcespy.com/github/igvteamigv/).
 
-Note that Gradle creates a number of other subdirectories in 'build'.  These can be safely ignored.
+Note that Gradle creates a number of other subdirectories in 'build'. These can be safely ignored.
 
 #### Amazon Web Services support
 
-Public data files hosted in Amazon S3 buckets can be loaded into IGV using [https endpoints](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingBucket.html).  
+Public data files hosted in Amazon S3 buckets can be loaded into IGV
+using [https endpoints](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingBucket.html).
 
-Authenticated access using s3:// urls is supported by either (1) enabling OAuth access with Cognito using the UMCCR 
-contributed AWS configuration option, or (2) setting AWS credentials and region information as described 
-[here]( https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html) and 
+Authenticated access using s3:// urls is supported by either (1) enabling OAuth access with Cognito using the UMCCR
+contributed AWS configuration option, or (2) setting AWS credentials and region information as described
+[here]( https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html) and
 [here](https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/java-dg-region-selection.html).
 
-For more details on using Cognito for OAuth access, see the [UMCCR documentation on the backend](https://umccr.org/blog/igv-amazon-backend-setup/) 
+For more details on using Cognito for OAuth access, see
+the [UMCCR documentation on the backend](https://umccr.org/blog/igv-amazon-backend-setup/)
 and [frontend for a provisioning URL step by step guide](https://umccr.org/blog/igv-amazon-frontend-setup/).
 
 

--- a/src/main/java/org/broad/igv/sam/SupplementaryAlignment.java
+++ b/src/main/java/org/broad/igv/sam/SupplementaryAlignment.java
@@ -37,7 +37,7 @@ public class SupplementaryAlignment implements Locatable {
     private Integer lenOnRef = null;  //number of reference bases covered
     private Integer numberOfAlignedBases = null; //number of bases in read which are aligned
 
-    public SupplementaryAlignment(String chr, int start, Strand strand, Cigar cigar, int mapQ, int numMismatches) {
+    public SupplementaryAlignment(String chr, int start, Strand strand, Cigar cigar, int mapQ, int numMismatches){
         this.chr = chr;
         this.start = start;
         this.strand = strand;
@@ -55,10 +55,10 @@ public class SupplementaryAlignment implements Locatable {
                 0, 0);  //We're just using this as a placeholder for sorting since Alignment
         // and SupplementaryAlignment don't share any common class
         int insertionIndex = Collections.binarySearch(supplementaryAlignments, alignmentAsSupplementary, LEADING_CLIP_COMPARATOR);
-        if (insertionIndex > 0) {
+        if(insertionIndex > 0) {
             log.warn("Saw 2 SupplementaryReads with the same leading clip length.");
         } else {
-            insertionIndex = -1 * (insertionIndex + 1);
+            insertionIndex = -1* (insertionIndex + 1);
         }
         return insertionIndex;
     }
@@ -69,7 +69,7 @@ public class SupplementaryAlignment implements Locatable {
 
             final SupplementaryNeighbors supplementaryRenderingInfo;
 
-            if (alignment instanceof SAMAlignment) {
+            if( alignment instanceof SAMAlignment){
                 supplementaryAlignments = ((SAMAlignment) alignment).getSupplementaryAlignments();
             } else {
                 final Object rawSATag = alignment.getAttribute(SAMTag.SA.name());
@@ -77,10 +77,10 @@ public class SupplementaryAlignment implements Locatable {
             }
 
 
-            if (supplementaryAlignments != null && !supplementaryAlignments.isEmpty()) {
+            if(supplementaryAlignments != null && !supplementaryAlignments.isEmpty()) {
 
                 int insertionIndex = getInsertionIndex(alignment, supplementaryAlignments);
-                if (insertionIndex < 0) {
+                if( insertionIndex < 0 ){
                     log.warn("Encountered a group of supplementary alignments that couldn't be sorted unambiguously." +
                             "\nSee reads with the name: " + alignment.getReadName());
                     return null;
@@ -122,14 +122,14 @@ public class SupplementaryAlignment implements Locatable {
                 + " (" + strand.toShortString() + ") = " + Globals.DECIMAL_FORMAT.format(getLengthOnReference()) + "bp  @MAPQ " + mapQ + " NM" + numMismatches;
     }
 
-    public static List<SupplementaryAlignment> parseFromSATag(String saTag) {
+    public static List<SupplementaryAlignment> parseFromSATag(String saTag){
         return Arrays.stream(Globals.semicolonPattern.split(saTag))
                 .map(SupplementaryAlignment::fromSingleSaTagRecord)
                 .sorted(LEADING_CLIP_COMPARATOR)
                 .toList();
     }
 
-    public static SupplementaryAlignment fromSingleSaTagRecord(String saTagRecord) {
+    public static SupplementaryAlignment fromSingleSaTagRecord(String saTagRecord){
         //SA:(reference name, pos, strand, CIGAR, mapQ, NM;)+
         String[] tokens = Globals.commaPattern.split(saTagRecord);
 
@@ -147,7 +147,7 @@ public class SupplementaryAlignment implements Locatable {
     }
 
 
-    public int getCountOfLeadingClipping() {
+    public int getCountOfLeadingClipping(){
         ClippingCounts counts = ClippingCounts.fromCigar(this.cigar);
         return getCountOfLeadingClipping(counts, this.strand);
     }
@@ -181,7 +181,7 @@ public class SupplementaryAlignment implements Locatable {
 
     @Override
     public int getLengthOnReference() {
-        if (lenOnRef == null) {
+        if(lenOnRef == null) {
             lenOnRef = cigar.getReferenceLength();
         }
         return cigar.getReferenceLength();
@@ -191,14 +191,13 @@ public class SupplementaryAlignment implements Locatable {
      * get the count of non-clipped bases which are in the read
      * this differs from {@link #getLengthOnReference()} because it includes insertions bases but not deletions
      */
-    public int getNumberOfAlignedBases() {
-        if (numberOfAlignedBases == null) {
+    public int getNumberOfAlignedBases(){
+        if( numberOfAlignedBases == null) {
             int length = 0;
-            for (CigarElement element : cigar) {
+            for(CigarElement element : cigar) {
                 switch (element.getOperator()) {
                     case M, I, EQ, X -> length += element.getLength();
-                    default -> {
-                    }
+                    default -> {}
                 }
             }
             numberOfAlignedBases = length;
@@ -208,17 +207,17 @@ public class SupplementaryAlignment implements Locatable {
 
 
     record SupplementaryNeighbors(Alignment alignment, SupplementaryAlignment previous, SupplementaryAlignment next) {
-        SupplementaryNeighbors(Alignment alignment, SupplementaryAlignment previous, SupplementaryAlignment next) {
-            this.alignment = alignment;
-            if (alignment.isNegativeStrand()) {
-                this.next = previous;
-                this.previous = next;
-            } else {
-                this.next = next;
-                this.previous = previous;
+            SupplementaryNeighbors(Alignment alignment, SupplementaryAlignment previous, SupplementaryAlignment next) {
+                this.alignment = alignment;
+                if (alignment.isNegativeStrand()) {
+                    this.next = previous;
+                    this.previous = next;
+                } else {
+                    this.next = next;
+                    this.previous = previous;
+                }
             }
-        }
 
-    }
+        }
 
 }


### PR DESCRIPTION
Catch and log errors parsing SA tag to annotate clipped ends.  This allows alignment rendering to continue in case of malformed SA tags.