### PR TITLE
Move the amazon credentials check at startup into an async thread

### DIFF
--- a/src/main/java/org/broad/igv/ui/IGVMenuBar.java
+++ b/src/main/java/org/broad/igv/ui/IGVMenuBar.java
@@ -211,7 +211,7 @@ public class IGVMenuBar extends JMenuBar implements IGVEventObserver {
     }
 
     public void updateAWSMenu() {
-        AWSMenu.setVisible(AmazonUtils.isAwsProviderPresent());
+        SwingUtilities.invokeLater(() -> AWSMenu.setVisible(AmazonUtils.isAwsProviderPresent()));
     }
 
     /**

--- a/src/main/java/org/broad/igv/ui/IGVMenuBar.java
+++ b/src/main/java/org/broad/igv/ui/IGVMenuBar.java
@@ -194,14 +194,14 @@ public class IGVMenuBar extends JMenuBar implements IGVEventObserver {
             log.error("Error creating google menu: " + e.getMessage());
         }
 
-        try {
-            AWSMenu = createAWSMenu();
-            AWSMenu.setVisible(AmazonUtils.isAwsProviderPresent());
-            menus.add(AWSMenu);
-        } catch (IOException e) {
-            log.error("Error creating the Amazon AWS menu: " + e.getMessage());
-            AWSMenu.setVisible(false);
-        }
+
+        AWSMenu = createAWSMenu();
+        AWSMenu.setVisible(false);
+        menus.add(AWSMenu);
+        //detecting the provider is slow, do it in another thread
+        LongRunningTask.submit(this::updateAWSMenu);
+
+
 
         menus.add(createHelpMenu());
 
@@ -963,7 +963,7 @@ public class IGVMenuBar extends JMenuBar implements IGVEventObserver {
         return menu;
     }
 
-    private JMenu createAWSMenu() throws IOException {
+    private JMenu createAWSMenu() {
 
         boolean usingCognito = AmazonUtils.GetCognitoConfig() != null;
 

--- a/src/main/java/org/broad/igv/util/AmazonUtils.java
+++ b/src/main/java/org/broad/igv/util/AmazonUtils.java
@@ -83,7 +83,7 @@ public class AmazonUtils {
 
 
     /**
-     * Test to see if aws credentials are avaialable, either through IGV configuration of Cognito, or from the
+     * Test to see if aws credentials are available, either through IGV configuration of Cognito, or from the
      * default provider chain.  See https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html#credentials-default
      *
      * @return

--- a/src/main/java/org/broad/igv/util/LongRunningTask.java
+++ b/src/main/java/org/broad/igv/util/LongRunningTask.java
@@ -40,9 +40,9 @@ import java.util.concurrent.*;
  *
  * @author jrobinso
  */
-public class LongRunningTask implements Callable {
+public class LongRunningTask implements Callable<Void> {
 
-    private static Logger log = LogManager.getLogger(LongRunningTask.class);
+    private static final Logger log = LogManager.getLogger(LongRunningTask.class);
 
     private static final ExecutorService threadExecutor = Executors.newFixedThreadPool(5);
 
@@ -52,7 +52,7 @@ public class LongRunningTask implements Callable {
         return threadExecutor;
     }
 
-    public static Future submit(Runnable runnable) {
+    public static Future<Void> submit(Runnable runnable) {
         if (Globals.isBatch()) {
             runnable.run();
             return null;
@@ -65,7 +65,8 @@ public class LongRunningTask implements Callable {
         this.runnable = runnable;
     }
 
-    public Object call() {
+    @Override
+    public Void call() {
 
         CursorToken token = WaitCursorManager.showWaitCursor();
         try {


### PR DESCRIPTION
I was checking to make sure I hadn't slowed down rendering by adding more stuff to it, I noticed that loading the amazon credentials was adding about half a second to the startup time.   This should make the check asynchronous.  Could you make sure it seems sane to you?  I don't have amazon credentials configured so it's hard for me to check if I did something weird to them.