### PR TITLE
fix: skip batch mode for HTTP /load to allow parallel track loading

### DIFF
--- a/src/main/java/org/igv/batch/CommandExecutor.java
+++ b/src/main/java/org/igv/batch/CommandExecutor.java
@@ -1,4 +1,3 @@
-
 package org.igv.batch;
 
 import org.igv.Globals;
@@ -709,7 +708,7 @@ public class CommandExecutor {
         Map<String, String> ignore = null;
         String sort = null;
         String sortTag = null;
-        return loadFiles(fileString, index, coverage, name, format, locus, merge, ignore, sort, sortTag, true);
+        return loadFiles(fileString, index, coverage, name, format, locus, merge, ignore, sort, sortTag, true, true);
 
     }
 
@@ -724,6 +723,8 @@ public class CommandExecutor {
      * @param sort
      * @param sortTag    Used iff sort == SortOption.TAG
      * @param dup
+     * @param forceBatch if true, enables batch mode to synchronize loading (required for port/batch scripts);
+     *                   pass false for HTTP /load requests to allow parallel track loading
      * @return
      * @throws IOException
      */
@@ -737,12 +738,16 @@ public class CommandExecutor {
                      Map<String, String> params,
                      String sort,
                      String sortTag,
-                     boolean dup) {
+                     boolean dup,
+                     boolean forceBatch) {
 
         boolean currentBatchSetting = Globals.isBatch();
         try {
-            // Temporarily switch to batch mode to force synchronization of load followed by possible sort
-            Globals.setBatch(true);
+            // Force batch mode for port/batch script commands to ensure synchronization.
+            // HTTP /load requests pass forceBatch=false to allow parallel track loading.
+            if (forceBatch) {
+                Globals.setBatch(true);
+            }
 
             boolean isDataURL = ParsingUtils.isDataURL(fileString);
 

--- a/src/main/java/org/igv/batch/CommandListener.java
+++ b/src/main/java/org/igv/batch/CommandListener.java
@@ -405,7 +405,8 @@ public class CommandListener implements Runnable {
                 String sort = params.get("sort");
                 String sortTag = params.get("sortTag");
                 boolean dup = "true".equals(params.get("dup"));
-                result = cmdExe.loadFiles(file, index, coverage, name, format, locus, merge, params, sort, sortTag, dup);
+                // HTTP /load requests do not need batch mode — pass forceBatch=false to allow parallel track loading
+                result = cmdExe.loadFiles(file, index, coverage, name, format, locus, merge, params, sort, sortTag, dup, false);
             } else {
                 result = "OK";  // No files, perhaps genome only
             }


### PR DESCRIPTION
## Summary

Fixes the sequential track loading issue reported in #1849.

When loading multiple tracks via the HTTP command listener (`/load`), `loadFiles` was unconditionally calling `Globals.setBatch(true)`, which forced synchronous/sequential loading. This is necessary for port/batch script commands (where the next command is unknown), but not for HTTP requests where all files are known upfront.

**Changes:**
- Added `boolean forceBatch` parameter to `loadFiles` in `CommandExecutor`
- Port/batch script path passes `forceBatch=true` (no behavior change)
- HTTP `/load` path passes `forceBatch=false`, allowing IGV to load tracks without forcing batch mode

## Impact

- **HTTP `/load`**: tracks can now load in parallel instead of sequentially
- **Port/batch scripts**: no change, batch mode still enforced
- **Sort after load**: unaffected, sort is applied after `loadTracks` returns regardless of batch mode

## Test case

Loading 11 remote BAM files via HTTP `/load` previously took ~4.5 minutes (11 × ~25 sec sequential). With this change, loading time should drop significantly as tracks load in parallel.

Closes #1849