### PR TITLE
Fixing a bug with locally downloaded 2bit references.

### DIFF
--- a/src/main/java/org/broad/igv/feature/genome/Genome.java
+++ b/src/main/java/org/broad/igv/feature/genome/Genome.java
@@ -56,6 +56,7 @@ import org.broad.igv.track.TribbleFeatureSource;
 import org.broad.igv.ucsc.hub.Hub;
 import org.broad.igv.ucsc.hub.HubParser;
 import org.broad.igv.ucsc.twobit.TwoBitSequence;
+import org.broad.igv.util.FileUtils;
 import org.broad.igv.util.HttpUtils;
 import org.broad.igv.util.ResourceLocator;
 import org.broad.igv.util.liftover.Liftover;
@@ -65,8 +66,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.*;
-import java.util.stream.Collectors;
 
 /**
  * Simple model of a genome.  Keeps an ordered list of Chromosomes, an alias table, and genome position offsets
@@ -156,8 +158,7 @@ public class Genome {
         // for .2bit sequences a 'chromSizes" file is required.  If not supplied the chr pulldown and wg view are disabled.
         List<Chromosome> chromosomeList = null;
         if (config.chromSizesURL != null) {
-            long contentLength = HttpUtils.getInstance().getContentLength(new URL(config.chromSizesURL));
-            if (contentLength > 0 && contentLength < 100000) {
+            if(fileSizeIsOk(config.chromSizesURL, 100_000)) {
                 chromosomeList = ChromSizesParser.parse(config.chromSizesURL);
             }
         }
@@ -219,15 +220,12 @@ public class Genome {
             cytobandSource = new CytobandMap(config.getCytobands());    // Directly supplied, from .genome file
         } else if (config.cytobandBbURL != null) {
             // The cytoband BB file can be enormous if there are many chromosomes, and is usually not informative in that case
-            long contentLength = HttpUtils.getInstance().getContentLength(new URL(config.cytobandBbURL));
-            if (contentLength > 0 && contentLength < 1000000) {
+            if(fileSizeIsOk(config.cytobandBbURL, 1_000_000)) {
                 cytobandSource = new CytobandSourceBB(config.cytobandBbURL, this);
             }
-
         }
         if (cytobandSource == null && config.cytobandURL != null) {
-            long contentLength = HttpUtils.getInstance().getContentLength(new URL(config.cytobandURL));
-            if (contentLength > 0 && contentLength < 100000) {
+            if(fileSizeIsOk(config.cytobandURL, 100_000)){
                 cytobandSource = new CytobandMap(config.cytobandURL);
             }
         }
@@ -236,10 +234,7 @@ public class Genome {
         if (config.aliasURL != null) {
             chromAliasSource = (new ChromAliasFile(config.aliasURL, chromosomeNames));
         } else if (config.chromAliasBbURL != null) {
-
-            long contentLength = HttpUtils.getInstance().getContentLength(new URL(config.chromAliasBbURL));
-
-            if(contentLength > 0 && contentLength < 1000000) {
+            if(fileSizeIsOk(config.chromAliasBbURL, 1_000_000)) {
                 chromAliasSource = (new ChromAliasBB(config.chromAliasBbURL, this));
                 if (chromosomeNames != null && !chromosomeNames.isEmpty()) {
                         ((ChromAliasBB) chromAliasSource).preload(chromosomeNames);
@@ -864,6 +859,18 @@ public class Genome {
 
     public FeatureDB getFeatureDB() {
         return featureDB;
+    }
+
+    /* check that a file is not empty or too large.
+     *
+     * @param path local file path or remote file URL
+     * @param maxSize max size in bytes
+     */
+    private static boolean fileSizeIsOk(String path, long maxSize) throws IOException {
+        final long contentLength = FileUtils.isRemote(path)
+                ? HttpUtils.getInstance().getContentLength(new URL(path))
+                : Files.size(Paths.get(path));
+        return contentLength > 0 && contentLength <= maxSize;
     }
     
     


### PR DESCRIPTION
I noticed a problem when trying to download references that are 2bit.   I would get these errors:
```
SEVERE [Aug 12,2025 17:44] [MessageUtils] Error loading genome hg19<br/>no protocol: /home/whaleberg/igv/genomes/hg19/hg19.chrom.sizes
SEVERE [Aug 12,2025 17:44] [MessageUtils] java.net.MalformedURLException: no protocol: /home/whaleberg/igv/genomes/hg19/hg19.chrom.sizes
        at java.base/java.net.URL.<init>(URL.java:772)
        at java.base/java.net.URL.<init>(URL.java:654)
        at java.base/java.net.URL.<init>(URL.java:590)
        at org.igv/org.broad.igv.feature.genome.Genome.<init>(Genome.java:159)
        at org.igv/org.broad.igv.feature.genome.load.JsonGenomeLoader.loadGenome(JsonGenomeLoader.java:27)
        at org.igv/org.broad.igv.feature.genome.GenomeManager.loadGenome(GenomeManager.java:171)
        at org.igv/org.broad.igv.feature.genome.GenomeManager.loadGenomeById(GenomeManager.java:147)
        at org.igv/org.broad.igv.ui.IGV$StartupRunnable.run(IGV.java:1934)
        at org.igv/org.broad.igv.util.LongRunningTask.call(LongRunningTask.java:73)
        at org.igv/org.broad.igv.util.LongRunningTask.call(LongRunningTask.java:43)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
        at java.base/java.lang.Thread.run(Thread.java:1583)

SEVERE [Aug 12,2025 17:44] [MessageUtils] Error loading genome hg19<br/>no protocol: /home/whaleberg/igv/genomes/hg19/hg19.chrom.sizes
```

It turns out there were some places in Genome that were assuming that the fields from the json that were called urls were actual http urls when for local files they are local file paths.  I added a branch to the checks to handle local files as well.  

I suspect there are still reasonable file types that aren't handled here, like google paths, but now I can at least download files and not get errors.  I would love to more generally convert things to use the HtsPath and the HttpNio connector but that seems like a huge change to the current state of things.

* Auxiliary files for 2bit references were being loaded as HttpUrls which works for remote files but not local ones.
* Fixes to account for local files