### PR TITLE
Correct rendered range of symbolic VCF alleles

### DIFF
--- a/src/main/java/org/broad/igv/variant/vcf/VCFVariant.java
+++ b/src/main/java/org/broad/igv/variant/vcf/VCFVariant.java
@@ -385,6 +385,17 @@ public class VCFVariant implements Variant {
         if (variantContext.getType() == VariantContext.Type.INDEL || variantContext.getType() == VariantContext.Type.MIXED) {
             prefixLength = findCommonPrefixLength();
         }
+
+        /**
+         * Since v4.1, the VCF spec has defined POS as the base preceding the polymorphism for any symbolic allele.
+         *
+         * https://github.com/samtools/hts-specs/blob/4cde0e235b4e4cfbd67a0c3a38abea611d56d256/VCFv4.1.tex#L165
+         *
+         */
+        if (variantContext.getType() == VariantContext.Type.SYMBOLIC) {
+            prefixLength = 1;
+        }
+
         this.start = (variantContext.getStart() - 1) + prefixLength;
     }
 

--- a/src/main/java/org/broad/igv/variant/vcf/VCFVariant.java
+++ b/src/main/java/org/broad/igv/variant/vcf/VCFVariant.java
@@ -392,7 +392,7 @@ public class VCFVariant implements Variant {
          * https://github.com/samtools/hts-specs/blob/4cde0e235b4e4cfbd67a0c3a38abea611d56d256/VCFv4.1.tex#L165
          *
          */
-        if (variantContext.getType() == VariantContext.Type.SYMBOLIC) {
+        if (variantContext.getType(true) == VariantContext.Type.SYMBOLIC) {
             prefixLength = 1;
         }
 

--- a/src/main/java/org/broad/igv/variant/vcf/VCFVariant.java
+++ b/src/main/java/org/broad/igv/variant/vcf/VCFVariant.java
@@ -387,9 +387,7 @@ public class VCFVariant implements Variant {
         }
 
         /**
-         * Since v4.1, the VCF spec has defined POS as the base preceding the polymorphism for any symbolic allele.
-         *
-         * https://github.com/samtools/hts-specs/blob/4cde0e235b4e4cfbd67a0c3a38abea611d56d256/VCFv4.1.tex#L165
+         * The VCF spec defines POS as the base preceding the polymorphism for non-ref symbolic alleles.
          *
          */
         if (variantContext.getType(true) == VariantContext.Type.SYMBOLIC) {


### PR DESCRIPTION
This patch adjusts the start position of symbolic VCF alleles to better match the VCF spec definition:

https://github.com/samtools/hts-specs/blob/4cde0e235b4e4cfbd67a0c3a38abea611d56d256/VCFv4.1.tex#L165

Motivated by discussion on https://github.com/samtools/hts-specs/issues/792  -- cc: @jrobinso / @d-cameron

