### PR TITLE
Custom FileDialog that can handle thousands of files/folders

### DIFF
--- a/src/main/java/org/broad/igv/Globals.java
+++ b/src/main/java/org/broad/igv/Globals.java
@@ -100,7 +100,7 @@ public class Globals {
 
 
     final public static boolean USE_CUSTOM_FILEDIALOG =
-            "true".equalsIgnoreCase(System.getenv("USE_CUSTOM_FILEDIALOG"));
+            "true".equalsIgnoreCase(System.getenv("USE_CUSTOM_FILEDIALOG")) && IS_LINUX;
 
     public static final String JAVA_VERSION_STRING = "java.version";
 

--- a/src/main/java/org/broad/igv/ui/util/FileDialogUtils.java
+++ b/src/main/java/org/broad/igv/ui/util/FileDialogUtils.java
@@ -72,10 +72,18 @@ public class FileDialogUtils {
         if (initialFile != null) initialFile = new File(initialFile.getName());
 
         if (Globals.USE_CUSTOM_FILEDIALOG) {
-            JFileChooser fileChooser = getJFileChooser(title, initialDirectory, initialFile, filter, JFileChooser.FILES_ONLY);
+            JFileChooser fileChooser = getJFileChooser(title, initialDirectory, initialFile, filter, directoriesMode);
             fileChooser.setMultiSelectionEnabled(false);
             Frame parentFrame = getParentFrame();
-            int result = fileChooser.showOpenDialog(parentFrame);
+            int result;
+            if (mode == LOAD) {
+                result = fileChooser.showOpenDialog(parentFrame);
+            } else if (mode == SAVE) {
+                result = fileChooser.showSaveDialog(parentFrame);
+            } else {
+                // Default to open dialog if mode is unrecognized
+                result = fileChooser.showOpenDialog(parentFrame);
+            }
 
             if (result == JFileChooser.APPROVE_OPTION) {
                 file = fileChooser.getSelectedFile();

--- a/src/main/java/org/broad/igv/ui/util/LsFileChooser.java
+++ b/src/main/java/org/broad/igv/ui/util/LsFileChooser.java
@@ -8,7 +8,7 @@ Note this only used if environment variable USE_CUSTOM_FILEDIALOG is set to "tru
 
 Background: We are running IGV in an XPRA desktop session on a remote server.
 The filesystem has a directory mounted where the backend is a cloud object store (s3)
-Some of the folders have more than 3000 files/folders in them and the standard FielDialog either took
+Some of the folders have more than 3000 files/folders in them and the standard FileDialog either took
 hours to fetch the list of files/folders. At the same time we observed that running 'ls' on these folders
 was nearly instantaneous (a few seconds at most).
 */
@@ -49,6 +49,8 @@ public class LsFileChooser extends JFileChooser {
 
     /**
      * Scans the given directory and logs the number of files and directories.
+     * <p>
+     * <b>Note:</b> Currently, logging is the only action performed by this method.
      *
      * @param dir The directory to scan.
      */
@@ -79,7 +81,11 @@ public class LsFileChooser extends JFileChooser {
                     " | Files: " + fileCount + " | Folders: " + dirCount);
         } catch (IOException | InterruptedException e) {
             log.error("Error scanning directory: " + dir.getAbsolutePath(), e);
-        } finally {
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+        }
+        finally {
             if (process != null) {
                 process.destroy();
             }


### PR DESCRIPTION
This PR contains a new custom FileDialog which behind the scenes calls unix ls command to get the files and folders whenever a user navigates ino a folder.

The original FileDialog cannot cope with folders that contain many thousands of sub-folders and files.

Our implementation is running IGV on an XPRA desktop running in a data studio on the Seqera platform.
S3 buckets can be mounted as data sources and attached to the data studio where they are exposed in the filesystem as a mounted folder. Problem was some folders have > 3000 sub-folders and files and the existing native FileDialog took hours to fetch the list. We noted that running ls command in a Terminal returned a list of those files and folders almost instantly so the fix was to leverage that in the custom FileDialog component.

I put the new dialog behind an environment variable so that the new dialog will only be used if the environment variable exists AND is set to 'true'

The environment variable is called: USE_CUSTOM_FILEDIALOG

This is for the issue: https://github.com/igvteam/igv/issues/1786