### PR TITLE
Remove unnecessary XZ library exclusion from build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,6 @@ configurations {
 
         exclude group: 'xmlpull', module: 'xmlpull'
         exclude group: 'xpp3', module: 'xpp3_min'
-        exclude group: 'org.tukaani', module: 'xz'
 
         exclude group: 'org.apache.ant', module: 'ant'
         exclude group: 'org.apache.ant', module: 'ant-launcher'


### PR DESCRIPTION
Fix #1767 