### PR TITLE
Add a module requirement on commons compress

### DIFF
--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -15,6 +15,7 @@ module org.igv {
     exports org.broad.igv.ucsc.hub;
 
     requires com.google.common;
+    requires org.apache.commons.compress;
     requires commons.math3;
     requires com.google.gson;
     requires htsjdk;


### PR DESCRIPTION
This fixes a confusing issue with cram files silently failing to load
due to a missing class file.
