### PR TITLE
fix the issue 1512

### DIFF
--- a/src/main/java/org/broad/igv/prefs/IGVPreferences.java
+++ b/src/main/java/org/broad/igv/prefs/IGVPreferences.java
@@ -568,6 +568,13 @@ public class IGVPreferences {
     public void setApplicationFrameBounds(Rectangle bounds) {
 
         if (bounds.width > 0 && bounds.height > 0) {
+            // check the values of MaxX(x+width) and MaxY(y+width)
+            if(bounds.getMaxY()<300) {
+                bounds.setLocation(bounds.x,0);
+            }
+            if(bounds.getMaxX()<300) {
+                bounds.setLocation(0,bounds.y);
+            }
             StringBuffer buffer = new StringBuffer();
             buffer.append(bounds.x);
             buffer.append(",");

--- a/src/main/java/org/broad/igv/ui/IGV.java
+++ b/src/main/java/org/broad/igv/ui/IGV.java
@@ -247,7 +247,9 @@ public class IGV implements IGVEventObserver {
         Rectangle applicationBounds = preferences.getApplicationFrameBounds();
 
         if (applicationBounds == null || applicationBounds.getMaxX() > screenBounds.getWidth() ||
+                applicationBounds.getMaxX() < 300 ||
                 applicationBounds.getMaxY() > screenBounds.getHeight() ||
+                applicationBounds.getMaxY() < 300 ||
                 applicationBounds.width == 0 || applicationBounds.height == 0) {
             int width = Math.min(1150, (int) screenBounds.getWidth());
             int height = Math.min(800, (int) screenBounds.getHeight());


### PR DESCRIPTION
I have found the true reason of the issue #1512. It is caused by multiple monitors. 

When you have  two monitors and set your primary screen to the right. You open the IGV in the main screen and drag the window of IGV to the other screen, then turn off  IGV , the `setApplicationFrameBounds(Rectangle bounds)` will store a IGV.Bounds with an x-coordinate less than the negative width of the screen. At this point, if you unplug the secondary monitor and open IGV again, you will reproduce this problem. 

The original code only considers another case. When the main display is on the left,.In that scenario,if you open IGV on the main display and then drag the IGV window to the secondary display before closing IGV. `setApplicationFrameBounds(Rectangle bounds)` will save an x-coordinate ​​greater than width of the screen . The original code can handle this case, but it does not account for the situation described above.

To address this, I added additional conditions to handle the aforementioned scenario, as well as to check the y-coordinate when creating the window and closing IGV, ensuring minimum width and height (300, 300).
