### PR TITLE
Update dependencies to quiet dependabot

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -119,10 +119,10 @@ dependencies {
     implementation(
             fileTree(dir: 'lib', include: '*.jar'), // first search on disk (old behavior), then maven repos
             [group: 'org.apache.commons', name: 'commons-math3', version: '3.6.1'],
-            [group: 'commons-io', name: 'commons-io', version: '2.7'],
+            [group: 'commons-io', name: 'commons-io', version: '2.14.0'],
             [group: 'org.apache.commons', name: 'commons-compress', version: '1.26.0'],
             [group: 'org.apache.commons', name: 'commons-jexl', version: '2.1.1'],
-            [group: 'org.apache.commons', name: 'commons-lang3', version: '3.9'],
+            [group: 'org.apache.commons', name: 'commons-lang3', version: '3.18.0'],
             [group: 'com.github.samtools', name: 'htsjdk', version: '4.3.0'],
             [group: 'org.swinglabs', name: 'swing-layout', version: '1.0.3'],
             [group: 'com.formdev', name: 'jide-oss', version: '3.7.12'],
@@ -144,7 +144,11 @@ dependencies {
             // 1.20 and 1.3.0 we need to specify it here.
             // This can be removed when amazon moves from 1.2.0 -> 1.3.0 and updates it's module requirements
             // See https://logging.apache.org/blog/2023/12/02/apache-common-logging-1.3.0.html
-            [group: 'commons-logging', name: 'commons-logging', version: '1.3.0']
+            [group: 'commons-logging', name: 'commons-logging', version: '1.3.0'],
+
+            //set the jetty version because spark-java defaults to an older one with vulnerabilities
+            //this doesn't add a dependency on jetty, but it constrains which versions we get transitively
+            platform('org.eclipse.jetty:jetty-bom:9.4.57.v20241219')
     )
 
 


### PR DESCRIPTION
This should fix the annoying dependabot notices, but probably has minimal effect on actual security. 

* updating several dependencies to resolve dependabot complaints.
* almost all of the issues are from a spark-java which is only used in testing so this probably has very little impact in practice