### PR TITLE
Fix base modification filter canonical base lookup

### DIFF
--- a/src/main/java/org/igv/alignment/mods/BaseModificationRenderer.java
+++ b/src/main/java/org/igv/alignment/mods/BaseModificationRenderer.java
@@ -66,7 +66,7 @@ public class BaseModificationRenderer {
                 if (bmSet.containsPosition(i)) {
                     int lh = Byte.toUnsignedInt(bmSet.getLikelihoods().get(i));
                     noModLh -= lh;
-                    if ((filter == null || filter.pass(bmSet.getModification(), canonicalBase)) && (modification == null || lh > maxLh)) {
+                    if ((filter == null || filter.pass(bmSet.getModification(), bmSet.getCanonicalBase())) && (modification == null || lh > maxLh)) {
                         modification = bmSet.getModification();
                         canonicalBase = bmSet.getCanonicalBase();
                         maxLh = lh;
@@ -120,5 +120,4 @@ public class BaseModificationRenderer {
         }
     }
 }
-
 

--- a/src/main/java/org/igv/sam/mods/BaseModificationRenderer.java
+++ b/src/main/java/org/igv/sam/mods/BaseModificationRenderer.java
@@ -69,7 +69,7 @@ public class BaseModificationRenderer {
                 if (bmSet.containsPosition(i)) {
                     int lh = Byte.toUnsignedInt(bmSet.getLikelihoods().get(i));
                     noModLh -= lh;
-                    if ((filter == null || filter.pass(bmSet.getModification(), canonicalBase)) && (modification == null || lh > maxLh)) {
+                    if ((filter == null || filter.pass(bmSet.getModification(), bmSet.getCanonicalBase())) && (modification == null || lh > maxLh)) {
                         modification = bmSet.getModification();
                         canonicalBase = bmSet.getCanonicalBase();
                         maxLh = lh;
@@ -123,5 +123,4 @@ public class BaseModificationRenderer {
         }
     }
 }
-
 


### PR DESCRIPTION
Fix the canonical base passed to the base modification filter

Currently, `canonicalBase` is passed to the filter before it is updated from `bmSet`. As a result, the filter may receive the initial value instead of the actual canonical base.

This change passes `bmSet.getCanonicalBase()` directly when applying the filter.