### PR TITLE
Improve behavior of the Hide small indels menu option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 /.gradle/
 /build/
 /.idea/
+
+#JENV local config file
+.java-version

--- a/src/main/java/org/broad/igv/sam/AlignmentTrackMenu.java
+++ b/src/main/java/org/broad/igv/sam/AlignmentTrackMenu.java
@@ -123,10 +123,17 @@ class AlignmentTrackMenu extends IGVPopupMenu {
         smallIndelsItem.addActionListener(aEvt -> UIUtilities.invokeOnEventThread(() -> {
             if (smallIndelsItem.isSelected()) {
                 String sith = MessageUtils.showInputDialog("Small indel threshold: ", String.valueOf(renderOptions.getSmallIndelThreshold()));
-                try {
-                    renderOptions.setSmallIndelThreshold(Integer.parseInt(sith));
-                } catch (NumberFormatException exc) {
-                    log.error("Error setting small indel threshold - not an integer", exc);
+                if (sith == null) {
+                    // dialogue was cancelled so no change should be made
+                    return;
+                } else {
+                    try {
+                        renderOptions.setSmallIndelThreshold(Integer.parseInt(sith));
+                    } catch (NumberFormatException exc) {
+                        log.error("Error setting small indel threshold - not an integer", exc);
+                        //error so no change should be made
+                        return;
+                    }
                 }
             }
             renderOptions.setHideSmallIndels(smallIndelsItem.isSelected());


### PR DESCRIPTION
* If you cancel the popup dialogue or enter an invalid value then no change will be made.
  Previously cancelling it produced a stacktrace in the log and toggled the state using the
  old value.
