### PR TITLE
Fix for 2bit reference crash when reading the end of the reference

### DIFF
--- a/src/main/java/org/broad/igv/ucsc/twobit/TwoBitSequence.java
+++ b/src/main/java/org/broad/igv/ucsc/twobit/TwoBitSequence.java
@@ -133,6 +133,9 @@ public class TwoBitSequence implements Sequence {
                 throw new RuntimeException("regionStart cannot be less than 0");
             }
 
+            //don't run off the end of the genome
+            regionEnd = Math.min(record.getDnaSize(), regionEnd);
+
             Queue<Block> nBlocks = _getOverlappingBlocks(regionStart, regionEnd, record.nBlocks);
             Queue<Block> maskBlocks = _getOverlappingBlocks(regionStart, regionEnd, record.maskBlocks);
 


### PR DESCRIPTION
* Clip requests for sequence to not go over the length of the chromosome.
* fixes https://github.com/igvteam/igv/issues/1583

@jrobinso Could you make sure this is sane?  When the tile loader asks for reference it gets it in chunks of 100000 which was running off the edge of the stream.  This seems to fix it but I'm not sure if there are other things to think about with 2bit that I'm not aware of.

The user noticed it on chrM but it also happens at the end of other chromosomes, its' just rare to be there to see it happen.