### PR TITLE
Fix for Amazon failing.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -137,8 +137,15 @@ dependencies {
             [group: 'software.amazon.awssdk', name: 'cognitoidentity', version: amazonVersion],
             [group: 'software.amazon.awssdk', name: 'sts', version: amazonVersion],
             [group: 'software.amazon.awssdk', name: 's3', version: amazonVersion],
-            [group: 'software.amazon.awssdk', name: 'sso', version: amazonVersion]
+            [group: 'software.amazon.awssdk', name: 'sso', version: amazonVersion],
+
+            // This is a transitive dependency from amazon but due to modularization changes between
+            // 1.20 and 1.3.0 we need to specify it here.
+            // This can be removed when amazon moves from 1.2.0 -> 1.3.0 and updates it's module requirements
+            // See https://logging.apache.org/blog/2023/12/02/apache-common-logging-1.3.0.html
+            [group: 'commons-logging', name: 'commons-logging', version: '1.3.0']
     )
+
 
     testImplementation(
             [group: 'junit', name: 'junit', version: '4.13.2'],

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -43,5 +43,9 @@ module org.igv {
     requires software.amazon.awssdk.http;
     requires software.amazon.awssdk.utils;
 
+    // Transitive dependency of amazon modules that is required to be specified
+    // because amazon resolves the unmodularized 1.2.0 version while htjsdk brings in the modular 1.3.0
+    requires org.apache.commons.logging;
+
     requires jide.oss;
 }


### PR DESCRIPTION
* Fix the amazon failures due to LogFactory not found by adding a module dependency
* on apache logging.  This is necessary because commons-logging became modularized
* between 1.2.0 and 1.3.0 but amazon is expecting the non-modular 1.2.0 while
* 1.3.0 is being brought in due to changes in htsjdk.
* See https://logging.apache.org/blog/2023/12/02/apache-common-logging-1.3.0.html for
* more info.
* Fix for https://github.com/igvteam/igv/issues/1598


@jrobinso  Can you test this on your system before we merge?  It seems to fix the problem for me but I want to be sure it's also fixing it for you.