### PR TITLE
Fix issue1512

### DIFF
--- a/src/main/java/org/broad/igv/prefs/IGVPreferences.java
+++ b/src/main/java/org/broad/igv/prefs/IGVPreferences.java
@@ -568,13 +568,6 @@ public class IGVPreferences {
     public void setApplicationFrameBounds(Rectangle bounds) {
 
         if (bounds.width > 0 && bounds.height > 0) {
-            // check the values of MaxX(x+width) and MaxY(y+width)
-//            if(bounds.getMaxY()<300) {
-//                bounds.setLocation(bounds.x,0);
-//            }
-//            if(bounds.getMaxX()<300) {
-//                bounds.setLocation(0,bounds.y);
-//            }
             StringBuffer buffer = new StringBuffer();
             buffer.append(bounds.x);
             buffer.append(",");

--- a/src/main/java/org/broad/igv/prefs/IGVPreferences.java
+++ b/src/main/java/org/broad/igv/prefs/IGVPreferences.java
@@ -568,6 +568,13 @@ public class IGVPreferences {
     public void setApplicationFrameBounds(Rectangle bounds) {
 
         if (bounds.width > 0 && bounds.height > 0) {
+            // check the values of MaxX(x+width) and MaxY(y+width)
+            if(bounds.getMaxY()<300) {
+                bounds.setLocation(bounds.x,0);
+            }
+            if(bounds.getMaxX()<300) {
+                bounds.setLocation(0,bounds.y);
+            }
             StringBuffer buffer = new StringBuffer();
             buffer.append(bounds.x);
             buffer.append(",");

--- a/src/main/java/org/broad/igv/prefs/IGVPreferences.java
+++ b/src/main/java/org/broad/igv/prefs/IGVPreferences.java
@@ -569,12 +569,12 @@ public class IGVPreferences {
 
         if (bounds.width > 0 && bounds.height > 0) {
             // check the values of MaxX(x+width) and MaxY(y+width)
-            if(bounds.getMaxY()<300) {
-                bounds.setLocation(bounds.x,0);
-            }
-            if(bounds.getMaxX()<300) {
-                bounds.setLocation(0,bounds.y);
-            }
+//            if(bounds.getMaxY()<300) {
+//                bounds.setLocation(bounds.x,0);
+//            }
+//            if(bounds.getMaxX()<300) {
+//                bounds.setLocation(0,bounds.y);
+//            }
             StringBuffer buffer = new StringBuffer();
             buffer.append(bounds.x);
             buffer.append(",");

--- a/src/main/java/org/broad/igv/ui/IGV.java
+++ b/src/main/java/org/broad/igv/ui/IGV.java
@@ -247,7 +247,9 @@ public class IGV implements IGVEventObserver {
         Rectangle applicationBounds = preferences.getApplicationFrameBounds();
 
         if (applicationBounds == null || applicationBounds.getMaxX() > screenBounds.getWidth() ||
+                applicationBounds.getMaxX() < 300 ||
                 applicationBounds.getMaxY() > screenBounds.getHeight() ||
+                applicationBounds.getMaxY() < 300 ||
                 applicationBounds.width == 0 || applicationBounds.height == 0) {
             int width = Math.min(1150, (int) screenBounds.getWidth());
             int height = Math.min(800, (int) screenBounds.getHeight());

--- a/src/main/java/org/broad/igv/ui/IGV.java
+++ b/src/main/java/org/broad/igv/ui/IGV.java
@@ -286,8 +286,10 @@ public class IGV implements IGVEventObserver {
 
         subscribeToEvents();
 
+
         // Start running periodic autosaves (unless the user has specified not to retain timed autosaves)
-        if (PreferencesManager.getPreferences().getAsInt(AUTOSAVES_TO_KEEP) > 0) {
+
+        if (PreferencesManager.getPreferences().getAsInt(Constants.AUTOSAVES_TO_KEEP) > 0) {
             int timerDelay = PreferencesManager.getPreferences().getAsInt(AUTOSAVE_FREQUENCY) * 60000; // Convert timer delay to ms
             sessionAutosaveTimer.scheduleAtFixedRate(new AutosaveTimerTask(this), timerDelay, timerDelay);
         }

--- a/src/main/java/org/broad/igv/ui/IGV.java
+++ b/src/main/java/org/broad/igv/ui/IGV.java
@@ -262,7 +262,7 @@ public class IGV implements IGVEventObserver {
         boolean isNullOrNotContained = true;
 
         if(applicationBounds != null){
-            //iterate the screens and check it whether be in the coordinate
+            //Iterate over each screen value to find if there is currently a screen that can contain these values.
             int userX = applicationBounds.x;
             int userY = applicationBounds.y;
             double userMaxX = applicationBounds.getMaxX();


### PR DESCRIPTION
This commit is for fixing the issue  #1512 with the solution from [jrobinso in #1588](https://github.com/igvteam/igv/pull/1588#issuecomment-2380423738)  , the changes are as follows.

1. Get the configurations of all screens.
2. Check whether user preference is null.
2. Check whether (x, y)  in user preference is within a certain screen.

fix
- the case #1512 in windows.

other behaviors
- when the window of igv was  crossing two screens in windows, the previous code will open it in the  same  position as last closing, this code will change it to the upper left corner of the screen containing the (x,y) of IGV
- work normal in windows 11 with jdk21 or jdk17.



Please review the code and test it in the macos.