### PR TITLE
Add Recent Files Menu and Improve Recent Sessions

### DIFF
--- a/src/main/java/org/broad/igv/prefs/Constants.java
+++ b/src/main/java/org/broad/igv/prefs/Constants.java
@@ -42,6 +42,7 @@ final public class Constants {
 
     //
     public static final String RECENT_SESSIONS = "IGV.Session.recent.sessions";
+    public static final String RECENT_URLS = "IGV.Session.recent.urls";
     public static final String LAST_EXPORTED_REGION_DIRECTORY = "LAST_EXPORTED_REGION_DIRECTORY";
     public static final String LAST_TRACK_DIRECTORY = "LAST_TRACK_DIRECTORY";
     public static final String LAST_SNAPSHOT_DIRECTORY = "LAST_SNAPSHOT_DIRECTORY";

--- a/src/main/java/org/broad/igv/prefs/IGVPreferences.java
+++ b/src/main/java/org/broad/igv/prefs/IGVPreferences.java
@@ -46,6 +46,7 @@ import org.broad.igv.sam.mods.BaseModificationColors;
 import org.broad.igv.track.TrackType;
 import org.broad.igv.ui.IGV;
 import org.broad.igv.ui.IGVMenuBar;
+import org.broad.igv.ui.RecentFileSet;
 import org.broad.igv.ui.UIConstants;
 import org.broad.igv.ui.color.ColorUtilities;
 import org.broad.igv.ui.color.PaletteColorTable;
@@ -280,7 +281,7 @@ public class IGVPreferences {
             // Explicitly setting removes override
             overrideKeys.remove(key);
 
-            if (value == null || value.trim().length() == 0) {
+            if (value == null || value.isBlank()) {
                 userPreferences.remove(key);
             } else {
                 userPreferences.put(key, value);
@@ -297,7 +298,7 @@ public class IGVPreferences {
 
     public void putAll(Map<String, String> updatedPrefs) {
         for (Map.Entry<String, String> entry : updatedPrefs.entrySet()) {
-            if (entry.getValue() == null || entry.getValue().trim().length() == 0) {
+            if (entry.getValue() == null || entry.getValue().isBlank()) {
                 remove(entry.getKey());
             } else {
                 put(entry.getKey(), entry.getValue());
@@ -610,12 +611,14 @@ public class IGVPreferences {
      * @param recentSessions
      */
     public void setRecentSessions(String recentSessions) {
+        remove(RECENT_SESSIONS);
         put(RECENT_SESSIONS, recentSessions);
     }
 
 
-    public String getRecentSessions() {
-        return get(RECENT_SESSIONS, null);
+    public RecentFileSet getRecentSessions() {
+        String sessionsString = get(RECENT_SESSIONS, null);
+        return RecentFileSet.fromString(sessionsString, UIConstants.NUMBER_OF_RECENT_SESSIONS_TO_LIST);
     }
 
     public String getDataServerURL() {

--- a/src/main/java/org/broad/igv/prefs/IGVPreferences.java
+++ b/src/main/java/org/broad/igv/prefs/IGVPreferences.java
@@ -44,10 +44,7 @@ import org.broad.igv.renderer.ContinuousColorScale;
 import org.broad.igv.renderer.SequenceRenderer;
 import org.broad.igv.sam.mods.BaseModificationColors;
 import org.broad.igv.track.TrackType;
-import org.broad.igv.ui.IGV;
-import org.broad.igv.ui.IGVMenuBar;
-import org.broad.igv.ui.RecentFileSet;
-import org.broad.igv.ui.UIConstants;
+import org.broad.igv.ui.*;
 import org.broad.igv.ui.color.ColorUtilities;
 import org.broad.igv.ui.color.PaletteColorTable;
 import org.broad.igv.ui.util.MessageUtils;
@@ -620,6 +617,18 @@ public class IGVPreferences {
         String sessionsString = get(RECENT_SESSIONS, null);
         return RecentFileSet.fromString(sessionsString, UIConstants.NUMBER_OF_RECENT_SESSIONS_TO_LIST);
     }
+
+    public void setRecentUrls(String recentUrls) {
+        remove(RECENT_URLS);
+        put(RECENT_URLS, recentUrls);
+    }
+
+
+    public RecentUrlsSet getRecentUrls() {
+        String sessionsString = get(RECENT_URLS, null);
+        return RecentUrlsSet.fromString(sessionsString, UIConstants.NUMBER_OF_RECENT_SESSIONS_TO_LIST);
+    }
+
 
     public String getDataServerURL() {
         String masterResourceFile = get(DATA_SERVER_URL_KEY);

--- a/src/main/java/org/broad/igv/ui/DynamicMenuItemsAdjustmentListener.java
+++ b/src/main/java/org/broad/igv/ui/DynamicMenuItemsAdjustmentListener.java
@@ -1,0 +1,76 @@
+package org.broad.igv.ui;
+
+import javax.swing.*;
+import javax.swing.event.MenuEvent;
+import javax.swing.event.MenuListener;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * MenuListener which updates the availble menu items based on the contents of a changeable collection.
+ *
+ * Whenever the menu is selected the relevant JMenuItems are regenerated according to the current values in the backing
+ * collection.
+ *
+ * Items are inserted in a row beneath a given separator.
+ *
+ * @param <T> element type of the collection
+ */
+public class DynamicMenuItemsAdjustmentListener<T> implements MenuSelectedListener {
+    private final JMenu menu;
+
+    private final JSeparator insertionPoint;
+    private final Collection<T> values;
+    private final Function<T, JMenuItem> itemConstructor;
+
+    //Store the currently visible components here so they can be removed when necessary
+    private final List<JComponent> activeComponents;
+
+    /**
+     *
+     * @param menu the menu to modify
+     * @param insertionPoint a JSeparator which acts as an anchor to always insert elements below.  This element is hidden
+     *                       when the collection is empty
+     * @param values a collection which is used to generate menu items
+     * @param itemConstructor a function to create a JMenuItem from an element in the collection
+     */
+    public DynamicMenuItemsAdjustmentListener(JMenu menu, JSeparator insertionPoint, Collection<T> values, Function<T, JMenuItem> itemConstructor) {
+        this.menu = menu;
+        this.insertionPoint = insertionPoint;
+        this.values = values;
+        this.itemConstructor = itemConstructor;
+        this.activeComponents = new ArrayList<>();
+    }
+
+    private List<JMenuItem> getCurrentItems() {
+        return values.stream().map(itemConstructor).toList();
+    }
+
+    @Override
+    public void menuSelected(MenuEvent e) {
+        List<JMenuItem> newComponents = getCurrentItems();
+
+        // We definitely don't want to be doing this while other things are also changing the menu
+        // this should at least protect against multiple of these listeners modifying the same menu at once.
+        synchronized (menu) {
+            activeComponents.forEach(menu::remove);
+            if (newComponents.isEmpty()) {
+                insertionPoint.setVisible(false);
+            } else {
+                insertionPoint.setVisible(true);
+
+                final int componentIndex = Arrays.asList(menu.getMenuComponents()).indexOf(insertionPoint);
+                for (int i = 0; i < newComponents.size(); i++) {
+                    menu.insert(newComponents.get(i), componentIndex + i + 1);
+                }
+                activeComponents.addAll(newComponents);
+            }
+        }
+
+        menu.revalidate();
+        menu.repaint();
+    }
+}

--- a/src/main/java/org/broad/igv/ui/IGV.java
+++ b/src/main/java/org/broad/igv/ui/IGV.java
@@ -1135,6 +1135,11 @@ public class IGV implements IGVEventObserver {
         return recentUrlsList;
     }
 
+    /**
+     * Add new values to the recent URLS set.  Calling this method rather than adding them directly
+     * allows showing the menu when the first URL is added to the collection.
+     * @param toAdd
+     */
     public void addToRecentUrls(Collection<ResourceLocator> toAdd){
         RecentUrlsSet recentFiles = getRecentUrls();
         recentFiles.addAll(toAdd);

--- a/src/main/java/org/broad/igv/ui/IGV.java
+++ b/src/main/java/org/broad/igv/ui/IGV.java
@@ -137,6 +137,7 @@ public class IGV implements IGVEventObserver {
     private Map<String, List<Track>> overlayTracksMap = new HashMap<>();
     private Set<Track> overlaidTracks = new HashSet<>();
     private RecentFileSet recentSessionList;
+    private RecentUrlsSet recentUrlsList;
 
     // Vertical line that follows the mouse
     private boolean rulerEnabled;
@@ -517,6 +518,12 @@ public class IGV implements IGVEventObserver {
         RecentFileSet recentSessions = getRecentSessionList();
         if (!recentSessions.isEmpty()) {
             PreferencesManager.getPreferences().setRecentSessions(recentSessions.asString());
+        }
+
+        // Store recent files
+        RecentUrlsSet recentUrls = getRecentUrls();
+        if (!recentUrls.isEmpty()) {
+            PreferencesManager.getPreferences().setRecentUrls(recentUrls.asString());
         }
 
         // Stop the timer that is triggering the timed autosave
@@ -1120,6 +1127,22 @@ public class IGV implements IGVEventObserver {
         }
         return recentSessionList;
     }
+
+    public RecentUrlsSet getRecentUrls() {
+        if(recentUrlsList == null){
+            recentUrlsList = PreferencesManager.getPreferences().getRecentUrls();
+        }
+        return recentUrlsList;
+    }
+
+    public void addToRecentUrls(Collection<ResourceLocator> toAdd){
+        RecentUrlsSet recentFiles = getRecentUrls();
+        recentFiles.addAll(toAdd);
+        if(!recentFiles.isEmpty()){
+            menuBar.showRecentFilesMenu();
+        }
+    }
+
 
     public IGVContentPane getContentPane() {
         return contentPane;

--- a/src/main/java/org/broad/igv/ui/IGV.java
+++ b/src/main/java/org/broad/igv/ui/IGV.java
@@ -1173,7 +1173,7 @@ public class IGV implements IGVEventObserver {
 
         for (final ResourceLocator locator : locators) {
 
-            // If its a local file, check explicitly for existence (rather than rely on exception)
+            // If it's a local file, check explicitly for existence (rather than rely on exception)
             if (locator.isLocal()) {
                 File trackSetFile = new File(locator.getPath());
                 if (!trackSetFile.exists()) {

--- a/src/main/java/org/broad/igv/ui/IGVMenuBar.java
+++ b/src/main/java/org/broad/igv/ui/IGVMenuBar.java
@@ -36,7 +36,6 @@ import org.broad.igv.event.IGVEvent;
 import org.broad.igv.event.IGVEventBus;
 import org.broad.igv.event.IGVEventObserver;
 import org.broad.igv.feature.genome.Genome;
-import org.broad.igv.feature.genome.GenomeDownloadUtils;
 import org.broad.igv.feature.genome.GenomeManager;
 import org.broad.igv.feature.genome.ChromSizesUtils;
 import org.broad.igv.track.AttributeManager;
@@ -70,7 +69,6 @@ import javax.swing.*;
 import javax.swing.event.MenuEvent;
 import javax.swing.event.MenuListener;
 import javax.swing.plaf.basic.BasicBorders;
-import javax.swing.plaf.basic.BasicMenuItemUI;
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -114,10 +112,12 @@ public class IGVMenuBar extends JMenuBar implements IGVEventObserver {
     private JMenuItem loadGenomeFromServerMenuItem;
     private JMenuItem loadTracksFromServerMenuItem;
     private JMenuItem selectGenomeAnnotationsItem;
-    private JMenuItem encodeUCSCMenuItem;
 
+    private JMenuItem encodeUCSCMenuItem;
     private List<JComponent> encodeMenuItems = new ArrayList<>();
+
     private JMenuItem reloadSessionItem;
+    private JMenuItem recentFilesMenu;
 
 
     static IGVMenuBar createInstance(IGV igv) {
@@ -298,6 +298,9 @@ public class IGVMenuBar extends JMenuBar implements IGVEventObserver {
         menuAction.setToolTipText(UIConstants.LOAD_SERVER_DATA_TOOLTIP);
         loadTracksFromServerMenuItem = MenuAndToolbarUtils.createMenuItem(menuAction);
         menuItems.add(loadTracksFromServerMenuItem);
+
+        recentFilesMenu = new RecentUrlsMenu();
+        menuItems.add(recentFilesMenu);
 
         if (PreferencesManager.getPreferences().getAsBoolean(DB_ENABLED)) {
             menuAction = new LoadFromDatabaseAction("Load from Database...", 0, igv);
@@ -1233,6 +1236,10 @@ public class IGVMenuBar extends JMenuBar implements IGVEventObserver {
         this.reloadSessionItem.setEnabled(true);
     }
 
+    public void showRecentFilesMenu(){
+        this.recentFilesMenu.setVisible(true);
+    }
+
     public void disableReloadSession() {
         this.reloadSessionItem.setEnabled(false);
     }
@@ -1269,9 +1276,7 @@ public class IGVMenuBar extends JMenuBar implements IGVEventObserver {
             return;
         }
 
-        PrintWriter pw = null;
-        try {
-            pw = new PrintWriter(new BufferedWriter(new FileWriter(file)));
+        try (PrintWriter pw = new PrintWriter(new BufferedWriter(new FileWriter(file)))) {
 
             List<String> attributes = AttributeManager.getInstance().getVisibleAttributes();
 
@@ -1291,25 +1296,11 @@ public class IGVMenuBar extends JMenuBar implements IGVEventObserver {
                 }
                 pw.println();
             }
-
-
         } catch (IOException e) {
             MessageUtils.showErrorMessage("Error writing to file", e);
             log.error(e);
-        } finally {
-            if (pw != null) pw.close();
         }
-
     }
-}
-
-class Foo extends BasicMenuItemUI {
-
-
-    public Foo() {
-        this.disabledForeground = Color.black;
-    }
-
 
     private static class DynamicItemsDisplay<T> implements MenuListener {
         private final Collection<T> values;
@@ -1355,3 +1346,4 @@ class Foo extends BasicMenuItemUI {
         public void menuCanceled(MenuEvent e) {}
     }
 }
+

--- a/src/main/java/org/broad/igv/ui/LimitedLinkedSet.java
+++ b/src/main/java/org/broad/igv/ui/LimitedLinkedSet.java
@@ -1,0 +1,67 @@
+package org.broad.igv.ui;
+
+import java.io.File;
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ *
+ */
+public class LimitedLinkedSet<T> extends AbstractCollection<T>{
+    final protected LinkedList<T> values = new LinkedList<>();
+    final int maxSize;
+
+    public LimitedLinkedSet(int maxSize) {
+        if (maxSize <= 0) {
+            throw new IllegalArgumentException("maxSize must be > 0");
+        }
+        this.maxSize = maxSize;
+    }
+
+    public LimitedLinkedSet(Collection<T> c, int maxSize) {
+        this(maxSize);
+        Collection<T> unique = new LinkedHashSet<>(c);
+        List<T> limited = unique.stream().limit(maxSize).toList();
+        values.addAll(limited);
+    }
+
+    @Override
+    public boolean add(T t) {
+        values.remove(t);
+        if (values.size() >= maxSize) {
+            values.removeLast();
+        }
+        values.addFirst(t);
+        return true;
+    }
+
+    @Override
+    public boolean addAll(Collection<? extends T> c) {
+        ArrayList<? extends T> list = new ArrayList<>(c);
+        list.reversed().forEach(this::add);
+        return true;
+    }
+
+    @Override
+    public boolean remove(Object o) {
+        return values.remove(o);
+    }
+
+    @Override
+    public void clear() {
+        values.clear();
+    }
+
+    @Override
+    public Iterator<T> iterator() {
+        return values.iterator();
+    }
+
+    @Override
+    public int size() {
+        return values.size();
+    }
+
+}
+
+

--- a/src/main/java/org/broad/igv/ui/MenuSelectedListener.java
+++ b/src/main/java/org/broad/igv/ui/MenuSelectedListener.java
@@ -1,0 +1,19 @@
+package org.broad.igv.ui;
+
+import javax.swing.event.MenuEvent;
+import javax.swing.event.MenuListener;
+
+/**
+ * A menu listener which provides default noop implementations of menuDeselected and menuCancelled
+ */
+public interface MenuSelectedListener extends MenuListener {
+
+    @Override
+    void menuSelected(MenuEvent e);
+
+    @Override
+    default void menuDeselected(MenuEvent e) {}
+
+    @Override
+    default void menuCanceled(MenuEvent e) {}
+}

--- a/src/main/java/org/broad/igv/ui/RecentFileSet.java
+++ b/src/main/java/org/broad/igv/ui/RecentFileSet.java
@@ -1,0 +1,35 @@
+package org.broad.igv.ui;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+public class RecentFileSet extends LimitedLinkedSet<String> {
+
+    public RecentFileSet(int maxSize) {
+        super(maxSize);
+    }
+
+    public RecentFileSet(Collection<String> c, int maxSize) {
+        super(c, maxSize);
+    }
+
+    public String asString() {
+        return String.join(";", this);
+    }
+
+    public static RecentFileSet fromString(String string, int maxSize) {
+        if(string == null || string.isBlank()){
+            return new RecentFileSet(maxSize);
+        }
+        String[] files = string.split(";");
+        List<String> fileList = Arrays.stream(files)
+                .filter(s -> !s.isBlank())
+                // "null" was previously accounted for in older code so it's handled here
+                // it doesn't seem like it should be possible to produce now though
+                .filter(s -> !s.equals("null"))
+                .map(String::strip)
+                .toList();
+        return new RecentFileSet(fileList, maxSize);
+    }
+}

--- a/src/main/java/org/broad/igv/ui/RecentFileSet.java
+++ b/src/main/java/org/broad/igv/ui/RecentFileSet.java
@@ -4,9 +4,15 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
+/**
+ * An implement of StackSet for local file paths which supports serializing/deserializing itself to a string.
+ *
+ * The serialized form matches the format which already existed to store recent session files.
+ * This is used by the by the
+ */
 public class RecentFileSet extends StackSet<String> {
 
-    private   static final String DELIMITER = ";";
+    private static final String DELIMITER = ";";
 
     public RecentFileSet(int maxSize) {
         super(maxSize);

--- a/src/main/java/org/broad/igv/ui/RecentFileSet.java
+++ b/src/main/java/org/broad/igv/ui/RecentFileSet.java
@@ -4,7 +4,9 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
-public class RecentFileSet extends LimitedLinkedSet<String> {
+public class RecentFileSet extends StackSet<String> {
+
+    private   static final String DELIMITER = ";";
 
     public RecentFileSet(int maxSize) {
         super(maxSize);
@@ -15,14 +17,14 @@ public class RecentFileSet extends LimitedLinkedSet<String> {
     }
 
     public String asString() {
-        return String.join(";", this);
+        return String.join(DELIMITER, this);
     }
 
     public static RecentFileSet fromString(String string, int maxSize) {
         if(string == null || string.isBlank()){
             return new RecentFileSet(maxSize);
         }
-        String[] files = string.split(";");
+        String[] files = string.split(DELIMITER);
         List<String> fileList = Arrays.stream(files)
                 .filter(s -> !s.isBlank())
                 // "null" was previously accounted for in older code so it's handled here
@@ -32,4 +34,6 @@ public class RecentFileSet extends LimitedLinkedSet<String> {
                 .toList();
         return new RecentFileSet(fileList, maxSize);
     }
+
+
 }

--- a/src/main/java/org/broad/igv/ui/RecentUrlsSet.java
+++ b/src/main/java/org/broad/igv/ui/RecentUrlsSet.java
@@ -1,0 +1,68 @@
+package org.broad.igv.ui;
+
+import org.broad.igv.util.ResourceLocator;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+public class RecentUrlsSet extends StackSet<ResourceLocator> {
+    public static final String INDEX_DELIM = "index:";
+    private static final Pattern INDEX_SPLITTER = Pattern.compile("\\s" + INDEX_DELIM);
+    public RecentUrlsSet(int maxSize) {
+        super(maxSize);
+    }
+
+    public RecentUrlsSet(Collection<ResourceLocator> c, int maxSize) {
+        super(c, maxSize);
+    }
+
+    public String asString(){
+        return this.stream()
+                .map(RecentUrlsSet::locatorToString)
+                .collect(Collectors.joining("|"));
+    }
+
+    private static String locatorToString(ResourceLocator locator) {
+        StringBuilder builder = new StringBuilder();
+        builder.append(locator.getPath());
+        if(locator.getIndexPath() != null) {
+            builder.append(" " + INDEX_DELIM);
+            builder.append(locator.getIndexPath());
+        }
+        return builder.toString();
+    }
+
+
+
+    private static ResourceLocator stringToLocator(String locationString) {
+        String[] split = INDEX_SPLITTER.split(locationString);
+
+        if (split.length != 1 && split.length != 2){
+            return null;
+        }
+        final ResourceLocator result = new ResourceLocator(split[0].strip());
+        if(split.length == 2) {
+            result.setIndexPath(split[1].strip());
+        }
+        return result;
+    }
+
+    public static RecentUrlsSet fromString(String urls, int maxLength){
+        if(urls == null) {
+            return new RecentUrlsSet(maxLength);
+        }
+
+        String[] elements = urls.split("\\|");
+        List<ResourceLocator> locators = Arrays.stream(elements)
+                .filter(Objects::nonNull)
+                .filter(elem -> !elem.isBlank())
+                .map(RecentUrlsSet::stringToLocator)
+                .filter(Objects::nonNull)
+                .toList();
+        return new RecentUrlsSet(locators, maxLength);
+    }
+}

--- a/src/main/java/org/broad/igv/ui/RecentUrlsSet.java
+++ b/src/main/java/org/broad/igv/ui/RecentUrlsSet.java
@@ -1,5 +1,7 @@
 package org.broad.igv.ui;
 
+import org.broad.igv.ui.action.LoadFilesMenuAction;
+import org.broad.igv.ui.action.LoadFromURLMenuAction;
 import org.broad.igv.util.ResourceLocator;
 
 import java.util.Arrays;
@@ -9,9 +11,16 @@ import java.util.Objects;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+/**
+ * An implementation of StackSet which supports {@link ResourceLocator}s which include a path and an index
+ * This matches the form used by the {@link LoadFilesMenuAction} and {@link LoadFromURLMenuAction}
+ *
+ *
+ */
 public class RecentUrlsSet extends StackSet<ResourceLocator> {
-    public static final String INDEX_DELIM = "index:";
+    private static final String INDEX_DELIM = "index:";
     private static final Pattern INDEX_SPLITTER = Pattern.compile("\\s" + INDEX_DELIM);
+
     public RecentUrlsSet(int maxSize) {
         super(maxSize);
     }
@@ -35,8 +44,6 @@ public class RecentUrlsSet extends StackSet<ResourceLocator> {
         }
         return builder.toString();
     }
-
-
 
     private static ResourceLocator stringToLocator(String locationString) {
         String[] split = INDEX_SPLITTER.split(locationString);

--- a/src/main/java/org/broad/igv/ui/StackSet.java
+++ b/src/main/java/org/broad/igv/ui/StackSet.java
@@ -3,23 +3,49 @@ package org.broad.igv.ui;
 import java.util.*;
 
 /**
+ * This is a very specific collection which is designed to support "recent item" lists.
  *
+ * It behaves like a stack, the most recently added item is always the first, second most recent is the second, and so forth
+ * It disallows duplicate items. Adding a duplicate item will move it to the top of the list.
+ * There is also size limit, adding additional items beyond the maximum size will remove the oldest items from the collection
+ * to make room.
+ *
+ * @implNote This is implemented in an extremely inefficient way, do not use this for large collections.
  */
 public class StackSet<T> extends AbstractCollection<T> implements Set<T>, SequencedCollection<T> {
     final private LinkedList<T> values;
     final int maxSize;
 
+    /**
+     * Create an empty StackSet with maxSize
+     */
     public StackSet(int maxSize) {
         this(new LinkedList<>(), maxSize);
     }
 
-    public StackSet(Collection<T> c, int maxSize) {
+    /**
+     * Constructs a StackSet containing the elements of the specified collection, in the order
+     * they are returned by the collection's iterator.  (The first element returned by the collection's
+     * iterator becomes the first element, or <i>top</i> of the stack.)
+     *
+     * Duplicate values appear at their earliest position.
+     *
+     * This order consistent with the way {@link ArrayDeque} is implemented;
+     *
+     * @param initialValues
+     * @param maxSize
+     */
+    public StackSet(Collection<T> initialValues, int maxSize) {
         this(new LinkedList<>(), maxSize);
-        Collection<T> unique = new LinkedHashSet<>(c);
+        Collection<T> unique = new LinkedHashSet<>(initialValues);
         List<T> limited = unique.stream().limit(maxSize).toList();
         values.addAll(limited);
     }
 
+
+    /**
+     * private constructor allowing direct setting of the values in order to support reverse views
+     */
     private StackSet(LinkedList<T> values, int maxSize) {
         if (maxSize <= 0) {
             throw new IllegalArgumentException("maxSize must be > 0");
@@ -28,6 +54,12 @@ public class StackSet<T> extends AbstractCollection<T> implements Set<T>, Sequen
         this.values = values;
     }
 
+    /**
+     * Add an element to the top of the stack.  If it is already present it will be
+     * moved to the top.
+     * @param t element to add
+     * @return always true
+     */
     @Override
     public boolean add(T t) {
         values.remove(t);
@@ -38,6 +70,14 @@ public class StackSet<T> extends AbstractCollection<T> implements Set<T>, Sequen
         return true;
     }
 
+    /**
+     * Add the elements of this collection to the top of the stack in the order of the collections
+     * iterator.
+     *
+     * This is different from the implementation of {@link Deque} which adds to the end of the queue
+     * @param c collection containing elements to be added to this collection
+     * @return always true
+     */
     @Override
     public boolean addAll(Collection<? extends T> c) {
         ArrayList<? extends T> list = new ArrayList<>(c);
@@ -45,26 +85,48 @@ public class StackSet<T> extends AbstractCollection<T> implements Set<T>, Sequen
         return true;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public boolean remove(Object o) {
         return values.remove(o);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void clear() {
         values.clear();
     }
 
+    /**
+     * @return an iterator over the elements of the Stack from most recently to oldest
+     */
     @Override
     public Iterator<T> iterator() {
         return values.iterator();
     }
 
+    /**
+    * {@inheritDoc}
+    */
     @Override
     public int size() {
         return values.size();
     }
 
+    /**
+     * @return the maximum allowed size for this collection
+     */
+    public int getMaxSize(){
+        return maxSize;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public StackSet<T> reversed() {
         return new StackSet<>(values.reversed(), maxSize);

--- a/src/main/java/org/broad/igv/ui/StackSet.java
+++ b/src/main/java/org/broad/igv/ui/StackSet.java
@@ -1,28 +1,31 @@
 package org.broad.igv.ui;
 
-import java.io.File;
 import java.util.*;
-import java.util.stream.Collectors;
 
 /**
  *
  */
-public class LimitedLinkedSet<T> extends AbstractCollection<T>{
-    final protected LinkedList<T> values = new LinkedList<>();
+public class StackSet<T> extends AbstractCollection<T> implements Set<T>, SequencedCollection<T> {
+    final private LinkedList<T> values;
     final int maxSize;
 
-    public LimitedLinkedSet(int maxSize) {
+    public StackSet(int maxSize) {
+        this(new LinkedList<>(), maxSize);
+    }
+
+    public StackSet(Collection<T> c, int maxSize) {
+        this(new LinkedList<>(), maxSize);
+        Collection<T> unique = new LinkedHashSet<>(c);
+        List<T> limited = unique.stream().limit(maxSize).toList();
+        values.addAll(limited);
+    }
+
+    private StackSet(LinkedList<T> values, int maxSize) {
         if (maxSize <= 0) {
             throw new IllegalArgumentException("maxSize must be > 0");
         }
         this.maxSize = maxSize;
-    }
-
-    public LimitedLinkedSet(Collection<T> c, int maxSize) {
-        this(maxSize);
-        Collection<T> unique = new LinkedHashSet<>(c);
-        List<T> limited = unique.stream().limit(maxSize).toList();
-        values.addAll(limited);
+        this.values = values;
     }
 
     @Override
@@ -60,6 +63,11 @@ public class LimitedLinkedSet<T> extends AbstractCollection<T>{
     @Override
     public int size() {
         return values.size();
+    }
+
+    @Override
+    public StackSet<T> reversed() {
+        return new StackSet<>(values.reversed(), maxSize);
     }
 
 }

--- a/src/main/java/org/broad/igv/ui/action/LoadFilesMenuAction.java
+++ b/src/main/java/org/broad/igv/ui/action/LoadFilesMenuAction.java
@@ -30,7 +30,6 @@
 package org.broad.igv.ui.action;
 
 import org.broad.igv.logging.*;
-import org.broad.igv.Globals;
 import org.broad.igv.prefs.IGVPreferences;
 import org.broad.igv.prefs.PreferencesManager;
 import org.broad.igv.session.SessionReader;
@@ -42,7 +41,6 @@ import org.broad.igv.util.ResourceLocator;
 import java.awt.event.ActionEvent;
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -122,6 +120,7 @@ public class LoadFilesMenuAction extends MenuAction {
             if (!validFiles.isEmpty()) {
                 // Create DataResourceLocators for the selected files
                 final List<ResourceLocator> locators = ResourceLocator.getLocators(validFiles);
+                igv.addToRecentUrls(locators);
                 igv.loadTracks(locators);
             }
         }

--- a/src/main/java/org/broad/igv/ui/action/LoadFilesMenuAction.java
+++ b/src/main/java/org/broad/igv/ui/action/LoadFilesMenuAction.java
@@ -44,6 +44,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * @author jrobinso
@@ -89,17 +90,12 @@ public class LoadFilesMenuAction extends MenuAction {
         if (files != null && files.length > 0) {
 
             final List<File> validFiles = new ArrayList<>();
-            StringBuilder buffer = new StringBuilder();
-            buffer.append("File(s) not found: ");
-            boolean allFilesExist = true;
+            final List<File> missingFiles = new ArrayList<>();
+
             for (File file : files) {
-
                 if (!file.exists()) {
-                    allFilesExist = false;
-                    buffer.append("\n\t");
-                    buffer.append(file.getAbsolutePath());
+                    missingFiles.add(file);
                 } else {
-
                     String path = file.getAbsolutePath();
                     if (SessionReader.isSessionFile(path)) {
                         final String msg = "File " + path +
@@ -115,8 +111,10 @@ public class LoadFilesMenuAction extends MenuAction {
 
             }
 
-            if (!allFilesExist) {
-                final String msg = buffer.toString();
+            if (!missingFiles.isEmpty()) {
+                String msg = missingFiles.stream()
+                        .map(File::getAbsolutePath)
+                        .collect(Collectors.joining("\n\t", "File(s) not found: \n\t", ""));
                 log.error(msg);
                 MessageUtils.showMessage(msg);
             }

--- a/src/main/java/org/broad/igv/ui/action/LoadFromURLMenuAction.java
+++ b/src/main/java/org/broad/igv/ui/action/LoadFromURLMenuAction.java
@@ -118,7 +118,7 @@ public class LoadFromURLMenuAction extends MenuAction {
                 MessageUtils.showMessage("Error loading url: " + url + " (" + ex + ")");
             }
         } else {
-            if (indexes.size() != inputs.size()) {
+            if (!indexes.isEmpty() && indexes.size() != inputs.size()) {
                 throw new RuntimeException("The number of Index URLs must equal the number of File URLs");
             }
             checkURLs(indexes);
@@ -164,7 +164,7 @@ public class LoadFromURLMenuAction extends MenuAction {
         for (int i = 0; i < inputs.size(); i++) {
             final String url = inputs.get(i);
             final ResourceLocator rl = new ResourceLocator(url.trim());
-            if (indexes != null) {
+            if (!indexes.isEmpty()) {
                 final String indexUrl = indexes.get(i);
                 rl.setIndexPath(indexUrl);
             }

--- a/src/main/java/org/broad/igv/ui/action/LoadFromURLMenuAction.java
+++ b/src/main/java/org/broad/igv/ui/action/LoadFromURLMenuAction.java
@@ -34,21 +34,18 @@ import org.broad.igv.feature.genome.Genome;
 import org.broad.igv.feature.genome.load.HubGenomeLoader;
 import org.broad.igv.logging.*;
 import org.broad.igv.feature.genome.GenomeManager;
-import org.broad.igv.util.GoogleUtils;
-import org.broad.igv.prefs.Constants;
-import org.broad.igv.prefs.PreferencesManager;
 import org.broad.igv.session.SessionReader;
 import org.broad.igv.ui.IGV;
 import org.broad.igv.ui.util.LoadFromURLDialog;
 import org.broad.igv.ui.util.MessageUtils;
 import org.broad.igv.util.*;
-import org.broad.igv.ui.IGVMenuBar;
 
 import javax.swing.*;
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.List;
 
 import static org.broad.igv.util.AmazonUtils.isObjectAccessible;
 
@@ -57,12 +54,13 @@ import static org.broad.igv.util.AmazonUtils.isObjectAccessible;
  */
 public class LoadFromURLMenuAction extends MenuAction {
 
-    static Logger log = LogManager.getLogger(LoadFilesMenuAction.class);
     public static final String LOAD_FROM_URL = "Load from URL...";
     public static final String LOAD_GENOME_FROM_URL = "Load Genome from URL...";
     public static final String LOAD_FROM_HTSGET = "Load from htsget Server...";
     public static final String LOAD_TRACKHUB = "Load Track Hub...";
-    private IGV igv;
+
+    private static final Logger log = LogManager.getLogger(LoadFromURLMenuAction.class);
+    private final IGV igv;
 
     public LoadFromURLMenuAction(String label, int mnemonic, IGV igv) {
         super(label, null, mnemonic);
@@ -74,114 +72,105 @@ public class LoadFromURLMenuAction extends MenuAction {
 
         JPanel ta = new JPanel();
         ta.setPreferredSize(new Dimension(600, 20));
-        boolean isHtsGet = e.getActionCommand().equalsIgnoreCase(LOAD_FROM_HTSGET);
-        if (e.getActionCommand().equalsIgnoreCase(LOAD_FROM_URL) || isHtsGet) {
+        String command = e.getActionCommand();
+        boolean isHtsGet = command.equalsIgnoreCase(LOAD_FROM_HTSGET);
+        if (command.equalsIgnoreCase(LOAD_FROM_URL) || isHtsGet) {
 
             LoadFromURLDialog dlg = new LoadFromURLDialog(IGV.getInstance().getMainFrame(), isHtsGet);
             dlg.setVisible(true);
 
             if (!dlg.isCanceled()) {
-
-
-                String inputURLs = dlg.getFileURL();
-                if (inputURLs != null && inputURLs.trim().length() > 0) {
-
-                    String[] inputs = Globals.whitespacePattern.split(inputURLs.trim());
-                    checkURLs(inputs);
-                    if (inputs.length == 1 && HubGenomeLoader.isHubURL(inputs[0])) {
-                        LongRunningTask.submit(() -> {
-                            try {
-                               Genome newGenome = GenomeManager.getInstance().loadGenome(inputs[0]);
-                            } catch (IOException ex) {
-                                log.error("Error loading tack hub", ex);
-                                MessageUtils.showMessage("Error loading track hub: " + ex.getMessage());
-
-                            }
-                        });
-                    }
-                    else if (inputs.length == 1 && SessionReader.isSessionFile(inputs[0])) {
-                        // Session URL
-                        String url = inputs[0];
-                        if (url.startsWith("s3://")) {
-                            checkAWSAccessbility(url);
-                        }
-                        try {
-                            LongRunningTask.submit(() -> this.igv.loadSession(url, null));
-                        } catch (Exception ex) {
-                            MessageUtils.showMessage("Error loading url: " + url + " (" + ex.toString() + ")");
-                        }
-                    } else {
-                        // Files, possibly indexed
-                        String[] indexes = null;
-                        String indexURLs = dlg.getIndexURL();
-                        if (indexURLs != null && indexURLs.trim().length() > 0) {
-                            indexes = Globals.whitespacePattern.split(indexURLs.trim());
-                            if (indexes.length != inputs.length) {
-                                throw new RuntimeException("The number of Index URLs must equal the number of File URLs");
-                            }
-                            checkURLs(indexes);
-                        }
-
-                        ArrayList<ResourceLocator> locators = new ArrayList<>();
-                        for (int i = 0; i < inputs.length; i++) {
-                            String url = inputs[i];
-                            ResourceLocator rl = new ResourceLocator(url.trim());
-                            if (indexes != null) {
-                                String indexUrl = indexes[i];
-                                rl.setIndexPath(indexUrl);
-                            }
-                            if (isHtsGet) {
-                                rl.setHtsget(true);
-                            }
-                            locators.add(rl);
-                        }
-                        igv.loadTracks(locators);
-                    }
-                }
+                loadUrls(dlg.getFileURLs(),  dlg.getIndexURLs(), isHtsGet);
             }
-        } else if ((e.getActionCommand().equalsIgnoreCase(LOAD_GENOME_FROM_URL))) {
+        } else if ((command.equalsIgnoreCase(LOAD_GENOME_FROM_URL))) {
 
             String url = JOptionPane.showInputDialog(IGV.getInstance().getMainFrame(), ta, "Enter URL to .genome or FASTA file",
                     JOptionPane.QUESTION_MESSAGE);
 
-            if (url != null && url.trim().length() > 0) {
-                url = url.trim();
+            loadGenomeFromUrl(url);
+
+        } else if ((command.equalsIgnoreCase(LOAD_TRACKHUB))) {
+            loadTrackHub(ta);
+        }
+    }
+
+    private void loadUrls(List<String> inputs, List<String> indexes, boolean isHtsGet) {
+        checkURLs(inputs);
+        if (inputs.size() == 1 && HubGenomeLoader.isHubURL(inputs.getFirst())) {
+            LongRunningTask.submit(() -> {
                 try {
-                    checkURLs(new String[]{url});
-                    GenomeManager.getInstance().loadGenome(url);
-                } catch (Exception e1) {
-                    MessageUtils.showMessage("Error loading genome: " + e1.getMessage());
-                }
+                    GenomeManager.getInstance().loadGenome(inputs.getFirst());
+                } catch (IOException ex) {
+                    log.error("Error loading tack hub", ex);
+                    MessageUtils.showMessage("Error loading track hub: " + ex.getMessage());
 
+                }
+            });
+        } else if (inputs.size() == 1 && SessionReader.isSessionFile(inputs.getFirst())) {
+            // Session URL
+            String url = inputs.getFirst();
+            if (url.startsWith("s3://")) {
+                checkAWSAccessbility(url);
             }
-        } else if ((e.getActionCommand().equalsIgnoreCase(LOAD_TRACKHUB))) {
-
-            String urlOrAccension = JOptionPane.showInputDialog(IGV.getInstance().getMainFrame(), ta, "Enter GCA or GCF accension, or URL to hub.txt file",
-                    JOptionPane.QUESTION_MESSAGE);
-
-            if(urlOrAccension == null) return;
-            urlOrAccension = urlOrAccension.trim();
-            String url;
-            if(urlOrAccension.startsWith("GC")) {
-                url = HubGenomeLoader.convertToHubURL(urlOrAccension);
-                if(url == null || !FileUtils.resourceExists(url)) {
-                    MessageUtils.showMessage("Unrecognized hub identifier: " + urlOrAccension);
-                }
-            } else {
-                url = urlOrAccension;
+            try {
+                LongRunningTask.submit(() -> this.igv.loadSession(url, null));
+            } catch (Exception ex) {
+                MessageUtils.showMessage("Error loading url: " + url + " (" + ex + ")");
             }
+        } else {
+            if (indexes.size() != inputs.size()) {
+                throw new RuntimeException("The number of Index URLs must equal the number of File URLs");
+            }
+            checkURLs(indexes);
+            List<ResourceLocator> locators = getResourceLocators(inputs, indexes, isHtsGet);
+            igv.loadTracks(locators);
+        }
+    }
 
-            if (url != null && url.trim().length() > 0) {
-                url = url.trim();
-                try {
-                    checkURLs(new String[]{url});
-                    GenomeManager.getInstance().loadGenome(url);
-                } catch (Exception e1) {
-                    MessageUtils.showMessage("Error loading genome: " + e1.getMessage());
-                }
+    private static void loadTrackHub(JPanel ta) {
+        String urlOrAccension = JOptionPane.showInputDialog(IGV.getInstance().getMainFrame(), ta, "Enter GCA or GCF accession, or URL to hub.txt file",
+                JOptionPane.QUESTION_MESSAGE);
 
+        if(urlOrAccension == null) return;
+        urlOrAccension = urlOrAccension.trim();
+        final String url;
+        if(urlOrAccension.startsWith("GC")) {
+            url = HubGenomeLoader.convertToHubURL(urlOrAccension);
+            if(!FileUtils.resourceExists(url)) {
+                MessageUtils.showMessage("Unrecognized hub identifier: " + urlOrAccension);
+            }
+        } else {
+            url = urlOrAccension;
+        }
+
+        loadGenomeFromUrl(url);
+    }
+
+    private static void loadGenomeFromUrl(String url) {
+        if (url != null && !url.isBlank()) {
+            url = url.trim();
+            try {
+                checkURLs(List.of(url));
+                GenomeManager.getInstance().loadGenome(url);
+            } catch (Exception e) {
+                MessageUtils.showMessage("Error loading genome: " + e.getMessage());
             }
         }
+    }
+
+    private static List<ResourceLocator> getResourceLocators(List<String>inputs, List<String> indexes, boolean isHtsGet) {
+        List<ResourceLocator> locators = new ArrayList<>();
+        for (int i = 0; i < inputs.size(); i++) {
+            final String url = inputs.get(i);
+            final ResourceLocator rl = new ResourceLocator(url.trim());
+            if (indexes != null) {
+                final String indexUrl = indexes.get(i);
+                rl.setIndexPath(indexUrl);
+            }
+            rl.setHtsget(isHtsGet);
+            locators.add(rl);
+        }
+        return locators;
     }
 
     /**
@@ -190,11 +179,11 @@ public class LoadFromURLMenuAction extends MenuAction {
      * @param input
      * @return
      */
-    private boolean isHubURL(String input) {
+    private static boolean isHubURL(String input) {
         return input.endsWith("/hub.txt");
     }
 
-    private void checkURLs(String[] urls) {
+    private static void checkURLs(List<String> urls) {
         for (String url : urls) {
             if (url.startsWith("s3://")) {
                 checkAWSAccessbility(url);
@@ -204,7 +193,7 @@ public class LoadFromURLMenuAction extends MenuAction {
         }
     }
 
-    private void checkAWSAccessbility(String url) {
+    private static void checkAWSAccessbility(String url) {
         try {
             // If AWS support is active, check if objects are in accessible tiers via Load URL menu...
             if (AmazonUtils.isAwsS3Path(url)) {

--- a/src/main/java/org/broad/igv/ui/action/LoadFromURLMenuAction.java
+++ b/src/main/java/org/broad/igv/ui/action/LoadFromURLMenuAction.java
@@ -123,6 +123,7 @@ public class LoadFromURLMenuAction extends MenuAction {
             }
             checkURLs(indexes);
             List<ResourceLocator> locators = getResourceLocators(inputs, indexes, isHtsGet);
+            igv.addToRecentUrls(locators);
             igv.loadTracks(locators);
         }
     }

--- a/src/main/java/org/broad/igv/ui/action/OpenSessionMenuAction.java
+++ b/src/main/java/org/broad/igv/ui/action/OpenSessionMenuAction.java
@@ -64,7 +64,7 @@ public class OpenSessionMenuAction extends MenuAction {
         super(sessionFile);
         this.sessionFile = sessionFile;
         this.igv = igv;
-        autoload = true;
+        this.autoload = true;
     }
 
     public OpenSessionMenuAction(String label, int mnemonic, IGV igv) {
@@ -76,18 +76,25 @@ public class OpenSessionMenuAction extends MenuAction {
     public void actionPerformed(ActionEvent e) {
 
         if (sessionFile == null || autoload == false) {
-            File lastSessionDirectory = PreferencesManager.getPreferences().getLastTrackDirectory();
-            File tmpFile = FileDialogUtils.chooseFile("Open Session", lastSessionDirectory, JFileChooser.FILES_ONLY);
-
-            if (tmpFile == null) {
-                return;
-            }
-            sessionFile = tmpFile.getAbsolutePath();
-            PreferencesManager.getPreferences().setLastTrackDirectory(tmpFile.getParentFile());
+            sessionFile = pickSessionFile();
         }
         if (sessionFile != null) {
             LongRunningTask.submit(() -> this.igv.loadSession(sessionFile, null));
         }
+    }
+
+    private static String pickSessionFile() {
+        File lastSessionDirectory = PreferencesManager.getPreferences().getLastTrackDirectory();
+        File tmpFile = FileDialogUtils.chooseFile("Open Session", lastSessionDirectory, JFileChooser.FILES_ONLY);
+
+        final String result;
+        if (tmpFile == null) {
+            result = null;
+        } else {
+            result = tmpFile.getAbsolutePath();
+            PreferencesManager.getPreferences().setLastTrackDirectory(tmpFile.getParentFile());
+        }
+        return result;
     }
 }
 

--- a/src/main/java/org/broad/igv/ui/util/AutosaveMenu.java
+++ b/src/main/java/org/broad/igv/ui/util/AutosaveMenu.java
@@ -64,9 +64,9 @@ public class AutosaveMenu extends JMenu {
             }
         }
         // Create a menu item for each of the timed autosave files and add it to the menu
-        for(int i = 0; i < timedAutosaves.length; i++) {
+        for (File timedAutosave : timedAutosaves) {
             add(MenuAndToolbarUtils.createMenuItem(
-                    new OpenSessionMenuAction(timedAutosaves[i].getAbsolutePath(), IGV.getInstance())
+                    new OpenSessionMenuAction(timedAutosave.getAbsolutePath(), IGV.getInstance())
             ));
         }
     }

--- a/src/main/java/org/broad/igv/ui/util/AutosaveMenu.java
+++ b/src/main/java/org/broad/igv/ui/util/AutosaveMenu.java
@@ -2,6 +2,7 @@ package org.broad.igv.ui.util;
 
 import org.broad.igv.session.autosave.SessionAutosaveManager;
 import org.broad.igv.ui.IGV;
+import org.broad.igv.ui.MenuSelectedListener;
 import org.broad.igv.ui.action.OpenSessionMenuAction;
 
 import javax.swing.*;
@@ -24,22 +25,7 @@ public class AutosaveMenu extends JMenu {
     private AutosaveMenu(String name) {
         super(name);
 
-        this.addMenuListener(new MenuListener() {
-            @Override
-            public void menuSelected(MenuEvent e) {
-                fillAutosaveList();
-            }
-
-            @Override
-            public void menuDeselected(MenuEvent e) {
-
-            }
-
-            @Override
-            public void menuCanceled(MenuEvent e) {
-
-            }
-        });
+        this.addMenuListener((MenuSelectedListener) e -> fillAutosaveList());
     }
 
     /**

--- a/src/main/java/org/broad/igv/ui/util/HistoryMenu.java
+++ b/src/main/java/org/broad/igv/ui/util/HistoryMenu.java
@@ -27,6 +27,7 @@ package org.broad.igv.ui.util;
 
 import org.broad.igv.ui.IGV;
 import org.broad.igv.session.History;
+import org.broad.igv.ui.MenuSelectedListener;
 
 import javax.swing.*;
 import javax.swing.event.MenuEvent;
@@ -77,14 +78,14 @@ public class HistoryMenu extends JMenu {
         });
 
 
-        this.addMenuListener(new MenuListener() {
+        this.addMenuListener(new MenuSelectedListener() {
             public void menuSelected(MenuEvent menuEvent) {
 
                 final History history = IGV.getInstance().getSession().getHistory();
 
 
                 List<History.Entry> allLoci = IGV.getInstance().getSession().getAllHistory();
-                
+
                 boolean hasBack = history.peekBack() != null;
                 boolean hasForward = history.peekForward() != null;
                 backItem.setEnabled(hasBack);
@@ -120,14 +121,6 @@ public class HistoryMenu extends JMenu {
                 add(clearAllItem);
 
 
-            }
-
-            public void menuDeselected(MenuEvent menuEvent) {
-                //To change body of implemented methods use File | Settings | File Templates.
-            }
-
-            public void menuCanceled(MenuEvent menuEvent) {
-                //To change body of implemented methods use File | Settings | File Templates.
             }
         });
     }

--- a/src/main/java/org/broad/igv/ui/util/LoadFromURLDialog.java
+++ b/src/main/java/org/broad/igv/ui/util/LoadFromURLDialog.java
@@ -29,10 +29,13 @@
 
 package org.broad.igv.ui.util;
 
+import org.broad.igv.Globals;
+
 import java.awt.*;
 import java.awt.event.*;
-import java.net.MalformedURLException;
-import java.net.URL;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import javax.swing.*;
 import javax.swing.border.*;
 
@@ -74,12 +77,20 @@ public class LoadFromURLDialog extends org.broad.igv.ui.IGVDialog {
         return canceled;
     }
 
-    public String getFileURL() {
-        return fileURL;
+    public List<String> getFileURLs() {
+        return splitOnWhiteSpace(fileURL);
     }
 
-    public String getIndexURL() {
-        return indexURL;
+    private static List<String> splitOnWhiteSpace(String string) {
+        if (string != null && !string.isBlank()) {
+            String[] inputs = Globals.whitespacePattern.split(string.trim());
+            return Arrays.asList(inputs);
+        }
+        return Collections.emptyList();
+    }
+
+    public List<String> getIndexURLs() {
+        return splitOnWhiteSpace(indexURL);
     }
 
     private void initComponents(boolean isHtsget) {

--- a/src/main/java/org/broad/igv/ui/util/RecentUrlsMenu.java
+++ b/src/main/java/org/broad/igv/ui/util/RecentUrlsMenu.java
@@ -1,0 +1,68 @@
+package org.broad.igv.ui.util;
+
+import org.broad.igv.ui.IGV;
+import org.broad.igv.ui.RecentFileSet;
+import org.broad.igv.ui.RecentUrlsSet;
+import org.broad.igv.ui.action.MenuAction;
+import org.broad.igv.util.ResourceLocator;
+
+import javax.swing.*;
+import javax.swing.event.MenuEvent;
+import javax.swing.event.MenuListener;
+import java.awt.event.ActionEvent;
+import java.util.List;
+
+public class RecentUrlsMenu extends JMenu {
+
+    public RecentUrlsMenu() {
+        this("Recent Files");
+    }
+
+    private RecentUrlsMenu(String name) {
+        super(name);
+
+        this.addMenuListener(new MenuListener() {
+            @Override
+            public void menuSelected(MenuEvent e) {
+                RecentUrlsSet recentFileList = IGV.getInstance().getRecentUrls();
+                if (recentFileList.isEmpty()) {
+                    RecentUrlsMenu.this.setVisible(false);
+                } else {
+                    RecentUrlsMenu.this.setVisible(true);
+                    // Remove what's in the menu right now
+                    RecentUrlsMenu.this.removeAll();
+                    // Create a menu item for each of the timed autosave files and add it to the menu
+                    for (ResourceLocator resourceLocator : recentFileList) {
+                        MenuAction menuItemAction = new MenuAction(resourceLocator.getPath()) {
+                            @Override
+                            public void actionPerformed(ActionEvent event) {
+                                IGV igv = IGV.getInstance();
+                                List<ResourceLocator> resource = List.of(resourceLocator);
+                                igv.loadTracks(resource);
+                                igv.addToRecentUrls(resource);
+                            }
+                        };
+
+                        String toolTipText = resourceLocator.getIndexPath() == null
+                                ? "Load track from " + resourceLocator.getPath()
+                                : "<html>Load track from <br>path:  " + resourceLocator.getPath()
+                                    + "<br>index: " + resourceLocator.getIndexPath()
+                                    + "</html>";
+
+                        menuItemAction.setToolTipText(toolTipText);
+                        add(MenuAndToolbarUtils.createMenuItem(menuItemAction));
+                    }
+                }
+            }
+
+            @Override
+            public void menuDeselected(MenuEvent e) {
+            }
+
+            @Override
+            public void menuCanceled(MenuEvent e) {
+            }
+        });
+    }
+}
+

--- a/src/main/java/org/broad/igv/ui/util/RecentUrlsMenu.java
+++ b/src/main/java/org/broad/igv/ui/util/RecentUrlsMenu.java
@@ -1,14 +1,13 @@
 package org.broad.igv.ui.util;
 
 import org.broad.igv.ui.IGV;
-import org.broad.igv.ui.RecentFileSet;
+import org.broad.igv.ui.MenuSelectedListener;
 import org.broad.igv.ui.RecentUrlsSet;
 import org.broad.igv.ui.action.MenuAction;
 import org.broad.igv.util.ResourceLocator;
 
 import javax.swing.*;
-import javax.swing.event.MenuEvent;
-import javax.swing.event.MenuListener;
+import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.util.List;
 
@@ -21,48 +20,52 @@ public class RecentUrlsMenu extends JMenu {
     private RecentUrlsMenu(String name) {
         super(name);
 
-        this.addMenuListener(new MenuListener() {
-            @Override
-            public void menuSelected(MenuEvent e) {
-                RecentUrlsSet recentFileList = IGV.getInstance().getRecentUrls();
-                if (recentFileList.isEmpty()) {
-                    RecentUrlsMenu.this.setVisible(false);
-                } else {
-                    RecentUrlsMenu.this.setVisible(true);
-                    // Remove what's in the menu right now
-                    RecentUrlsMenu.this.removeAll();
-                    // Create a menu item for each of the timed autosave files and add it to the menu
-                    for (ResourceLocator resourceLocator : recentFileList) {
-                        MenuAction menuItemAction = new MenuAction(resourceLocator.getPath()) {
-                            @Override
-                            public void actionPerformed(ActionEvent event) {
-                                IGV igv = IGV.getInstance();
-                                List<ResourceLocator> resource = List.of(resourceLocator);
-                                igv.loadTracks(resource);
-                                igv.addToRecentUrls(resource);
-                            }
-                        };
-
-                        String toolTipText = resourceLocator.getIndexPath() == null
-                                ? "Load track from " + resourceLocator.getPath()
-                                : "<html>Load track from <br>path:  " + resourceLocator.getPath()
-                                    + "<br>index: " + resourceLocator.getIndexPath()
-                                    + "</html>";
-
-                        menuItemAction.setToolTipText(toolTipText);
-                        add(MenuAndToolbarUtils.createMenuItem(menuItemAction));
-                    }
+        this.addMenuListener((MenuSelectedListener) e -> {
+            RecentUrlsSet recentFileList = IGV.getInstance().getRecentUrls();
+            if (recentFileList.isEmpty()) {
+                RecentUrlsMenu.this.setVisible(false);
+            } else {
+                RecentUrlsMenu.this.setVisible(true);
+                // Remove what's in the menu right now
+                RecentUrlsMenu.this.removeAll();
+                // Create a menu item for each of the timed autosave files and add it to the menu
+                for (ResourceLocator resourceLocator : recentFileList) {
+                    JMenuItem menuItem = createMenuItem(resourceLocator);
+                    add(menuItem);
                 }
-            }
 
-            @Override
-            public void menuDeselected(MenuEvent e) {
-            }
-
-            @Override
-            public void menuCanceled(MenuEvent e) {
+                addSeparator();
+                JMenuItem clearButton = MenuAndToolbarUtils.createMenuItem(new MenuAction("Clear Recent Files") {
+                    @Override
+                    public void actionPerformed(ActionEvent event) {
+                        IGV.getInstance().getRecentUrls().clear();
+                        RecentUrlsMenu.this.setVisible(false);
+                    }
+                });
+                add(clearButton);
             }
         });
+    }
+
+    private static JMenuItem createMenuItem(ResourceLocator resourceLocator) {
+        MenuAction menuItemAction = new MenuAction(resourceLocator.getPath()) {
+            @Override
+            public void actionPerformed(ActionEvent event) {
+                IGV igv = IGV.getInstance();
+                List<ResourceLocator> resource = List.of(resourceLocator);
+                igv.loadTracks(resource);
+                igv.addToRecentUrls(resource);
+            }
+        };
+
+        String toolTipText = resourceLocator.getIndexPath() == null
+                ? "Load track from " + resourceLocator.getPath()
+                : "<html>Load track from <br>path:  " + resourceLocator.getPath()
+                    + "<br>index: " + resourceLocator.getIndexPath()
+                    + "</html>";
+
+        menuItemAction.setToolTipText(toolTipText);
+        return MenuAndToolbarUtils.createMenuItem(menuItemAction);
     }
 }
 

--- a/src/main/java/org/broad/igv/util/ResourceLocator.java
+++ b/src/main/java/org/broad/igv/util/ResourceLocator.java
@@ -53,7 +53,7 @@ import static org.broad.igv.util.StringUtils.stripQuotes;
  */
 public class ResourceLocator {
 
-    private static Logger log = LogManager.getLogger(ResourceLocator.class);
+    private static final Logger log = LogManager.getLogger(ResourceLocator.class);
 
     /**
      * Display name
@@ -736,7 +736,7 @@ public class ResourceLocator {
         INDEX("index"),
         HTSGET("htsget");
 
-        private String name;
+        private final String name;
 
         AttributeType(String name) {
             this.name = name;

--- a/src/main/java/org/broad/igv/util/collections/LRUCache.java
+++ b/src/main/java/org/broad/igv/util/collections/LRUCache.java
@@ -46,10 +46,6 @@ public class LRUCache<K, V> {
         this.maxEntries = new AtomicInteger(max);
     }
 
-    public void setMaxEntries(int max) {
-        this.maxEntries.set(max);
-    }
-
     private void createMap() {
         map = Collections.synchronizedMap(
                 new LinkedHashMap<K, V>(16, 0.75f, true) {

--- a/src/test/java/org/broad/igv/sam/BisulfiteBaseInfoTest.java
+++ b/src/test/java/org/broad/igv/sam/BisulfiteBaseInfoTest.java
@@ -29,9 +29,11 @@ import htsjdk.samtools.SAMRecord;
 import org.broad.igv.feature.LocusScore;
 import org.broad.igv.feature.Strand;
 import org.broad.igv.track.WindowFunction;
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.awt.*;
+import java.util.LinkedHashSet;
 import java.util.List;
 
 /**

--- a/src/test/java/org/broad/igv/ui/LimitedLinkedSetTest.java
+++ b/src/test/java/org/broad/igv/ui/LimitedLinkedSetTest.java
@@ -1,0 +1,60 @@
+package org.broad.igv.ui;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+public class LimitedLinkedSetTest {
+
+
+    @Test
+    public void testAdds(){
+        LimitedLinkedSet<Integer> set = new LimitedLinkedSet<>(5);
+        set.add(1);
+        assertEquals(set, List.of(1));
+        set.add(2);
+        assertEquals(set, List.of(2, 1));
+        set.add(3);
+        assertEquals(set, List.of(3, 2, 1));
+        set.add(4);
+        assertEquals(set, List.of(4, 3, 2, 1));
+        set.add(5);
+        assertEquals(set, List.of(5, 4, 3, 2, 1));
+        set.add(6);
+        assertEquals(set, List.of(6, 5, 4, 3, 2));
+        set.add(7);
+        assertEquals(set, List.of(7, 6, 5, 4, 3));
+        set.add(7);
+        assertEquals(set, List.of(7, 6, 5, 4, 3));
+        set.add(1);
+        assertEquals(set, List.of(1, 7, 6, 5, 4));
+        set.add(7);
+        assertEquals(set, List.of(7, 1, 6, 5, 4));
+        set.remove(1);
+        assertEquals(set, List.of(7, 6, 5, 4));
+        set.add(7);
+        assertEquals(set, List.of(7, 6, 5, 4));
+    }
+
+    @Test
+    public void testNewCollection(){
+        LimitedLinkedSet<Integer> set = new LimitedLinkedSet<>(List.of(1, 1, 2, 3, 4, 5, 6, 7, 3), 5);
+        assertEquals(set, List.of(1,2,3,4,5));
+        set = new LimitedLinkedSet<>(List.of(1,1,1,1,1,1,1,1,1,1), 10);
+        assertEquals(set, List.of(1));
+        set = new LimitedLinkedSet<>(Collections.emptySet(), 1);
+        assertEquals(set, List.of());
+        set.add(1);
+        assertEquals(set, List.of(1));
+        set.add(2);
+        assertEquals(set, List.of(2));
+    }
+
+    public static <T> void assertEquals(Collection<T> actual, List<T> expected){
+        Assert.assertEquals(expected.size(), actual.size());
+        Assert.assertArrayEquals(expected.toArray(), actual.toArray());
+    }
+}

--- a/src/test/java/org/broad/igv/ui/RecentFileSetTest.java
+++ b/src/test/java/org/broad/igv/ui/RecentFileSetTest.java
@@ -15,41 +15,41 @@ public class RecentFileSetTest {
         set1.add("c");
         set1.add("d");
         set1.add("e");
-        LimitedLinkedSetTest.assertEquals(set1, List.of("e","d","c"));
+        StackSetTest.assertEquals(set1, List.of("e","d","c"));
     }
 
     @Test
     public void testAsListRoundTrip(){
         RecentFileSet set = new RecentFileSet(List.of("a", "b", "c", "d", "b"), 3);
-        LimitedLinkedSetTest.assertEquals(set, List.of("a", "b", "c"));
+        StackSetTest.assertEquals(set, List.of("a", "b", "c"));
         String string = set.asString();
         Assert.assertEquals("a;b;c", string);
         RecentFileSet set2 = RecentFileSet.fromString(string, 5);
-        LimitedLinkedSetTest.assertEquals(set2, List.of("a", "b", "c"));
+        StackSetTest.assertEquals(set2, List.of("a", "b", "c"));
     }
 
     @Test
     public void testNullString(){
         RecentFileSet set = RecentFileSet.fromString(null, 5);
-        LimitedLinkedSetTest.assertEquals(set, List.of());
+        StackSetTest.assertEquals(set, List.of());
     }
 
     @Test
     public void testEmptyString(){
         RecentFileSet set = RecentFileSet.fromString("", 5);
-        LimitedLinkedSetTest.assertEquals(set, List.of());
+        StackSetTest.assertEquals(set, List.of());
     }
 
     @Test
     public void testWhiteSpaceString(){
         RecentFileSet set = RecentFileSet.fromString(" a; b ; c; ", 5);
-        LimitedLinkedSetTest.assertEquals(set, List.of("a", "b", "c"));
+        StackSetTest.assertEquals(set, List.of("a", "b", "c"));
     }
 
     @Test
     public void testInternalWhiteSpaceString(){
         RecentFileSet set = RecentFileSet.fromString("this file has spaces;thisonedoesnt", 5);
-        LimitedLinkedSetTest.assertEquals(set, List.of("this file has spaces", "thisonedoesnt"));
+        StackSetTest.assertEquals(set, List.of("this file has spaces", "thisonedoesnt"));
     }
 
 

--- a/src/test/java/org/broad/igv/ui/RecentFileSetTest.java
+++ b/src/test/java/org/broad/igv/ui/RecentFileSetTest.java
@@ -1,0 +1,56 @@
+package org.broad.igv.ui;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+
+public class RecentFileSetTest {
+
+    @Test
+    public void testAdds() {
+        RecentFileSet set1 = new RecentFileSet(3);
+        set1.add("a");
+        set1.add("b");
+        set1.add("c");
+        set1.add("d");
+        set1.add("e");
+        LimitedLinkedSetTest.assertEquals(set1, List.of("e","d","c"));
+    }
+
+    @Test
+    public void testAsListRoundTrip(){
+        RecentFileSet set = new RecentFileSet(List.of("a", "b", "c", "d", "b"), 3);
+        LimitedLinkedSetTest.assertEquals(set, List.of("a", "b", "c"));
+        String string = set.asString();
+        Assert.assertEquals("a;b;c", string);
+        RecentFileSet set2 = RecentFileSet.fromString(string, 5);
+        LimitedLinkedSetTest.assertEquals(set2, List.of("a", "b", "c"));
+    }
+
+    @Test
+    public void testNullString(){
+        RecentFileSet set = RecentFileSet.fromString(null, 5);
+        LimitedLinkedSetTest.assertEquals(set, List.of());
+    }
+
+    @Test
+    public void testEmptyString(){
+        RecentFileSet set = RecentFileSet.fromString("", 5);
+        LimitedLinkedSetTest.assertEquals(set, List.of());
+    }
+
+    @Test
+    public void testWhiteSpaceString(){
+        RecentFileSet set = RecentFileSet.fromString(" a; b ; c; ", 5);
+        LimitedLinkedSetTest.assertEquals(set, List.of("a", "b", "c"));
+    }
+
+    @Test
+    public void testInternalWhiteSpaceString(){
+        RecentFileSet set = RecentFileSet.fromString("this file has spaces;thisonedoesnt", 5);
+        LimitedLinkedSetTest.assertEquals(set, List.of("this file has spaces", "thisonedoesnt"));
+    }
+
+
+}

--- a/src/test/java/org/broad/igv/ui/RecentUrlsSetTest.java
+++ b/src/test/java/org/broad/igv/ui/RecentUrlsSetTest.java
@@ -1,0 +1,57 @@
+package org.broad.igv.ui;
+
+import org.broad.igv.util.ResourceLocator;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Iterator;
+import java.util.List;
+
+
+public class RecentUrlsSetTest {
+
+    @Test
+    public void testRoundTrip() {
+        ResourceLocator withIndex1 = new ResourceLocator("path");
+        withIndex1.setIndexPath("index");
+
+        ResourceLocator withIndex2 = new ResourceLocator("i have an index");
+        withIndex2.setIndexPath("yes i do");
+
+        ResourceLocator noIndex1 = new ResourceLocator("path/no/index");
+        ResourceLocator noIndex2 = new ResourceLocator("path 2");
+
+        RecentUrlsSet resourceLocators = new RecentUrlsSet(List.of(withIndex1, withIndex2, noIndex1, noIndex2, withIndex1), 5);
+        String serialized = resourceLocators.asString();
+        Assert.assertEquals(serialized, "path index:index|i have an index index:yes i do|path/no/index|path 2");
+
+        RecentUrlsSet roundTrip = RecentUrlsSet.fromString(serialized, 5);
+        Assert.assertEquals(roundTrip.size(), resourceLocators.size());
+        Iterator<ResourceLocator> actual = roundTrip.iterator();
+        Iterator<ResourceLocator> expected = resourceLocators.iterator();
+        while (actual.hasNext() && expected.hasNext()) {
+            assertEqualLocator(expected.next(), actual.next());
+        }
+    }
+
+    @Test
+    public void testEmpty(){
+        RecentUrlsSet empty = new RecentUrlsSet(10);
+        Assert.assertEquals("", empty.asString());
+        RecentUrlsSet fromEmptyString = RecentUrlsSet.fromString("", 5);
+        Assert.assertEquals(0, fromEmptyString.size());
+    }
+
+    @Test
+    public void testNull(){
+        RecentUrlsSet empty = RecentUrlsSet.fromString(null, 5);
+        Assert.assertEquals(empty.size(),0);
+    }
+
+    public static void assertEqualLocator(ResourceLocator expected, ResourceLocator actual){
+        Assert.assertEquals(expected.getPath(), actual.getPath());
+        Assert.assertEquals(expected.getIndexPath(), actual.getIndexPath());
+    }
+
+
+}

--- a/src/test/java/org/broad/igv/ui/StackSetTest.java
+++ b/src/test/java/org/broad/igv/ui/StackSetTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedList;
 import java.util.List;
 
 public class StackSetTest {
@@ -45,7 +46,7 @@ public class StackSetTest {
         set.add(1);
         set.add(2);
         set.add(3);
-        set.addAll(List.of(3,3,4,5));
+        set.addAll(List.of(3,3,4,5,3));
         assertEquals(set, List.of(3,4,5,2,1));
     }
 
@@ -61,6 +62,12 @@ public class StackSetTest {
         assertEquals(set, List.of(1));
         set.add(2);
         assertEquals(set, List.of(2));
+    }
+
+    @Test
+    public void testDuplicateValuesPosition(){
+        StackSet<Integer> set = new StackSet<>(List.of(1, 2, 1, 3, 1, 4, 1, 5, 1), 5);
+        assertEquals(set, List.of(1,2,3,4,5));
     }
 
     @Test
@@ -83,4 +90,6 @@ public class StackSetTest {
         Assert.assertEquals(expected.size(), actual.size());
         Assert.assertArrayEquals(expected.toArray(), actual.toArray());
     }
+
+
 }

--- a/src/test/java/org/broad/igv/ui/StackSetTest.java
+++ b/src/test/java/org/broad/igv/ui/StackSetTest.java
@@ -7,12 +7,12 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
-public class LimitedLinkedSetTest {
+public class StackSetTest {
 
 
     @Test
     public void testAdds(){
-        LimitedLinkedSet<Integer> set = new LimitedLinkedSet<>(5);
+        StackSet<Integer> set = new StackSet<>(5);
         set.add(1);
         assertEquals(set, List.of(1));
         set.add(2);
@@ -40,18 +40,44 @@ public class LimitedLinkedSetTest {
     }
 
     @Test
+    public void testAddAll(){
+        StackSet<Integer> set = new StackSet<>(5);
+        set.add(1);
+        set.add(2);
+        set.add(3);
+        set.addAll(List.of(3,3,4,5));
+        assertEquals(set, List.of(3,4,5,2,1));
+    }
+
+    @Test
     public void testNewCollection(){
-        LimitedLinkedSet<Integer> set = new LimitedLinkedSet<>(List.of(1, 1, 2, 3, 4, 5, 6, 7, 3), 5);
+        StackSet<Integer> set = new StackSet<>(List.of(1, 1, 2, 3, 4, 5, 6, 7, 3), 5);
         assertEquals(set, List.of(1,2,3,4,5));
-        set = new LimitedLinkedSet<>(List.of(1,1,1,1,1,1,1,1,1,1), 10);
+        set = new StackSet<>(List.of(1,1,1,1,1,1,1,1,1,1), 10);
         assertEquals(set, List.of(1));
-        set = new LimitedLinkedSet<>(Collections.emptySet(), 1);
+        set = new StackSet<>(Collections.emptySet(), 1);
         assertEquals(set, List.of());
         set.add(1);
         assertEquals(set, List.of(1));
         set.add(2);
         assertEquals(set, List.of(2));
     }
+
+    @Test
+    public void testReverse(){
+        StackSet<Integer> set = new StackSet<>(List.of(1,2,3,4,5),5);
+        StackSet<Integer> reversed = set.reversed();
+        assertEquals(reversed, List.of(5,4,3,2,1));
+
+        reversed.add(1);
+        assertEquals(reversed, List.of(1,5,4,3,2));
+        assertEquals(set, List.of(2,3,4,5,1));
+
+        set.remove((4));
+        assertEquals(set, List.of(2,3,5,1));
+        assertEquals(reversed, List.of(1,5,3,2));
+    }
+
 
     public static <T> void assertEquals(Collection<T> actual, List<T> expected){
         Assert.assertEquals(expected.size(), actual.size());

--- a/src/test/java/org/broad/igv/util/TestUtils.java
+++ b/src/test/java/org/broad/igv/util/TestUtils.java
@@ -42,6 +42,7 @@ import htsjdk.tribble.Feature;
 import htsjdk.tribble.readers.AsciiLineReader;
 import org.junit.Assert;
 import org.junit.Ignore;
+import org.junit.Test;
 
 import java.awt.*;
 import java.io.*;


### PR DESCRIPTION
This primarily does 2 things:
1.  It adds a new Recent Files pop up menu which keeps track of the most recently opened files and URLs and allows reopening them quickly.  This was asked for here:  (#1547). It doesn't include the asked for feature of tracking the genome associated with each file to make it easier to reload that genome, that could be added in the future if necessary.

2. It makes the recent sessions list update dynamically instead of only on file load. Previously saving or opening a session doesn't update the list, now it will update as expected.

It adds a new collection type which I called "StackSet" which is basically a stack that only allows unique entries.  Adding an element that already exists moves it to the top of the stack.  It's implemented twice (RecentFilesSet, RecentUrlsSet) since the serialization of recent session files has to be handled differently than the serialization of files which might have an associated index.  

I've refactored the code around saving recent sessions to make it a bit cleaner.

In the future, it might make sense to move the list of recent sessions to a pop up as well.