### PR TITLE
Catch error instead of exception in longrunning task

### DIFF
--- a/src/main/java/org/broad/igv/util/LongRunningTask.java
+++ b/src/main/java/org/broad/igv/util/LongRunningTask.java
@@ -71,7 +71,7 @@ public class LongRunningTask implements Callable<Void> {
         CursorToken token = WaitCursorManager.showWaitCursor();
         try {
             runnable.run();
-        } catch (Error e) {
+        } catch (Throwable e) {
             MessageUtils.showMessage("<html>Unexpected error: " + e.getMessage() + ".<br>See igv.log for more details");
             log.error("Exception running task", e);
         } finally {

--- a/src/main/java/org/broad/igv/util/LongRunningTask.java
+++ b/src/main/java/org/broad/igv/util/LongRunningTask.java
@@ -71,7 +71,7 @@ public class LongRunningTask implements Callable<Void> {
         CursorToken token = WaitCursorManager.showWaitCursor();
         try {
             runnable.run();
-        } catch (Exception e) {
+        } catch (Error e) {
             MessageUtils.showMessage("<html>Unexpected error: " + e.getMessage() + ".<br>See igv.log for more details");
             log.error("Exception running task", e);
         } finally {


### PR DESCRIPTION
This causes some previously ignored errors to bubble up. 