### PR TITLE
IGV FlatLaf theme support and selector

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -132,6 +132,7 @@ dependencies {
             [group: 'org.apache.xmlgraphics', name: 'batik-svggen', version: xmlGraphicsVersion],
             [group: 'org.apache.xmlgraphics', name: 'batik-codec', version: xmlGraphicsVersion],
             [group: 'org.netbeans.external', name: 'AbsoluteLayout', version: 'RELEASE110'],
+            [group: 'com.formdev', name: 'flatlaf', version: '3.5.4'],
 
             // Amazon deps
             [group: 'software.amazon.awssdk', name: 'cognitoidentity', version: amazonVersion],

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -115,6 +115,7 @@ module org.igv {
     requires batik.svggen;
     requires batik.dom;
     requires AbsoluteLayout.RELEASE110;
+    requires com.formdev.flatlaf;
 
     // AWS
     requires software.amazon.awssdk.core;

--- a/src/main/java/org/broad/igv/prefs/Constants.java
+++ b/src/main/java/org/broad/igv/prefs/Constants.java
@@ -39,6 +39,7 @@ final public class Constants {
     public static final String AUTOLOAD_LAST_AUTOSAVE = "AUTOLOAD_LAST_AUTOSAVE";
     public static final String AUTOSAVE_FREQUENCY = "AUTOSAVE_FREQUENCY";
     public static final String AUTOSAVES_TO_KEEP = "AUTOSAVES_TO_KEEP";
+    public static final String USER_THEME = "USER_THEME";
 
     //
     public static final String RECENT_SESSIONS = "IGV.Session.recent.sessions";

--- a/src/main/java/org/broad/igv/ui/Main.java
+++ b/src/main/java/org/broad/igv/ui/Main.java
@@ -329,6 +329,9 @@ public class Main {
                 case "FLATINTELLIJ":
                     UIManager.setLookAndFeel(new FlatIntelliJLaf());
                     break;
+                case "FLATINTELLIJDARK":
+                    UIManager.setLookAndFeel(new FlatDarculaLaf());
+                    break;
                 default:
                     UIManager.setLookAndFeel(UIManager.getCrossPlatformLookAndFeelClassName());
                     break;

--- a/src/main/java/org/broad/igv/ui/Main.java
+++ b/src/main/java/org/broad/igv/ui/Main.java
@@ -25,6 +25,8 @@
 
 package org.broad.igv.ui;
 
+import com.formdev.flatlaf.themes.FlatMacDarkLaf;
+import com.formdev.flatlaf.themes.FlatMacLightLaf;
 import com.jidesoft.plaf.LookAndFeelFactory;
 import com.sanityinc.jargs.CmdLineParser;
 import htsjdk.samtools.seekablestream.SeekableStreamFactory;
@@ -40,6 +42,7 @@ import org.broad.igv.util.HttpUtils;
 import org.broad.igv.util.RuntimeUtils;
 import org.broad.igv.util.stream.IGVSeekableStreamFactory;
 import org.broad.igv.util.stream.IGVUrlHelperFactory;
+import com.formdev.flatlaf.*;
 
 import javax.swing.*;
 import java.awt.*;
@@ -302,8 +305,34 @@ public class Main {
     private static void initializeLookAndFeel() {
 
         try {
-            String lnf = UIManager.getSystemLookAndFeelClassName();
-            UIManager.setLookAndFeel(lnf);
+            String lnfselect = PreferencesManager.getPreferences().get(USER_THEME);
+
+            switch(lnfselect){
+                case "SYSTEM":
+                    if (!Globals.IS_LINUX)
+                        UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
+                    else
+                        UIManager.setLookAndFeel(UIManager.getCrossPlatformLookAndFeelClassName());
+                    break;
+                case "FLATLIGHT":
+                    if(Globals.IS_MAC)
+                        UIManager.setLookAndFeel(new FlatMacLightLaf());
+                    else
+                        UIManager.setLookAndFeel(new FlatLightLaf());
+                    break;
+                case "FLATDARK":
+                    if(Globals.IS_MAC)
+                        UIManager.setLookAndFeel(new FlatMacDarkLaf());
+                    else
+                        UIManager.setLookAndFeel(new FlatDarkLaf());
+                    break;
+                case "FLATINTELLIJ":
+                    UIManager.setLookAndFeel(new FlatIntelliJLaf());
+                    break;
+                default:
+                    UIManager.setLookAndFeel(UIManager.getCrossPlatformLookAndFeelClassName());
+                    break;
+            }
 
         } catch (Exception e) {
             log.error("Error setting look and feel", e);
@@ -326,7 +355,6 @@ public class Main {
 
         if (Globals.IS_LINUX) {
             try {
-                UIManager.setLookAndFeel(UIManager.getCrossPlatformLookAndFeelClassName());
                 UIManager.put("JideSplitPane.dividerSize", 5);
                 UIManager.put("JideSplitPaneDivider.background", Color.darkGray);
 

--- a/src/main/resources/org/broad/igv/prefs/preferences.tab
+++ b/src/main/resources/org/broad/igv/prefs/preferences.tab
@@ -25,7 +25,7 @@ DEFAULT_FONT_SIZE	Default font size	integer	10
 SCALE_FONTS	Scale fonts. Useful for some high-resolution screens.  ** REQUIRES RESTART **	boolean	FALSE
 FONT_SCALE_FACTOR	Font scale factor	float	1
 ENABLE_ANTIALIASING	Enable anti-aliasing	boolean	TRUE
-USER_THEME	Select Theme (Requires Restart)	select SYSTEM|FLATLIGHT|FLATDARK|FLATINTELLIJ	SYSTEM
+USER_THEME	Select Theme (Requires Restart)	select SYSTEM|FLATLIGHT|FLATDARK|FLATINTELLIJ|FLATINTELLIJDARK	SYSTEM
 
 ##Nucleotide Colors
 COLOR.A	A	color	0,150,0

--- a/src/main/resources/org/broad/igv/prefs/preferences.tab
+++ b/src/main/resources/org/broad/igv/prefs/preferences.tab
@@ -25,6 +25,7 @@ DEFAULT_FONT_SIZE	Default font size	integer	10
 SCALE_FONTS	Scale fonts. Useful for some high-resolution screens.  ** REQUIRES RESTART **	boolean	FALSE
 FONT_SCALE_FACTOR	Font scale factor	float	1
 ENABLE_ANTIALIASING	Enable anti-aliasing	boolean	TRUE
+USER_THEME	Select Theme (Requires Restart)	select SYSTEM|FLATLIGHT|FLATDARK|FLATINTELLIJ	SYSTEM
 
 ##Nucleotide Colors
 COLOR.A	A	color	0,150,0


### PR DESCRIPTION
Hi IGV team.
I added a theme selector and flatlaf support for IGV to get a modern look under Linux system. This may also help IGV to have a unified look under cross operating systems as well if FlatLaf is selected as default. Currently System (win, mac) or cross platform (linux) is default. 

![image](https://github.com/user-attachments/assets/56eaaa17-cdb1-45fd-86c9-2974aa3e60b8)


![image](https://github.com/user-attachments/assets/3b5264e5-79de-4b70-a684-60881151ac28)
