### PR TITLE
Fix null pointer exception in SAMAlignment.getAlignmentValueString

### DIFF
--- a/src/main/java/org/broad/igv/sam/SAMAlignment.java
+++ b/src/main/java/org/broad/igv/sam/SAMAlignment.java
@@ -723,7 +723,7 @@ public class SAMAlignment implements Alignment {
     @Override
     public String getAlignmentValueString(double position, int mouseX, AlignmentTrack.RenderOptions renderOptions) {
 
-        if(renderOptions.isHideTailSbx() && this.sbxTrimmed != null) {
+        if(renderOptions != null && renderOptions.isHideTailSbx() && this.sbxTrimmed != null) {
             return this.sbxTrimmed.getAlignmentValueString(position, mouseX, renderOptions);
         }
 


### PR DESCRIPTION
Hi, I noticed that at some point the "Copy read details" right click option stopped working.  Looking at the output in the terminal I noticed it was throwing a `NullPointerException`.

Commit `eecf30a591` introduced a code path that checks if a particular render option is set:

https://github.com/igvteam/igv/commit/eecf30a591#diff-d82920baf22166da98fa8c91df53d91ba01d510763b0ee7eb551a0d5278c0902L846-R729

But sometimes this function is called with `null` for the `renderOptions` argument (e.g. in `getClipboardString`, expand the diff context above my change and see line `699`), which results in a null pointer exception, like when using "Copy read details" in the right click menu.

This adds a null check to avoid the NPE so we can copy read details again.

I don't know what "SBX" means in the code path that was added, so if there's a better way to fix this let me know and I can have a look at it.