### PR TITLE
Fix operator precedence bug in SAMAlignment.getBaseModificationSets()

### DIFF
--- a/src/main/java/org/igv/alignment/SAMAlignment.java
+++ b/src/main/java/org/igv/alignment/SAMAlignment.java
@@ -361,7 +361,7 @@ public class SAMAlignment implements Alignment {
 
     public List<BaseModificationSet> getBaseModificationSets() {
 
-        if (baseModificationSets == null && record.hasAttribute("Mm") || record.hasAttribute("MM")) {
+        if (baseModificationSets == null && (record.hasAttribute("Mm") || record.hasAttribute("MM"))) {
 
             Object mm = record.hasAttribute("Mm") ? record.getAttribute("Mm") : record.getAttribute("MM");
             byte[] ml = (byte[]) (record.hasAttribute("Ml") ? record.getAttribute("Ml") : record.getAttribute("ML"));

--- a/src/main/java/org/igv/sam/SAMAlignment.java
+++ b/src/main/java/org/igv/sam/SAMAlignment.java
@@ -361,7 +361,7 @@ public class SAMAlignment implements Alignment {
 
     public List<BaseModificationSet> getBaseModificationSets() {
 
-        if (baseModificationSets == null && record.hasAttribute("Mm") || record.hasAttribute("MM")) {
+        if (baseModificationSets == null && (record.hasAttribute("Mm") || record.hasAttribute("MM"))) {
 
             Object mm = record.hasAttribute("Mm") ? record.getAttribute("Mm") : record.getAttribute("MM");
             byte[] ml = (byte[]) (record.hasAttribute("Ml") ? record.getAttribute("Ml") : record.getAttribute("ML"));


### PR DESCRIPTION
Hi IGV team.

This fixes the precedence of a condition.

In Java, `&&` has higher precedence than `||`, so the current condition recomputes `baseModificationSets` when the read has an `MM` tag, even if it has already been initialized.

This adds parentheses so that base modification sets are computed only once for both `Mm` and `MM` tags.