### PR TITLE
Fix NullPointerException in motif finder

### DIFF
--- a/src/main/java/org/igv/tools/motiffinder/MotifFinderPlugin.java
+++ b/src/main/java/org/igv/tools/motiffinder/MotifFinderPlugin.java
@@ -55,7 +55,9 @@ public class MotifFinderPlugin {
      */
     static List<Track> addTracksForPatterns(String[] pattern, String[] posTrackNames, String[] negTrackNames) {
         List<Track> trackList = generateTracksForPatterns(pattern, posTrackNames, negTrackNames);
-        IGV.getInstance().addTracks(trackList);
+        for (Track track : trackList) {
+            IGV.getInstance().addTrack(track, PanelName.ANNOTATION_PANEL.getName());
+        }
         return trackList;
     }
 


### PR DESCRIPTION
Hello, got another `NullPointerException` fix for you.  A while back my coworker noticed the motif finder had stopped working (we're both still living on `main` IGV, so I'm unsure if this ever made it into a release).  Running the motif finder produces a null pointer exception and a stack trace:

```
SEVERE [Apr 01,2026 10:14] [DefaultExceptionHandler] Unhandled exception
SEVERE [Apr 01,2026 10:14] [DefaultExceptionHandler] java.lang.NullPointerException: Cannot invoke "org.igv.util.ResourceLocator.getPath()" because the return value of "org.igv.track.Track.getResourceLocator()" is null
        at org.igv.ui.IGV.lambda$addTracks$5(IGV.java:1217)
        at java.base/java.util.stream.Collectors.lambda$groupingBy$53(Collectors.java:1105)
        at java.base/java.util.stream.ReduceOps$3ReducingSink.accept(ReduceOps.java:169)
        at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1708)
        at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
        at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
        at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)
        at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
        at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682)
        at org.igv.ui.IGV.addTracks(IGV.java:1217)
        at org.igv.tools.motiffinder.MotifFinderPlugin.addTracksForPatterns(MotifFinderPlugin.java:58)
        at org.igv.tools.motiffinder.MotifFinderPlugin.handleDialogResult(MotifFinderPlugin.java:44)
        at org.igv.tools.motiffinder.MotifFinderPlugin.lambda$getMenuItem$0(MotifFinderPlugin.java:33)
        at java.desktop/javax.swing.AbstractButton.fireActionPerformed(AbstractButton.java:1972)
        at java.desktop/javax.swing.AbstractButton$Handler.actionPerformed(AbstractButton.java:2314)
        at java.desktop/javax.swing.DefaultButtonModel.fireActionPerformed(DefaultButtonModel.java:407)
        at java.desktop/javax.swing.DefaultButtonModel.setPressed(DefaultButtonModel.java:262)
        at java.desktop/javax.swing.AbstractButton.doClick(AbstractButton.java:374)
        at java.desktop/javax.swing.plaf.basic.BasicMenuItemUI.doClick(BasicMenuItemUI.java:1029)
        at java.desktop/javax.swing.plaf.basic.BasicMenuItemUI$Handler.mouseReleased(BasicMenuItemUI.java:1073)
        at java.desktop/java.awt.Component.processMouseEvent(Component.java:6621)
        at java.desktop/javax.swing.JComponent.processMouseEvent(JComponent.java:3398)
        at java.desktop/java.awt.Component.processEvent(Component.java:6386)
        at java.desktop/java.awt.Container.processEvent(Container.java:2266)
        at java.desktop/java.awt.Component.dispatchEventImpl(Component.java:4996)
        at java.desktop/java.awt.Container.dispatchEventImpl(Container.java:2324)
        at java.desktop/java.awt.Component.dispatchEvent(Component.java:4828)
        at java.desktop/java.awt.LightweightDispatcher.retargetMouseEvent(Container.java:4948)
        at java.desktop/java.awt.LightweightDispatcher.processMouseEvent(Container.java:4575)
        at java.desktop/java.awt.LightweightDispatcher.dispatchEvent(Container.java:4516)
        at java.desktop/java.awt.Container.dispatchEventImpl(Container.java:2310)
        at java.desktop/java.awt.Window.dispatchEventImpl(Window.java:2780)
        at java.desktop/java.awt.Component.dispatchEvent(Component.java:4828)
        at java.desktop/java.awt.EventQueue.dispatchEventImpl(EventQueue.java:775)
        at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:720)
        at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:714)
        at java.base/java.security.AccessController.doPrivileged(AccessController.java:400)
        at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:87)
        at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:98)
        at java.desktop/java.awt.EventQueue$5.run(EventQueue.java:747)
        at java.desktop/java.awt.EventQueue$5.run(EventQueue.java:745)
        at java.base/java.security.AccessController.doPrivileged(AccessController.java:400)
        at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:87)
        at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:744)
        at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:203)
        at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:124)
        at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:113)
        at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:109)
        at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
        at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:90)
```

The problem seems to be that when adding the result tracks it uses `addTracks()`, which uses `.getResourceLocator()` on each track to figure out where to put it, and `MotifTrack` doesn't implement that function or pass any kind of resource locator to the `FeatureTrack` superclass constructor.

This commit fixes the NPE by adding the motif tracks one by one with `addTrack` and explicitly telling them to go to the annotation panel.  Another way to fix it might be to give `MotifTrack`s a resource locator, either by overriding `getResourceLocator` or by passing along some kind of `ResourceLocator` in the constructor instead of `null`.  I'm happy to take a crack at doing either of those instead if the current solution is too much of a hack (though I'm still a little fuzzy on what exactly a `ResourceLocator` is).

Thanks!